### PR TITLE
Sweep the profit-per-day hurdle per product line on the strategy page

### DIFF
--- a/app/features/inventory-strategy/components/HurdleSweep.tsx
+++ b/app/features/inventory-strategy/components/HurdleSweep.tsx
@@ -1,0 +1,119 @@
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import type { InventoryStrategyDashboard } from "../types/inventoryStrategy";
+import { currencyFormatter } from "./format";
+
+function formatHurdle(dailyReturnHurdle: number): string {
+  return `${(dailyReturnHurdle * 100).toFixed(2)}%/day`;
+}
+
+export function HurdleSweep({
+  dashboard,
+}: {
+  dashboard: InventoryStrategyDashboard;
+}) {
+  const productLines = [dashboard.overall, ...dashboard.productLines];
+  const hurdles = Array.from(
+    new Set(
+      productLines.flatMap((productLine) =>
+        productLine.hurdleSweep.map((scenario) => scenario.dailyReturnHurdle),
+      ),
+    ),
+  ).sort((left, right) => left - right);
+
+  return (
+    <Paper variant="outlined" sx={{ mb: 3 }}>
+      <Box sx={{ p: 2 }}>
+        <Typography variant="h6">Hurdle sweep</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Profit per day prices each SKU where its net proceeds, discounted at
+          the daily return hurdle over its expected wait, are highest. Each cell
+          shows the physical value at that hurdle, the median and P90 wait, and
+          how many SKUs it raises and lowers against their listed prices. The
+          shaded cell is the hurdle the product line is configured with; all
+          listed inventory applies one hurdle to every product line.
+        </Typography>
+      </Box>
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Product line</TableCell>
+              {hurdles.map((hurdle) => (
+                <TableCell key={hurdle} align="right">
+                  {formatHurdle(hurdle)}
+                </TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {productLines.map((productLine) => (
+              <TableRow key={productLine.key}>
+                <TableCell
+                  sx={{ fontWeight: productLine.key === "all" ? 700 : 400 }}
+                >
+                  {productLine.productLine}
+                </TableCell>
+                {hurdles.map((hurdle) => {
+                  const scenario = productLine.hurdleSweep.find(
+                    (candidate) => candidate.dailyReturnHurdle === hurdle,
+                  );
+                  return (
+                    <TableCell
+                      key={hurdle}
+                      align="right"
+                      sx={{
+                        bgcolor: scenario?.configured
+                          ? "action.selected"
+                          : undefined,
+                      }}
+                    >
+                      {scenario ? (
+                        <>
+                          <Typography
+                            variant="body2"
+                            fontWeight={scenario.configured ? 700 : 400}
+                          >
+                            {currencyFormatter.format(scenario.physicalValue)}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            display="block"
+                          >
+                            {scenario.estimatedTime
+                              ? `${scenario.estimatedTime.medianDays.toFixed(1)} / ${scenario.estimatedTime.p90Days.toFixed(1)} days`
+                              : "No wait estimate"}
+                          </Typography>
+                          <Typography
+                            variant="caption"
+                            color="text.secondary"
+                            display="block"
+                          >
+                            ↑ {scenario.raisedCount.toLocaleString()} · ↓{" "}
+                            {scenario.loweredCount.toLocaleString()}
+                          </Typography>
+                        </>
+                      ) : (
+                        "—"
+                      )}
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Paper>
+  );
+}

--- a/app/features/inventory-strategy/routes/inventory-strategy.tsx
+++ b/app/features/inventory-strategy/routes/inventory-strategy.tsx
@@ -16,6 +16,7 @@ import {
 import { refreshContinuousPricingInventory } from "~/features/continuous-pricing/services/continuousInventoryRefresh.server";
 import { ForecastGrading } from "../components/ForecastGrading";
 import { HorizonCurve } from "../components/HorizonCurve";
+import { HurdleSweep } from "../components/HurdleSweep";
 import { MetricCard } from "../components/MetricCard";
 import { PercentileMatrix } from "../components/PercentileMatrix";
 import { PolicyComparison } from "../components/PolicyComparison";
@@ -305,6 +306,7 @@ export default function InventoryStrategyRoute() {
       </Box>
 
       <PolicyComparison comparisons={dashboard.overall.policyComparisons} />
+      <HurdleSweep dashboard={dashboard} />
       <HorizonCurve dashboard={dashboard} />
       <ScenarioBuilder
         selections={selectedProductLines}

--- a/app/features/inventory-strategy/services/inventoryStrategy.test.ts
+++ b/app/features/inventory-strategy/services/inventoryStrategy.test.ts
@@ -482,6 +482,62 @@ const profitPerDayLabel = (productLineId: number | null) =>
 assert.equal(profitPerDayLabel(3), "Profit per day at 5.00%/day hurdle");
 assert.equal(profitPerDayLabel(5), "Profit per day at 0.50%/day hurdle");
 assert.equal(profitPerDayLabel(null), "Profit per day at product-line hurdles");
+
+const magicLine = productLineHurdleDashboard.productLines.find(
+  (productLine) => productLine.productLineId === 5,
+);
+assert.ok(magicLine);
+assert.deepEqual(
+  magicLine.hurdleSweep.map((scenario) => scenario.dailyReturnHurdle),
+  [0.0025, 0.005, 0.0075, 0.01, 0.015, 0.02],
+  "the sweep covers the hurdle ladder",
+);
+const magicConfigured = magicLine.hurdleSweep.find(
+  (scenario) => scenario.configured,
+);
+const magicComparison = magicLine.policyComparisons.find(
+  ({ key }) => key === "profit-per-day",
+);
+assert.equal(magicConfigured?.dailyReturnHurdle, 0.005);
+assert.deepEqual(
+  {
+    physicalValue: magicConfigured?.physicalValue,
+    oneCopyValue: magicConfigured?.oneCopyValue,
+    estimatedTime: magicConfigured?.estimatedTime,
+    raisedCount: magicConfigured?.raisedCount,
+  },
+  {
+    physicalValue: magicComparison?.physicalValue,
+    oneCopyValue: magicComparison?.oneCopyValue,
+    estimatedTime: magicComparison?.estimatedTime,
+    raisedCount: magicComparison?.raisedCount,
+  },
+  "the configured hurdle's scenario matches the policy comparison row",
+);
+assert.ok(
+  magicLine.hurdleSweep.every(
+    (scenario, index, sweep) =>
+      index === 0 || scenario.physicalValue <= sweep[index - 1].physicalValue,
+  ),
+  "a higher hurdle never lists for more",
+);
+const pokemonHurdleLine = productLineHurdleDashboard.productLines.find(
+  (productLine) => productLine.productLineId === 3,
+);
+assert.equal(
+  pokemonHurdleLine?.hurdleSweep.find((scenario) => scenario.configured)
+    ?.dailyReturnHurdle,
+  0.05,
+  "a product-line hurdle outside the ladder joins the sweep as configured",
+);
+assert.equal(pokemonHurdleLine?.hurdleSweep.length, 7);
+assert.equal(
+  productLineHurdleDashboard.overall.hurdleSweep.find(
+    (scenario) => scenario.configured,
+  )?.dailyReturnHurdle,
+  0.005,
+  "all listed inventory marks the default hurdle",
+);
 assert.equal(activeHorizonComparison?.role, "active");
 assert.equal(activeHorizonComparison?.oneCopyValue, 24);
 assert.equal(activeHorizonComparison?.planState, "single");

--- a/app/features/inventory-strategy/services/inventoryStrategy.ts
+++ b/app/features/inventory-strategy/services/inventoryStrategy.ts
@@ -26,12 +26,15 @@ import {
   type PricingDecision,
 } from "~/core/types/pricingPolicy";
 import {
+  INVENTORY_STRATEGY_HURDLES,
   INVENTORY_STRATEGY_MAX_PERCENTILE,
   INVENTORY_STRATEGY_MIN_PERCENTILE,
   INVENTORY_STRATEGY_PERCENTILES,
   INVENTORY_STRATEGY_PREVIEW_PERCENTILES,
   type InventoryStrategyDashboard,
+  type InventoryStrategyDecisionSummary,
   type InventoryStrategyHorizonModel,
+  type InventoryStrategyHurdleScenario,
   type InventoryStrategyConfidence,
   type InventoryStrategyPercentile,
   type InventoryStrategyPolicyComparison,
@@ -330,6 +333,101 @@ const ROW_POLICY_METHOD = {
   "profit-per-day": "profit-per-day",
 } as const;
 
+interface ItemDecision {
+  item: InventoryStrategySnapshotItem;
+  decision: PricingDecision | undefined;
+}
+
+/**
+ * Portfolio value, wait, and price movement across one decision per SKU;
+ * a SKU without a decision keeps its current price.
+ */
+function summarizeDecisions(
+  decisions: readonly ItemDecision[],
+): InventoryStrategyDecisionSummary {
+  let oneCopyValue = 0;
+  let physicalValue = 0;
+  let modeledSkuCount = 0;
+  let raisedCount = 0;
+  let loweredCount = 0;
+  let heldCount = 0;
+  const timeValues: WeightedValue[] = [];
+
+  for (const { item, decision } of decisions) {
+    const currentPrice = item.currentPrice ?? 0;
+    const selectedPrice = decision?.selectedPrice ?? currentPrice;
+    oneCopyValue += selectedPrice;
+    physicalValue += selectedPrice * item.quantity;
+    if (!decision) {
+      heldCount += 1;
+      continue;
+    }
+    const modeled =
+      decision.basis === "modeled" && decision.forecastStatus !== "unavailable";
+    if (modeled) modeledSkuCount += 1;
+    if (selectedPrice > currentPrice) raisedCount += 1;
+    else if (selectedPrice < currentPrice) loweredCount += 1;
+    else heldCount += 1;
+    if (modeled && decision.estimatedMedianSellDays !== undefined) {
+      timeValues.push({
+        value: decision.estimatedMedianSellDays,
+        weight: item.quantity,
+      });
+    }
+  }
+
+  return {
+    oneCopyValue: roundCurrency(oneCopyValue),
+    physicalValue: roundCurrency(physicalValue),
+    modeledSkuCount,
+    raisedCount,
+    loweredCount,
+    heldCount,
+    estimatedTime: summarizeTime(timeValues),
+  };
+}
+
+/** The distinct values one field takes across the decisions. */
+function distinct<Value>(
+  decisions: readonly ItemDecision[],
+  pick: (decision: PricingDecision) => Value | undefined,
+): Set<Value> {
+  return new Set(
+    decisions.flatMap(({ decision }) => {
+      const value = decision && pick(decision);
+      return value === undefined ? [] : [value];
+    }),
+  );
+}
+
+/**
+ * The profit-per-day policy at each hurdle of the ladder, plus the product
+ * line's configured hurdle when the ladder lacks it.
+ */
+function buildHurdleSweep(
+  items: InventoryStrategySnapshotItem[],
+  portfolioItems: readonly StrategyPortfolioItem[],
+  config: ServerPricingConfig,
+  configuredHurdle: number,
+): InventoryStrategyHurdleScenario[] {
+  const policy = profitPerDayPolicy(config.pricing.profitPerDay);
+  return [...new Set([...INVENTORY_STRATEGY_HURDLES, configuredHurdle])]
+    .sort((left, right) => left - right)
+    .map((dailyReturnHurdle) => {
+      const decisions = portfolioDecisions(portfolioItems, {
+        ...policy,
+        dailyReturnHurdle,
+      });
+      return {
+        dailyReturnHurdle,
+        configured: dailyReturnHurdle === configuredHurdle,
+        ...summarizeDecisions(
+          items.map((item) => ({ item, decision: decisions.get(item.sku) })),
+        ),
+      };
+    });
+}
+
 function buildPolicyComparisons(
   items: InventoryStrategySnapshotItem[],
   horizonDecisions: ReadonlyMap<number, PricingDecision>,
@@ -345,7 +443,7 @@ function buildPolicyComparisons(
     key: InventoryStrategyPolicyComparison["key"],
   ): InventoryStrategyPolicyComparison | null => {
     const isCurrent = key === "current";
-    const decisions = stored.map(
+    const decisions: ItemDecision[] = stored.map(
       ({ item, activeDecision, benchmarkDecision }) => ({
         item,
         decision:
@@ -368,54 +466,19 @@ function buildPolicyComparisons(
     );
     if (!isCurrent && !decisions.some(({ decision }) => decision)) return null;
 
-    let oneCopyValue = 0;
-    let physicalValue = 0;
-    let modeledSkuCount = 0;
-    let raisedCount = 0;
-    let loweredCount = 0;
-    let heldCount = 0;
-    const timeValues: WeightedValue[] = [];
-    const targetHorizons = new Set<number>();
-    const hurdles = new Set<number>();
-    const planIds = new Set<string>();
-    const planMatchStatuses = new Set<
-      "matched" | "boundary" | "infeasible"
-    >();
-
-    for (const { item, decision } of decisions) {
-      const currentPrice = item.currentPrice ?? 0;
-      const selectedPrice = decision?.selectedPrice ?? currentPrice;
-      oneCopyValue += selectedPrice;
-      physicalValue += selectedPrice * item.quantity;
-      if (decision) {
-        const isModeledDecision =
-          decision.basis === "modeled" &&
-          decision.forecastStatus !== "unavailable";
-        if (isModeledDecision) modeledSkuCount += 1;
-        if (selectedPrice > currentPrice) raisedCount += 1;
-        else if (selectedPrice < currentPrice) loweredCount += 1;
-        else heldCount += 1;
-        if (
-          isModeledDecision &&
-          decision.estimatedMedianSellDays !== undefined
-        ) {
-          timeValues.push({
-            value: decision.estimatedMedianSellDays,
-            weight: item.quantity,
-          });
-        }
-        if (decision.targetHorizonDays !== undefined)
-          targetHorizons.add(decision.targetHorizonDays);
-        if (decision.dailyReturnHurdle !== undefined)
-          hurdles.add(decision.dailyReturnHurdle);
-        if (decision.planId) planIds.add(decision.planId);
-        if (decision.planMatchStatus)
-          planMatchStatuses.add(decision.planMatchStatus);
-      } else {
-        heldCount += 1;
-      }
-    }
-
+    const targetHorizons = distinct(
+      decisions,
+      (decision) => decision.targetHorizonDays,
+    );
+    const hurdles = distinct(
+      decisions,
+      (decision) => decision.dailyReturnHurdle,
+    );
+    const planIds = distinct(decisions, (decision) => decision.planId);
+    const planMatchStatuses = distinct(
+      decisions,
+      (decision) => decision.planMatchStatus,
+    );
     const [profitPerDayHurdle] = hurdles;
     const role: InventoryStrategyPolicyComparison["role"] =
       key === "current"
@@ -461,13 +524,7 @@ function buildPolicyComparisons(
           : planMatchStatuses.size === 1
             ? [...planMatchStatuses][0]
             : null,
-      oneCopyValue: roundCurrency(oneCopyValue),
-      physicalValue: roundCurrency(physicalValue),
-      modeledSkuCount,
-      raisedCount,
-      loweredCount,
-      heldCount,
-      estimatedTime: summarizeTime(timeValues),
+      ...summarizeDecisions(decisions),
     };
   };
 
@@ -741,6 +798,14 @@ function buildProductLine(
     portfolioItems,
     config,
   );
+  const profitPerDay = profitPerDayPolicy(config.pricing.profitPerDay);
+  const configuredHurdle =
+    productLineId === null
+      ? profitPerDay.dailyReturnHurdle
+      : productLinePricingPolicy(
+          profitPerDay,
+          config.productLinePricing.productLineSettings[productLineId],
+        ).dailyReturnHurdle;
 
   return {
     key,
@@ -778,11 +843,17 @@ function buildProductLine(
       horizonDecisions.decisions,
       portfolioDecisions(portfolioItems, (item) =>
         productLinePricingPolicy(
-          profitPerDayPolicy(config.pricing.profitPerDay),
+          profitPerDay,
           config.productLinePricing.productLineSettings[item.productLineId],
         ),
       ),
       activePricingPolicy(config.pricing),
+    ),
+    hurdleSweep: buildHurdleSweep(
+      items,
+      portfolioItems,
+      config,
+      configuredHurdle,
     ),
     valueMatchedHorizonDays: horizonDecisions.valueMatchedHorizonDays,
     horizonModel: buildHorizonModel(portfolioItems),

--- a/app/features/inventory-strategy/types/inventoryStrategy.ts
+++ b/app/features/inventory-strategy/types/inventoryStrategy.ts
@@ -68,7 +68,30 @@ export interface InventoryStrategyScenario {
   estimatedTime: InventoryStrategyTimeDistribution | null;
 }
 
-export interface InventoryStrategyPolicyComparison {
+/** Daily return hurdles the profit-per-day policy is evaluated at. */
+export const INVENTORY_STRATEGY_HURDLES = [
+  0.0025, 0.005, 0.0075, 0.01, 0.015, 0.02,
+];
+
+/** Portfolio value, wait, and price movement under one decision per SKU. */
+export interface InventoryStrategyDecisionSummary {
+  oneCopyValue: number;
+  physicalValue: number;
+  modeledSkuCount: number;
+  raisedCount: number;
+  loweredCount: number;
+  heldCount: number;
+  estimatedTime: InventoryStrategyTimeDistribution | null;
+}
+
+/** The profit-per-day policy evaluated at one daily return hurdle. */
+export interface InventoryStrategyHurdleScenario extends InventoryStrategyDecisionSummary {
+  dailyReturnHurdle: number;
+  /** Whether this is the hurdle the product line is configured with. */
+  configured: boolean;
+}
+
+export interface InventoryStrategyPolicyComparison extends InventoryStrategyDecisionSummary {
   key: "current" | "percentile" | "target-horizon-shadow" | "profit-per-day";
   label: string;
   role: "current" | "active" | "benchmark" | "calibration";
@@ -79,13 +102,6 @@ export interface InventoryStrategyPolicyComparison {
     | "infeasible"
     | "mixed"
     | null;
-  oneCopyValue: number;
-  physicalValue: number;
-  modeledSkuCount: number;
-  raisedCount: number;
-  loweredCount: number;
-  heldCount: number;
-  estimatedTime: InventoryStrategyTimeDistribution | null;
 }
 
 export type InventoryStrategyConfidence =
@@ -124,6 +140,7 @@ export interface InventoryStrategyProductLine {
   matrixPercentiles: number[];
   scenarios: InventoryStrategyScenario[];
   policyComparisons: InventoryStrategyPolicyComparison[];
+  hurdleSweep: InventoryStrategyHurdleScenario[];
   valueMatchedHorizonDays: number | null;
   horizonModel: InventoryStrategyHorizonModel | null;
 }


### PR DESCRIPTION
The active policy's only parameter is the daily return hurdle, yet the page swept only the percentile and the target horizon. Each product line now evaluates the profit-per-day policy across a hurdle ladder (0.25% to 2.00% per day) and its own configured hurdle, recording value, wait, and price movement per hurdle through the same summary the policy comparison rows use. A hurdle sweep section shows the ladder for every product line with the configured hurdle shaded.

Verified: typecheck, 191 tests (the strategy test now checks the ladder, that the configured hurdle's row matches the policy comparison row, monotone value, an out-of-ladder product-line hurdle, and the overall row's default), build, and a dev render of the section.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)