### PR TITLE
Serve the strategy page from its last build while the next one runs

### DIFF
--- a/app/features/inventory-strategy/services/forecastGrading.server.test.ts
+++ b/app/features/inventory-strategy/services/forecastGrading.server.test.ts
@@ -47,17 +47,23 @@ const rows: ForecastGradingRecord[] = [
   row(4, 1, 1, { buyerChoiceCalibration: "older-fit" }),
 ];
 let requestedSince: Date | undefined;
-const reports = await loadForecastGrading(
-  "seller",
-  {
-    findForecastGradingRecords: async (_sellerKey, since) => {
-      requestedSince = since;
-      return rows;
-    },
-    findInStockSkus: async () => [1, 2, 3, 4],
+let recordReads = 0;
+const source = {
+  findSnapshotVersion: async () => "inventory-1",
+  findForecastGradingRecords: async (_sellerKey: string, since: Date) => {
+    requestedSince = since;
+    recordReads += 1;
+    return rows;
   },
-  now,
+  findInStockSkus: async () => [1, 2, 3, 4],
+};
+const reports = await loadForecastGrading("seller", source, now);
+assert.equal(
+  await loadForecastGrading("seller", source, now),
+  reports,
+  "the same inventory version within the hour serves the cached report",
 );
+assert.equal(recordReads, 1);
 assert.equal(
   requestedSince?.toISOString(),
   at(56).toISOString(),
@@ -93,6 +99,7 @@ assert.equal(
 const empty = await loadForecastGrading(
   "",
   {
+    findSnapshotVersion: async () => "",
     findForecastGradingRecords: async () => {
       throw new Error("must not query without a seller");
     },

--- a/app/features/inventory-strategy/services/forecastGrading.server.ts
+++ b/app/features/inventory-strategy/services/forecastGrading.server.ts
@@ -12,8 +12,10 @@ import {
   type ForecastGradingRecord,
   type ForecastGradingReport,
 } from "../types/inventoryStrategy";
+import { createVersionedCache } from "./versionedCache";
 
-const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
 const NO_GRADE: ForecastGrade = {
   count: 0,
   soldShare: 0,
@@ -22,11 +24,38 @@ const NO_GRADE: ForecastGrade = {
 };
 
 export interface ForecastGradingSource {
+  /** Changes whenever the inventory or its curves change, as every priced batch does. */
+  findSnapshotVersion(sellerKey: string): Promise<string>;
   findForecastGradingRecords(
     sellerKey: string,
     since: Date,
   ): Promise<ForecastGradingRecord[]>;
   findInStockSkus(sellerKey: string): Promise<number[]>;
+}
+
+const reports =
+  createVersionedCache<ForecastGradingReport[]>("Forecast grading");
+
+/**
+ * The seller's forecast grading, regraded after each priced batch and at
+ * least hourly as the cohort windows move, serving the last report while the
+ * next one builds.
+ */
+export async function loadForecastGrading(
+  sellerKey: string,
+  source: ForecastGradingSource = inventoryStrategyRepository,
+  now: Date = new Date(),
+): Promise<ForecastGradingReport[]> {
+  if (!sellerKey) return gradeForecasts(sellerKey, source, now);
+  return reports.read(
+    sellerKey,
+    "",
+    [
+      await source.findSnapshotVersion(sellerKey),
+      Math.floor(now.getTime() / HOUR_MS),
+    ].join("|"),
+    () => gradeForecasts(sellerKey, source, now),
+  );
 }
 
 /**
@@ -36,10 +65,10 @@ export interface ForecastGradingSource {
  * that forecast is at least one horizon old. Results priced under the target-horizon policy carry no curve
  * forecast, because that policy pins it to the horizon.
  */
-export async function loadForecastGrading(
+async function gradeForecasts(
   sellerKey: string,
-  source: ForecastGradingSource = inventoryStrategyRepository,
-  now: Date = new Date(),
+  source: ForecastGradingSource,
+  now: Date,
 ): Promise<ForecastGradingReport[]> {
   const since = new Date(
     now.getTime() - 2 * Math.max(...FORECAST_GRADING_HORIZON_DAYS) * DAY_MS,

--- a/app/features/inventory-strategy/services/inventoryStrategyDashboard.server.test.ts
+++ b/app/features/inventory-strategy/services/inventoryStrategyDashboard.server.test.ts
@@ -11,6 +11,7 @@ const source = {
     return [];
   },
 };
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 const first = await loadInventoryStrategyDashboard(
   "seller",
@@ -26,12 +27,24 @@ assert.equal(second, first, "an unchanged version serves the cached dashboard");
 assert.equal(snapshotReads, 1);
 
 version = "inventory-2";
+const stale = await loadInventoryStrategyDashboard(
+  "seller",
+  DEFAULT_SERVER_PRICING_CONFIG,
+  source,
+);
+assert.equal(
+  stale,
+  first,
+  "a changed inventory version serves the last dashboard while rebuilding",
+);
+assert.equal(snapshotReads, 2, "the rebuild started in the background");
+await settle();
 const rebuilt = await loadInventoryStrategyDashboard(
   "seller",
   DEFAULT_SERVER_PRICING_CONFIG,
   source,
 );
-assert.notEqual(rebuilt, first, "a changed inventory version rebuilds");
+assert.notEqual(rebuilt, first, "the next load serves the rebuilt dashboard");
 assert.equal(snapshotReads, 2);
 
 const reconfigured = await loadInventoryStrategyDashboard(
@@ -45,7 +58,11 @@ const reconfigured = await loadInventoryStrategyDashboard(
   },
   source,
 );
-assert.notEqual(reconfigured, rebuilt, "a changed configuration rebuilds");
+assert.notEqual(
+  reconfigured,
+  rebuilt,
+  "a changed configuration waits for its rebuild",
+);
 assert.equal(snapshotReads, 3);
 
 const empty = await loadInventoryStrategyDashboard(

--- a/app/features/inventory-strategy/services/inventoryStrategyDashboard.server.ts
+++ b/app/features/inventory-strategy/services/inventoryStrategyDashboard.server.ts
@@ -6,20 +6,21 @@ import type {
   InventoryStrategySnapshotItem,
 } from "../types/inventoryStrategy";
 import { buildInventoryStrategyDashboard } from "./inventoryStrategy";
+import { createVersionedCache } from "./versionedCache";
 
 export interface InventoryStrategySource {
   findSnapshotVersion(sellerKey: string): Promise<string>;
   findSnapshot(sellerKey: string): Promise<InventoryStrategySnapshotItem[]>;
 }
 
-const dashboards = new Map<
-  string,
-  { version: string; dashboard: Promise<InventoryStrategyDashboard> }
->();
+const dashboards = createVersionedCache<InventoryStrategyDashboard>(
+  "Inventory strategy dashboard",
+);
 
 /**
- * The seller's dashboard, rebuilt only when the inventory, its curves, or the
- * pricing configuration changed since the last build.
+ * The seller's dashboard. A changed pricing configuration waits for a
+ * rebuild; changed inventory or curves, which every priced batch brings,
+ * serve the last dashboard while the next one builds in the background.
  */
 export async function loadInventoryStrategyDashboard(
   sellerKey: string,
@@ -27,20 +28,15 @@ export async function loadInventoryStrategyDashboard(
   source: InventoryStrategySource = inventoryStrategyRepository,
 ): Promise<InventoryStrategyDashboard> {
   if (!sellerKey) return buildInventoryStrategyDashboard(sellerKey, [], config);
-  const version = [
-    PRICING_MODEL_VERSION,
+  return dashboards.read(
+    sellerKey,
+    [PRICING_MODEL_VERSION, JSON.stringify(config)].join("|"),
     await source.findSnapshotVersion(sellerKey),
-    JSON.stringify(config),
-  ].join("|");
-  const cached = dashboards.get(sellerKey);
-  if (cached?.version === version) return cached.dashboard;
-  const dashboard = source
-    .findSnapshot(sellerKey)
-    .then((items) => buildInventoryStrategyDashboard(sellerKey, items, config));
-  dashboards.set(sellerKey, { version, dashboard });
-  dashboard.catch(() => {
-    if (dashboards.get(sellerKey)?.dashboard === dashboard)
-      dashboards.delete(sellerKey);
-  });
-  return dashboard;
+    () =>
+      source
+        .findSnapshot(sellerKey)
+        .then((items) =>
+          buildInventoryStrategyDashboard(sellerKey, items, config),
+        ),
+  );
 }

--- a/app/features/inventory-strategy/services/inventoryStrategyWarmup.server.ts
+++ b/app/features/inventory-strategy/services/inventoryStrategyWarmup.server.ts
@@ -1,0 +1,23 @@
+import {
+  inventoryPublicationSettingsRepository,
+  pricingConfigRepository,
+} from "~/core/db";
+import { loadForecastGrading } from "./forecastGrading.server";
+import { loadInventoryStrategyDashboard } from "./inventoryStrategyDashboard.server";
+
+/**
+ * Starts rebuilding the strategy page's dashboard and forecast grading for
+ * the continuously priced seller, so the next page load finds them ready.
+ */
+export async function warmInventoryStrategy(): Promise<void> {
+  const [publication, pricingConfig] = await Promise.all([
+    inventoryPublicationSettingsRepository.get(),
+    pricingConfigRepository.get(),
+  ]);
+  const { sellerKey } = publication.settings.continuousPricing;
+  if (!sellerKey) return;
+  await Promise.all([
+    loadInventoryStrategyDashboard(sellerKey, pricingConfig),
+    loadForecastGrading(sellerKey),
+  ]);
+}

--- a/app/features/inventory-strategy/services/versionedCache.test.ts
+++ b/app/features/inventory-strategy/services/versionedCache.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { createVersionedCache } from "./versionedCache";
+
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+const cache = createVersionedCache<string>("test");
+let builds = 0;
+let release: (value: string) => void = () => {};
+let fail: (error: Error) => void = () => {};
+const build = () => {
+  builds += 1;
+  return new Promise<string>((resolve, reject) => {
+    release = resolve;
+    fail = reject;
+  });
+};
+
+const first = cache.read("seller", "config-a", "v1", build);
+const again = cache.read("seller", "config-a", "v1", build);
+assert.equal(builds, 1, "concurrent first reads share one build");
+release("built-1");
+assert.equal(await first, "built-1", "the first read waits for its build");
+assert.equal(await again, "built-1");
+assert.equal(
+  await cache.read("seller", "config-a", "v1", build),
+  "built-1",
+  "an unchanged version is served from cache",
+);
+assert.equal(builds, 1);
+
+const stale = cache.read("seller", "config-a", "v2", build);
+assert.equal(builds, 2, "a changed version starts a rebuild");
+assert.equal(await stale, "built-1", "and serves the last value meanwhile");
+assert.equal(
+  await cache.read("seller", "config-a", "v3", build),
+  "built-1",
+  "a version that moves during a build does not start another",
+);
+assert.equal(builds, 2);
+release("built-2");
+await settle();
+assert.equal(
+  await cache.read("seller", "config-a", "v2", build),
+  "built-2",
+  "the finished build is served at its version",
+);
+const catchUp = cache.read("seller", "config-a", "v3", build);
+assert.equal(
+  builds,
+  3,
+  "the next read after a build catches up to the newer version",
+);
+assert.equal(await catchUp, "built-2");
+const logged: unknown[][] = [];
+const consoleError = console.error;
+console.error = (...args: unknown[]) => {
+  logged.push(args);
+};
+fail(new Error("source down"));
+await settle();
+console.error = consoleError;
+assert.equal(logged.length, 1, "a failed rebuild is logged");
+assert.equal(
+  await cache.read("seller", "config-a", "v2", build),
+  "built-2",
+  "a failed rebuild keeps serving the last value",
+);
+assert.equal(builds, 3);
+assert.equal(
+  await cache.read("seller", "config-a", "v3", build).then(
+    () => builds,
+    () => -1,
+  ),
+  4,
+  "and the next read retries it",
+);
+release("built-3");
+await settle();
+
+const reconfigured = cache.read("seller", "config-b", "v3", build);
+assert.equal(builds, 5, "a changed identity rebuilds");
+release("built-4");
+assert.equal(
+  await reconfigured,
+  "built-4",
+  "and waits for the build instead of serving the old identity",
+);
+
+const rejected = cache.read("other", "config-a", "v1", build);
+fail(new Error("source down"));
+await assert.rejects(
+  rejected,
+  /source down/,
+  "a first build that fails rejects",
+);
+const retried = cache.read("other", "config-a", "v1", build);
+assert.equal(builds, 7, "and the next read builds again");
+release("built-5");
+assert.equal(await retried, "built-5");
+
+console.log(
+  "PASS versioned cache serves the last value while a newer version builds",
+);

--- a/app/features/inventory-strategy/services/versionedCache.ts
+++ b/app/features/inventory-strategy/services/versionedCache.ts
@@ -1,0 +1,69 @@
+/**
+ * One value per key, rebuilt whenever its identity or version changes. A
+ * changed version serves the last value at once while the new one builds, so
+ * only the first read of a key, or one whose identity changed, waits. One
+ * build runs per key at a time; a version that moves during a build is picked
+ * up by the next read. A failed rebuild keeps serving the last value and is
+ * retried on the next read.
+ */
+export interface VersionedCache<Value> {
+  read(
+    key: string,
+    identity: string,
+    version: string,
+    build: () => Promise<Value>,
+  ): Promise<Value>;
+}
+
+interface Build<Value> {
+  version: string;
+  value: Promise<Value>;
+}
+
+interface Entry<Value> {
+  identity: string;
+  ready?: { version: string; value: Value };
+  building?: Build<Value>;
+}
+
+export function createVersionedCache<Value>(
+  name: string,
+): VersionedCache<Value> {
+  const entries = new Map<string, Entry<Value>>();
+
+  function start(
+    entry: Entry<Value>,
+    version: string,
+    build: () => Promise<Value>,
+  ): Build<Value> {
+    const building = { version, value: build() };
+    entry.building = building;
+    building.value
+      .then(
+        (value) => {
+          entry.ready = { version, value };
+        },
+        (error) => {
+          if (entry.ready) console.error(`${name} rebuild failed:`, error);
+        },
+      )
+      .finally(() => {
+        if (entry.building === building) entry.building = undefined;
+      });
+    return building;
+  }
+
+  return {
+    read(key, identity, version, build) {
+      let entry = entries.get(key);
+      if (entry?.identity !== identity) {
+        entry = { identity };
+        entries.set(key, entry);
+      }
+      const { ready } = entry;
+      if (ready?.version === version) return Promise.resolve(ready.value);
+      const building = entry.building ?? start(entry, version, build);
+      return ready ? Promise.resolve(ready.value) : building.value;
+    },
+  };
+}

--- a/app/features/pending-inventory/services/inventoryBatchPricingWorker.server.ts
+++ b/app/features/pending-inventory/services/inventoryBatchPricingWorker.server.ts
@@ -7,6 +7,7 @@ import {
 } from "~/core/db";
 import { PricedSkuToTcgPlayerListingConverter } from "~/features/file-upload/services/dataConverters";
 import { planAutomaticInventoryBatchPublication } from "~/features/inventory-publication/services/automaticInventoryBatchPublication.server";
+import { warmInventoryStrategy } from "~/features/inventory-strategy/services/inventoryStrategyWarmup.server";
 import type {
   PersistedPricingDetails,
   ProcessingProgress,
@@ -191,8 +192,11 @@ async function processJob(
       result.summary,
       result.finalProgress,
     );
+    let curvesRecorded = 0;
     try {
-      await inventoryStrategyRepository.recordSuccessfulBatch(job.batchNumber);
+      curvesRecorded = await inventoryStrategyRepository.recordSuccessfulBatch(
+        job.batchNumber,
+      );
     } catch (strategyProjectionError) {
       console.error(
         `Inventory strategy projection update failed for batch ${job.batchNumber}:`,
@@ -215,6 +219,14 @@ async function processJob(
         `Automatic publication planning failed for batch ${job.batchNumber}:`,
         automaticPublicationError,
       );
+    }
+    if (curvesRecorded > 0) {
+      void warmInventoryStrategy().catch((warmupError) => {
+        console.error(
+          `Inventory strategy warm-up failed after batch ${job.batchNumber}:`,
+          warmupError,
+        );
+      });
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -6,6 +6,7 @@ import "../features/continuous-pricing/services/continuousPricingSettings.test";
 import "../features/continuous-pricing/services/continuousMarketPrices.server.test";
 import "../features/inventory-strategy/services/inventoryStrategy.test";
 import "../features/inventory-strategy/services/inventoryStrategyDashboard.server.test";
+import "../features/inventory-strategy/services/versionedCache.test";
 import "../features/inventory-publication/services/inventoryPublicationState.test";
 import "../features/inventory-publication/services/inventoryBatchPublication.server.test";
 import "../features/pending-inventory/routes/api.inventory-batch-publications.policy.test";


### PR DESCRIPTION
Every priced batch rewrites the strategy curves, so the dashboard cache missed on almost every visit and rebuilt inline for three seconds or more (production log: 2.8 to 4.5 s per load). A versioned cache now serves the last dashboard and forecast grading at once when only the inventory or its curves moved and rebuilds in the background; a changed pricing configuration still waits for its build. The pricing worker warms both after each batch that recorded curves, and the grading regrades at least hourly as its cohort windows move.

Verified: typecheck, 191 tests (new cache test covers stale serving, single in-flight build, catch-up, failed rebuilds, and identity changes), build. The production timing after deploy is still to be measured.

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)