### PR TITLE
Replace the horizon table with a chart and drop the value-matched calibration

### DIFF
--- a/app/features/inventory-strategy/components/HorizonChart.tsx
+++ b/app/features/inventory-strategy/components/HorizonChart.tsx
@@ -1,0 +1,364 @@
+import { Box, Typography, useTheme } from "@mui/material";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import type { HorizonPoint } from "./horizonPoints";
+import { currencyFormatter, formatDays } from "./format";
+
+/** A horizon called out on the chart, such as the knee or the best cycle. */
+export interface HorizonMark {
+  label: string;
+  point: HorizonPoint;
+  color: string;
+}
+
+const MARGIN = { left: 76, right: 20, top: 24, gap: 36, axis: 32 };
+const VALUE_HEIGHT = 190;
+const PROFIT_HEIGHT = 120;
+const HEIGHT =
+  MARGIN.top + VALUE_HEIGHT + MARGIN.gap + PROFIT_HEIGHT + MARGIN.axis;
+const X_TICK_CANDIDATES = [
+  0.1, 0.3, 1, 3, 10, 30, 100, 365, 1000, 3000, 10000, 30000,
+];
+
+function niceTicks(minimum: number, maximum: number, count: number): number[] {
+  const span = maximum - minimum;
+  if (!(span > 0)) return [minimum];
+  const rough = span / count;
+  const magnitude = 10 ** Math.floor(Math.log10(rough));
+  const step =
+    [1, 2, 2.5, 5, 10]
+      .map((unit) => unit * magnitude)
+      .find((candidate) => candidate >= rough) ?? magnitude;
+  const ticks: number[] = [];
+  for (
+    let tick = Math.ceil(minimum / step) * step;
+    tick <= maximum + step / 1e6;
+    tick += step
+  ) {
+    ticks.push(Math.round(tick / step) * step);
+  }
+  return ticks;
+}
+
+function useWidth(fallback: number) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(fallback);
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+    setWidth(element.getBoundingClientRect().width);
+    const observer = new ResizeObserver(([entry]) =>
+      setWidth(entry.contentRect.width),
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+  return [ref, width] as const;
+}
+
+/**
+ * Value and cycle profit per day against horizon on a log axis, with the
+ * marked horizons labeled. A crosshair follows the pointer or the arrow keys
+ * and reads every measure at that horizon.
+ */
+export function HorizonChart({
+  points,
+  marks,
+  label,
+}: {
+  points: HorizonPoint[];
+  marks: HorizonMark[];
+  label: string;
+}) {
+  const theme = useTheme();
+  const [container, width] = useWidth(720);
+  const [hovered, setHovered] = useState<number | null>(null);
+  const plotWidth = Math.max(120, width - MARGIN.left - MARGIN.right);
+  const first = points[0];
+  const last = points[points.length - 1];
+  const logMinimum = Math.log(first.horizonDays);
+  const logSpan = Math.log(last.horizonDays) - logMinimum || 1;
+  const x = (horizonDays: number) =>
+    MARGIN.left + ((Math.log(horizonDays) - logMinimum) / logSpan) * plotWidth;
+  const values = points.map((point) => point.value);
+  const valueTicks = niceTicks(Math.min(...values), Math.max(...values), 4);
+  const valueMinimum = Math.min(...values, ...valueTicks);
+  const valueMaximum = Math.max(...values, ...valueTicks);
+  const valueY = (value: number) =>
+    MARGIN.top +
+    VALUE_HEIGHT -
+    ((value - valueMinimum) / (valueMaximum - valueMinimum || 1)) *
+      VALUE_HEIGHT;
+  const profits = points.map((point) => point.profitPerDay);
+  const profitTicks = niceTicks(
+    Math.min(0, ...profits),
+    Math.max(0, ...profits),
+    3,
+  );
+  const profitMinimum = Math.min(...profits, ...profitTicks);
+  const profitMaximum = Math.max(...profits, ...profitTicks);
+  const profitTop = MARGIN.top + VALUE_HEIGHT + MARGIN.gap;
+  const profitY = (profit: number) =>
+    profitTop +
+    PROFIT_HEIGHT -
+    ((profit - profitMinimum) / (profitMaximum - profitMinimum || 1)) *
+      PROFIT_HEIGHT;
+  const xTicks = X_TICK_CANDIDATES.filter(
+    (tick) => tick >= first.horizonDays && tick <= last.horizonDays,
+  );
+  const nearestIndex = (horizonDays: number) =>
+    Math.round(
+      ((Math.log(horizonDays) - logMinimum) / logSpan) * (points.length - 1),
+    );
+  const valuePath = points
+    .map(
+      (point, index) =>
+        `${index === 0 ? "M" : "L"}${x(point.horizonDays).toFixed(1)},${valueY(point.value).toFixed(1)}`,
+    )
+    .join(" ");
+  const profitPath = points
+    .map(
+      (point, index) =>
+        `${index === 0 ? "M" : "L"}${x(point.horizonDays).toFixed(1)},${profitY(point.profitPerDay).toFixed(1)}`,
+    )
+    .join(" ");
+  const areaPath = `${valuePath} L${x(last.horizonDays).toFixed(1)},${(MARGIN.top + VALUE_HEIGHT).toFixed(1)} L${x(first.horizonDays).toFixed(1)},${(MARGIN.top + VALUE_HEIGHT).toFixed(1)} Z`;
+  const surface = theme.palette.background.paper;
+  const series = theme.palette.primary.main;
+  const grid = theme.palette.divider;
+  const ink = theme.palette.text.secondary;
+  const hoveredPoint = hovered === null ? null : points[hovered];
+
+  const onPointerMove = (event: React.PointerEvent<SVGSVGElement>) => {
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const position = (event.clientX - bounds.left - MARGIN.left) / plotWidth;
+    setHovered(
+      Math.max(
+        0,
+        Math.min(points.length - 1, Math.round(position * (points.length - 1))),
+      ),
+    );
+  };
+  const onKeyDown = (event: KeyboardEvent<SVGSVGElement>) => {
+    const step =
+      event.key === "ArrowRight" ? 1 : event.key === "ArrowLeft" ? -1 : 0;
+    if (step === 0) return;
+    event.preventDefault();
+    setHovered((current) =>
+      Math.max(
+        0,
+        Math.min(
+          points.length - 1,
+          (current ??
+            nearestIndex(marks[0]?.point.horizonDays ?? first.horizonDays)) +
+            step,
+        ),
+      ),
+    );
+  };
+
+  return (
+    <Box ref={container} sx={{ position: "relative" }}>
+      <svg
+        width={width}
+        height={HEIGHT}
+        role="img"
+        aria-label={label}
+        tabIndex={0}
+        onPointerMove={onPointerMove}
+        onPointerLeave={() => setHovered(null)}
+        onFocus={() =>
+          setHovered(
+            (current) =>
+              current ??
+              nearestIndex(marks[0]?.point.horizonDays ?? first.horizonDays),
+          )
+        }
+        onBlur={() => setHovered(null)}
+        onKeyDown={onKeyDown}
+        style={{ display: "block", outline: "none", fontSize: 12 }}
+      >
+        {valueTicks.map((tick) => (
+          <g key={`value-${tick}`}>
+            <line
+              x1={MARGIN.left}
+              x2={MARGIN.left + plotWidth}
+              y1={valueY(tick)}
+              y2={valueY(tick)}
+              stroke={grid}
+            />
+            <text
+              x={MARGIN.left - 8}
+              y={valueY(tick)}
+              dy="0.35em"
+              textAnchor="end"
+              fill={ink}
+              style={{ fontVariantNumeric: "tabular-nums" }}
+            >
+              {currencyFormatter.format(tick)}
+            </text>
+          </g>
+        ))}
+        {profitTicks.map((tick) => (
+          <g key={`profit-${tick}`}>
+            <line
+              x1={MARGIN.left}
+              x2={MARGIN.left + plotWidth}
+              y1={profitY(tick)}
+              y2={profitY(tick)}
+              stroke={tick === 0 ? ink : grid}
+            />
+            <text
+              x={MARGIN.left - 8}
+              y={profitY(tick)}
+              dy="0.35em"
+              textAnchor="end"
+              fill={ink}
+              style={{ fontVariantNumeric: "tabular-nums" }}
+            >
+              {currencyFormatter.format(tick)}
+            </text>
+          </g>
+        ))}
+        {xTicks.map((tick) => (
+          <text
+            key={`x-${tick}`}
+            x={x(tick)}
+            y={profitTop + PROFIT_HEIGHT + 20}
+            textAnchor={
+              x(tick) < MARGIN.left + 12
+                ? "start"
+                : x(tick) > MARGIN.left + plotWidth - 12
+                  ? "end"
+                  : "middle"
+            }
+            fill={ink}
+          >
+            {tick.toLocaleString()}
+          </text>
+        ))}
+        <text x={MARGIN.left} y={MARGIN.top - 10} fill={ink}>
+          Physical value by target horizon, days
+        </text>
+        <text x={MARGIN.left} y={profitTop - 10} fill={ink}>
+          Cycle profit per day
+        </text>
+        <path d={areaPath} fill={series} fillOpacity={0.1} />
+        <path
+          d={valuePath}
+          fill="none"
+          stroke={series}
+          strokeWidth={2}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+        <path
+          d={profitPath}
+          fill="none"
+          stroke={series}
+          strokeWidth={2}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+        {marks.map((mark) => {
+          const { point } = mark;
+          const markX = x(point.horizonDays);
+          const onRight = markX > MARGIN.left + plotWidth * 0.7;
+          return (
+            <g key={mark.label}>
+              <circle
+                cx={markX}
+                cy={valueY(point.value)}
+                r={5}
+                fill={mark.color}
+                stroke={surface}
+                strokeWidth={2}
+              />
+              <circle
+                cx={markX}
+                cy={profitY(point.profitPerDay)}
+                r={5}
+                fill={mark.color}
+                stroke={surface}
+                strokeWidth={2}
+              />
+              <text
+                x={markX + (onRight ? -10 : 10)}
+                y={valueY(point.value) - 10}
+                textAnchor={onRight ? "end" : "start"}
+                fill={theme.palette.text.primary}
+                fontWeight={600}
+              >
+                {mark.label} · {formatDays(point.horizonDays)}
+              </text>
+            </g>
+          );
+        })}
+        {hoveredPoint && (
+          <g pointerEvents="none">
+            <line
+              x1={x(hoveredPoint.horizonDays)}
+              x2={x(hoveredPoint.horizonDays)}
+              y1={MARGIN.top}
+              y2={profitTop + PROFIT_HEIGHT}
+              stroke={ink}
+            />
+            <circle
+              cx={x(hoveredPoint.horizonDays)}
+              cy={valueY(hoveredPoint.value)}
+              r={4}
+              fill={series}
+              stroke={surface}
+              strokeWidth={2}
+            />
+            <circle
+              cx={x(hoveredPoint.horizonDays)}
+              cy={profitY(hoveredPoint.profitPerDay)}
+              r={4}
+              fill={series}
+              stroke={surface}
+              strokeWidth={2}
+            />
+          </g>
+        )}
+      </svg>
+      {hoveredPoint && (
+        <Box
+          sx={{
+            position: "absolute",
+            top: MARGIN.top,
+            ...(x(hoveredPoint.horizonDays) > MARGIN.left + plotWidth * 0.6
+              ? { right: width - x(hoveredPoint.horizonDays) + 12 }
+              : { left: x(hoveredPoint.horizonDays) + 12 }),
+            pointerEvents: "none",
+            bgcolor: "background.paper",
+            border: 1,
+            borderColor: "divider",
+            borderRadius: 1,
+            px: 1.5,
+            py: 1,
+            boxShadow: 2,
+          }}
+        >
+          <Typography variant="body2" fontWeight={700}>
+            {formatDays(hoveredPoint.horizonDays)}
+          </Typography>
+          <Typography variant="body2">
+            {currencyFormatter.format(hoveredPoint.value)} value
+          </Typography>
+          <Typography variant="caption" color="text.secondary" display="block">
+            {currencyFormatter.format(hoveredPoint.marginalValuePerDay)}/day
+            marginal · e {hoveredPoint.elasticity.toFixed(2)}
+          </Typography>
+          <Typography
+            variant="caption"
+            display="block"
+            color={hoveredPoint.profit >= 0 ? "text.secondary" : "error.main"}
+          >
+            {currencyFormatter.format(hoveredPoint.profitPerDay)}/day profit ·{" "}
+            {currencyFormatter.format(hoveredPoint.netProceeds)} net
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/app/features/inventory-strategy/components/HorizonCurve.tsx
+++ b/app/features/inventory-strategy/components/HorizonCurve.tsx
@@ -9,21 +9,18 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  ToggleButton,
+  ToggleButtonGroup,
   Typography,
+  useTheme,
 } from "@mui/material";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
   bestCapitalCycle,
-  capitalCycleAtHorizon,
   type CapitalCycle,
   type CapitalCycleEconomics,
 } from "~/features/pricing/domain/capitalCycle";
-import {
-  horizonGainElasticity,
-  horizonKneeDays,
-  horizonMarginalValuePerDay,
-  horizonValue,
-} from "~/features/pricing/domain/horizonValueCurve";
+import { horizonKneeDays } from "~/features/pricing/domain/horizonValueCurve";
 import { ValidatedNumberField } from "~/shared/components/ValidatedNumberField";
 import {
   INVENTORY_STRATEGY_HORIZON_DAYS,
@@ -36,18 +33,20 @@ import {
   type CapitalCycleInputs,
 } from "./capitalCycleInputs";
 import { currencyFormatter, formatDays } from "./format";
+import { HorizonChart, type HorizonMark } from "./HorizonChart";
+import {
+  horizonPoint,
+  sampleHorizonPoints,
+  type HorizonPoint,
+} from "./horizonPoints";
+
+const CHART_SAMPLE_COUNT = 80;
 
 const fitConfidenceColor = {
   high: "success",
   medium: "warning",
   low: "default",
   unavailable: "default",
-} as const;
-
-const emphasisColor = {
-  knee: "success.main",
-  cycle: "info.main",
-  active: "text.primary",
 } as const;
 
 /** The product line's best cycle, or undefined without a curve or a profitable horizon. */
@@ -79,75 +78,35 @@ function cycleSummary(
   return `The best cycle on all listed inventory compounds capital at ${(cycle.dailyReturn * 100).toFixed(2)}% per day.`;
 }
 
-/**
- * Modeled value at one horizon with its marginal rate, elasticity, and the
- * profit per day of a capital cycle. Shows the horizon itself when it varies
- * by row (knee, best cycle, value-matched).
- */
-function HorizonValueCell({
-  productLine,
-  horizonDays,
-  economics,
-  showDays = false,
-  emphasis,
-}: {
-  productLine: InventoryStrategyProductLine;
-  horizonDays: number | null;
-  economics: CapitalCycleEconomics;
-  showDays?: boolean;
-  emphasis?: "active" | "knee" | "cycle";
-}) {
+function fitLabel(productLine: InventoryStrategyProductLine): string {
   const model = productLine.horizonModel;
-  if (!model?.curve || horizonDays === null) {
-    return <TableCell align="right">—</TableCell>;
-  }
-  const outsideRange =
-    horizonDays < model.minimumHorizonDays ||
-    horizonDays > model.maximumHorizonDays;
-  const cycle = capitalCycleAtHorizon(
-    model.curve,
-    cyclePortfolio(productLine),
-    economics,
-    horizonDays,
-  );
+  return !model
+    ? "No curve"
+    : !model.curve
+      ? "No fit"
+      : `${model.fitConfidence} confidence`;
+}
+
+/** Horizon, value, and profit per day for a called-out horizon, or a dash. */
+function HorizonCell({ point }: { point: HorizonPoint | undefined }) {
   return (
-    <TableCell
-      align="right"
-      sx={{ bgcolor: emphasis === "active" ? "action.selected" : undefined }}
-    >
-      {showDays && (
-        <Typography
-          variant="body2"
-          fontWeight={700}
-          color={emphasis ? emphasisColor[emphasis] : "text.primary"}
-        >
-          {formatDays(horizonDays)}
-        </Typography>
-      )}
-      <Typography
-        variant="body2"
-        fontWeight={emphasis === "active" ? 700 : 400}
-      >
-        {currencyFormatter.format(horizonValue(model.curve, horizonDays))}
-      </Typography>
-      <Typography variant="caption" color="text.secondary" display="block">
-        {currencyFormatter.format(
-          horizonMarginalValuePerDay(model.curve, horizonDays),
-        )}
-        /day · e {horizonGainElasticity(model.curve, horizonDays).toFixed(2)}
-      </Typography>
-      <Typography
-        variant="caption"
-        display="block"
-        color={cycle.profit >= 0 ? "text.secondary" : "error.main"}
-      >
-        {currencyFormatter.format(cycle.profitPerDay)}/day profit ·{" "}
-        {currencyFormatter.format(cycle.netProceeds)} net
-      </Typography>
-      {outsideRange && (
-        <Typography variant="caption" color="text.secondary" display="block">
-          Outside curve range
-        </Typography>
+    <TableCell align="right">
+      {point ? (
+        <>
+          <Typography variant="body2">
+            {formatDays(point.horizonDays)} ·{" "}
+            {currencyFormatter.format(point.value)}
+          </Typography>
+          <Typography
+            variant="caption"
+            display="block"
+            color={point.profit >= 0 ? "text.secondary" : "error.main"}
+          >
+            {currencyFormatter.format(point.profitPerDay)}/day profit
+          </Typography>
+        </>
+      ) : (
+        "—"
       )}
     </TableCell>
   );
@@ -164,6 +123,9 @@ export function HorizonCurve({
   cycleInputs: CapitalCycleInputs;
   onCycleInputsChange: (inputs: CapitalCycleInputs) => void;
 }) {
+  const theme = useTheme();
+  const [selectedKey, setSelectedKey] = useState(dashboard.overall.key);
+  const [tableView, setTableView] = useState(false);
   const allProductLines = useMemo(
     () => [dashboard.overall, ...dashboard.productLines],
     [dashboard.overall, dashboard.productLines],
@@ -172,9 +134,6 @@ export function HorizonCurve({
     dashboard.policy.method === "target-horizon"
       ? dashboard.policy.horizonDays
       : null;
-  const showValueMatchedColumn = allProductLines.some(
-    (productLine) => productLine.valueMatchedHorizonDays !== null,
-  );
   const bestCycles = useMemo(
     () =>
       Object.fromEntries(
@@ -185,26 +144,81 @@ export function HorizonCurve({
       ),
     [allProductLines, economics],
   );
+  const selected =
+    allProductLines.find((productLine) => productLine.key === selectedKey) ??
+    dashboard.overall;
+  const model = selected.horizonModel;
+  const curve = model?.curve ?? null;
+  const portfolio = cyclePortfolio(selected);
+  const pointAt = (
+    productLine: InventoryStrategyProductLine,
+    days: number | null | undefined,
+  ) =>
+    productLine.horizonModel?.curve && days
+      ? horizonPoint(
+          productLine.horizonModel.curve,
+          cyclePortfolio(productLine),
+          economics,
+          days,
+        )
+      : undefined;
+  const markAt = (label: string, horizonDays: number, color: string) =>
+    curve
+      ? [
+          {
+            label,
+            point: horizonPoint(curve, portfolio, economics, horizonDays),
+            color,
+          },
+        ]
+      : [];
+  const marks: HorizonMark[] = curve
+    ? [
+        ...markAt("Knee", horizonKneeDays(curve), theme.palette.success.main),
+        ...(bestCycles[selected.key]
+          ? markAt(
+              "Best cycle",
+              bestCycles[selected.key]!.horizonDays,
+              theme.palette.info.main,
+            )
+          : []),
+        ...(activeHorizonDays !== null
+          ? markAt("Active", activeHorizonDays, theme.palette.text.primary)
+          : []),
+      ]
+    : [];
+  const points =
+    curve && model
+      ? sampleHorizonPoints(
+          curve,
+          model,
+          portfolio,
+          economics,
+          CHART_SAMPLE_COUNT,
+        )
+      : [];
+  const tableRows = curve
+    ? [
+        ...marks.map(({ label, point }) => ({ label, point })),
+        ...INVENTORY_STRATEGY_HORIZON_DAYS.map((horizonDays) => ({
+          label: `${horizonDays} days`,
+          point: horizonPoint(curve, portfolio, economics, horizonDays),
+        })),
+      ].sort((left, right) => left.point.horizonDays - right.point.horizonDays)
+    : [];
 
   return (
     <Paper variant="outlined" sx={{ mb: 3 }}>
       <Box sx={{ p: 2 }}>
         <Typography variant="h6">Horizon curve</Typography>
         <Typography variant="body2" color="text.secondary">
-          Physical value across target horizons follows a fitted log-logistic
-          curve: floor plus headroom ÷ (1 + (midpoint ÷ horizon)^steepness). The
-          knee is where gain per doubling of horizon decelerates fastest, at
-          about 79% of headroom. Each cell shows modeled value, dollars per
-          extra day, and elasticity (percent of gain over floor earned per
-          percent longer horizon). Fit residual is the root-mean-square error in
-          headroom fraction.
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
-          Profit per day takes overhead off the sale, recovers the cost basis,
-          and divides by horizon plus turnaround. Best cycle is the horizon that
-          maximizes it. Overhead comes from the profit-per-day settings.
-          Horizons shorter than most SKUs&apos; fastest sell time overstate how
-          quickly a cycle completes.
+          Physical value with every modeled SKU priced to sell within one target
+          horizon, on a fitted log-logistic curve, and the profit per day of a
+          sell-and-rebuy cycle at that horizon: overhead off the sale, the cost
+          basis recovered, divided by horizon plus turnaround. The knee is where
+          gain per doubling of horizon slows fastest; the best cycle is the
+          horizon with the most profit per day. Horizons shorter than most
+          SKUs&apos; fastest sell time overstate how quickly a cycle completes.
         </Typography>
         <Stack
           direction="row"
@@ -230,25 +244,120 @@ export function HorizonCurve({
         </Stack>
         <Typography variant="body2" sx={{ mt: 2 }}>
           {cycleSummary(dashboard.overall, bestCycles[dashboard.overall.key])}{" "}
-          The default profit-per-day hurdle is configured at{" "}
-          {(dashboard.profitPerDay.dailyReturnHurdle * 100).toFixed(2)}% per
-          day.
+          Overhead comes from the profit-per-day settings.
         </Typography>
+        <Stack
+          direction="row"
+          spacing={2}
+          alignItems="center"
+          flexWrap="wrap"
+          useFlexGap
+          sx={{ mt: 2 }}
+        >
+          <ToggleButtonGroup
+            size="small"
+            exclusive
+            value={selected.key}
+            onChange={(_, key: string | null) => {
+              if (key !== null) setSelectedKey(key);
+            }}
+          >
+            {allProductLines.map((productLine) => (
+              <ToggleButton key={productLine.key} value={productLine.key}>
+                {productLine.key === "all" ? "All" : productLine.productLine}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+          <ToggleButton
+            size="small"
+            value="table"
+            selected={tableView}
+            onChange={() => setTableView((current) => !current)}
+          >
+            Table
+          </ToggleButton>
+          <Chip
+            size="small"
+            variant="outlined"
+            color={model ? fitConfidenceColor[model.fitConfidence] : "default"}
+            label={fitLabel(selected)}
+          />
+          {curve && model && (
+            <Typography variant="caption" color="text.secondary">
+              midpoint {formatDays(curve.midpointDays)} · steepness{" "}
+              {curve.steepness.toFixed(2)} · residual{" "}
+              {curve.residual.toFixed(3)} ·{" "}
+              {currencyFormatter.format(curve.floorValue)} →{" "}
+              {currencyFormatter.format(curve.ceilingValue)} over{" "}
+              {formatDays(model.minimumHorizonDays)} –{" "}
+              {formatDays(model.maximumHorizonDays)}
+            </Typography>
+          )}
+        </Stack>
+        {points.length > 0 ? (
+          <Box sx={{ mt: 2 }}>
+            <HorizonChart
+              points={points}
+              marks={marks}
+              label={`${selected.productLine}: physical value and cycle profit per day against target horizon`}
+            />
+          </Box>
+        ) : (
+          <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+            {selected.productLine} has no fitted horizon curve.
+          </Typography>
+        )}
       </Box>
+      {tableView && tableRows.length > 0 && (
+        <TableContainer>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Horizon</TableCell>
+                <TableCell align="right">Days</TableCell>
+                <TableCell align="right">Value</TableCell>
+                <TableCell align="right">Marginal / day</TableCell>
+                <TableCell align="right">Elasticity</TableCell>
+                <TableCell align="right">Profit / day</TableCell>
+                <TableCell align="right">Net proceeds</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {tableRows.map(({ label, point }) => (
+                <TableRow key={label}>
+                  <TableCell>{label}</TableCell>
+                  <TableCell align="right">
+                    {formatDays(point.horizonDays)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {currencyFormatter.format(point.value)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {currencyFormatter.format(point.marginalValuePerDay)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {point.elasticity.toFixed(2)}
+                  </TableCell>
+                  <TableCell
+                    align="right"
+                    sx={{ color: point.profit >= 0 ? undefined : "error.main" }}
+                  >
+                    {currencyFormatter.format(point.profitPerDay)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {currencyFormatter.format(point.netProceeds)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
       <TableContainer>
-        <Table size="small" sx={{ minWidth: 1200 }}>
+        <Table size="small">
           <TableHead>
             <TableRow>
-              <TableCell
-                sx={{
-                  position: "sticky",
-                  left: 0,
-                  bgcolor: "background.paper",
-                  zIndex: 1,
-                }}
-              >
-                Product line
-              </TableCell>
+              <TableCell>Product line</TableCell>
               <TableCell>Fit</TableCell>
               <TableCell align="right">Floor → ceiling</TableCell>
               <TableCell align="right">Knee</TableCell>
@@ -258,30 +367,21 @@ export function HorizonCurve({
                   Active ({formatDays(activeHorizonDays)})
                 </TableCell>
               )}
-              {showValueMatchedColumn && (
-                <TableCell align="right">Value-matched</TableCell>
-              )}
-              {INVENTORY_STRATEGY_HORIZON_DAYS.map((horizonDays) => (
-                <TableCell key={horizonDays} align="right">
-                  {horizonDays} days
-                </TableCell>
-              ))}
             </TableRow>
           </TableHead>
           <TableBody>
             {allProductLines.map((productLine) => {
-              const model = productLine.horizonModel;
-              const curve = model?.curve ?? null;
+              const lineCurve = productLine.horizonModel?.curve;
               return (
-                <TableRow key={productLine.key}>
+                <TableRow
+                  key={productLine.key}
+                  hover
+                  selected={productLine.key === selected.key}
+                  onClick={() => setSelectedKey(productLine.key)}
+                  sx={{ cursor: "pointer" }}
+                >
                   <TableCell
-                    sx={{
-                      position: "sticky",
-                      left: 0,
-                      bgcolor: "background.paper",
-                      zIndex: 1,
-                      fontWeight: productLine.key === "all" ? 700 : 400,
-                    }}
+                    sx={{ fontWeight: productLine.key === "all" ? 700 : 400 }}
                   >
                     {productLine.productLine}
                   </TableCell>
@@ -290,90 +390,37 @@ export function HorizonCurve({
                       size="small"
                       variant="outlined"
                       color={
-                        model
-                          ? fitConfidenceColor[model.fitConfidence]
+                        productLine.horizonModel
+                          ? fitConfidenceColor[
+                              productLine.horizonModel.fitConfidence
+                            ]
                           : "default"
                       }
-                      label={
-                        !model
-                          ? "No curve"
-                          : !curve
-                            ? "No fit"
-                            : `${model.fitConfidence} confidence`
-                      }
+                      label={fitLabel(productLine)}
                     />
-                    {curve && (
-                      <Typography
-                        variant="caption"
-                        color="text.secondary"
-                        display="block"
-                      >
-                        midpoint {formatDays(curve.midpointDays)} · steepness{" "}
-                        {curve.steepness.toFixed(2)} · residual{" "}
-                        {curve.residual.toFixed(3)}
-                      </Typography>
-                    )}
                   </TableCell>
                   <TableCell align="right">
-                    {model && curve ? (
-                      <>
-                        <Typography variant="body2">
-                          {currencyFormatter.format(curve.floorValue)} →{" "}
-                          {currencyFormatter.format(curve.ceilingValue)}
-                        </Typography>
-                        <Typography
-                          variant="caption"
-                          color="text.secondary"
-                          display="block"
-                        >
-                          {formatDays(model.minimumHorizonDays)} –{" "}
-                          {formatDays(model.maximumHorizonDays)}
-                        </Typography>
-                      </>
-                    ) : (
-                      "—"
-                    )}
+                    {lineCurve
+                      ? `${currencyFormatter.format(lineCurve.floorValue)} → ${currencyFormatter.format(lineCurve.ceilingValue)}`
+                      : "—"}
                   </TableCell>
-                  <HorizonValueCell
-                    productLine={productLine}
-                    horizonDays={curve ? horizonKneeDays(curve) : null}
-                    economics={economics}
-                    showDays
-                    emphasis="knee"
+                  <HorizonCell
+                    point={pointAt(
+                      productLine,
+                      lineCurve ? horizonKneeDays(lineCurve) : null,
+                    )}
                   />
-                  <HorizonValueCell
-                    productLine={productLine}
-                    horizonDays={
-                      bestCycles[productLine.key]?.horizonDays ?? null
-                    }
-                    economics={economics}
-                    showDays
-                    emphasis="cycle"
+                  <HorizonCell
+                    point={pointAt(
+                      productLine,
+                      bestCycles[productLine.key]?.horizonDays,
+                    )}
                   />
                   {activeHorizonDays !== null && (
-                    <HorizonValueCell
-                      productLine={productLine}
-                      horizonDays={activeHorizonDays}
-                      economics={economics}
-                      emphasis="active"
+                    <HorizonCell
+                      point={pointAt(productLine, activeHorizonDays)}
                     />
                   )}
-                  {showValueMatchedColumn && (
-                    <HorizonValueCell
-                      productLine={productLine}
-                      horizonDays={productLine.valueMatchedHorizonDays}
-                      economics={economics}
-                      showDays
-                    />
-                  )}
-                  {INVENTORY_STRATEGY_HORIZON_DAYS.map((horizonDays) => (
-                    <HorizonValueCell
-                      key={horizonDays}
-                      productLine={productLine}
-                      horizonDays={horizonDays}
-                      economics={economics}
-                    />
-                  ))}
                 </TableRow>
               );
             })}

--- a/app/features/inventory-strategy/components/PolicyComparison.tsx
+++ b/app/features/inventory-strategy/components/PolicyComparison.tsx
@@ -25,8 +25,8 @@ export function PolicyComparison({
         <Typography variant="h6">Policy comparison</Typography>
         <Typography variant="body2" color="text.secondary">
           The active policy supplies continuous-pricing candidates; benchmark
-          and calibration rows are read-only. One-copy value is the calibration
-          basis; physical value keeps actual quantities.
+          rows are read-only. One-copy value prices one of each SKU; physical
+          value keeps actual quantities.
         </Typography>
       </Box>
       <TableContainer>
@@ -59,15 +59,11 @@ export function PolicyComparison({
                         }
                         variant="outlined"
                         label={
-                          comparison.role === "active"
-                            ? "Active"
-                            : comparison.role === "benchmark"
-                              ? "Benchmark"
-                              : comparison.planState === "mixed"
-                                ? "Mixed plans"
-                                : comparison.matchStatus
-                                  ? `Calibration · ${comparison.matchStatus}`
-                                  : "Calibration"
+                          comparison.planState === "mixed"
+                            ? "Mixed plans"
+                            : comparison.role === "active"
+                              ? "Active"
+                              : "Benchmark"
                         }
                       />
                     )}

--- a/app/features/inventory-strategy/components/StrategyVerdict.tsx
+++ b/app/features/inventory-strategy/components/StrategyVerdict.tsx
@@ -20,6 +20,10 @@ function formatReturn(dailyReturn: number): string {
   return `${(dailyReturn * 100).toFixed(2)}%/day`;
 }
 
+function formatDaysDelta(days: number): string {
+  return `${days >= 0 ? "+" : "−"}${Math.abs(days).toFixed(1)} days`;
+}
+
 function policyLabel(dashboard: InventoryStrategyDashboard): string {
   const { policy, profitPerDay, productLines } = dashboard;
   if (policy.method === "percentile") {
@@ -70,7 +74,7 @@ function alternative(
     configured &&
     configured.scenario.estimatedTime &&
     best.scenario.estimatedTime
-      ? ` · ${formatDelta(best.scenario.physicalValue - configured.scenario.physicalValue)} · ${(best.scenario.estimatedTime.medianDays - configured.scenario.estimatedTime.medianDays).toFixed(1)} days median`
+      ? ` · ${formatDelta(best.scenario.physicalValue - configured.scenario.physicalValue)} listed · ${formatDaysDelta(best.scenario.estimatedTime.medianDays - configured.scenario.estimatedTime.medianDays)} median wait`
       : "";
   return {
     value: formatHurdle(best.scenario.dailyReturnHurdle),

--- a/app/features/inventory-strategy/components/format.ts
+++ b/app/features/inventory-strategy/components/format.ts
@@ -32,8 +32,12 @@ export function formatAge(isoDate: string | null): string {
     (Date.now() - new Date(isoDate).getTime()) / (60 * 60 * 1000),
   );
   if (ageHours < 1) return "Less than 1 hour";
-  if (ageHours < 48) return `${Math.round(ageHours)} hours`;
-  return `${Math.round(ageHours / 24)} days`;
+  if (ageHours < 48) return plural(Math.round(ageHours), "hour");
+  return plural(Math.round(ageHours / 24), "day");
+}
+
+function plural(count: number, unit: string): string {
+  return `${count} ${unit}${count === 1 ? "" : "s"}`;
 }
 
 export function formatHurdle(dailyReturnHurdle: number): string {

--- a/app/features/inventory-strategy/components/horizonPoints.ts
+++ b/app/features/inventory-strategy/components/horizonPoints.ts
@@ -1,0 +1,58 @@
+import {
+  capitalCycleAtHorizon,
+  type CapitalCycleEconomics,
+  type CapitalCyclePortfolio,
+} from "~/features/pricing/domain/capitalCycle";
+import {
+  horizonGainElasticity,
+  horizonMarginalValuePerDay,
+  horizonValue,
+  logSpacedHorizons,
+  type HorizonValueCurve,
+} from "~/features/pricing/domain/horizonValueCurve";
+
+/** Everything the page shows about one horizon on a fitted curve. */
+export interface HorizonPoint {
+  horizonDays: number;
+  value: number;
+  marginalValuePerDay: number;
+  elasticity: number;
+  profitPerDay: number;
+  netProceeds: number;
+  profit: number;
+}
+
+export function horizonPoint(
+  curve: HorizonValueCurve,
+  portfolio: CapitalCyclePortfolio,
+  economics: CapitalCycleEconomics,
+  horizonDays: number,
+): HorizonPoint {
+  const cycle = capitalCycleAtHorizon(curve, portfolio, economics, horizonDays);
+  return {
+    horizonDays,
+    value: horizonValue(curve, horizonDays),
+    marginalValuePerDay: horizonMarginalValuePerDay(curve, horizonDays),
+    elasticity: horizonGainElasticity(curve, horizonDays),
+    profitPerDay: cycle.profitPerDay,
+    netProceeds: cycle.netProceeds,
+    profit: cycle.profit,
+  };
+}
+
+/** Points spaced evenly in log horizon across the observed range. */
+export function sampleHorizonPoints(
+  curve: HorizonValueCurve,
+  range: { minimumHorizonDays: number; maximumHorizonDays: number },
+  portfolio: CapitalCyclePortfolio,
+  economics: CapitalCycleEconomics,
+  count: number,
+): HorizonPoint[] {
+  return logSpacedHorizons(
+    range.minimumHorizonDays,
+    range.maximumHorizonDays,
+    count,
+  ).map((horizonDays) =>
+    horizonPoint(curve, portfolio, economics, horizonDays),
+  );
+}

--- a/app/features/inventory-strategy/services/inventoryStrategy.test.ts
+++ b/app/features/inventory-strategy/services/inventoryStrategy.test.ts
@@ -258,20 +258,12 @@ const completedInventoryDashboard = buildInventoryStrategyDashboard(
   ],
   config,
 );
-const completedComparison =
+assert.equal(
   completedInventoryDashboard.overall.policyComparisons.find(
     ({ key }) => key === "target-horizon-shadow",
-  );
-assert.equal(
-  completedComparison?.planState,
-  "single",
-  "the dashboard resolves one plan from complete inventory curves",
-);
-assert.equal(completedComparison?.modeledSkuCount, 2);
-assert.ok(completedComparison?.estimatedTime);
-assert.ok(
-  Math.abs((completedComparison?.oneCopyValue ?? 0) - 36) <= 0.02,
-  "the inventory-wide shadow plan matches current one-copy value",
+  ),
+  undefined,
+  "no target-horizon row is resolved under another policy",
 );
 
 const activeHorizonItems = [
@@ -420,14 +412,7 @@ assert.equal(
   activeProfitPerDayRows.percentile?.label,
   "Configured percentile (benchmark)",
 );
-assert.equal(
-  activeProfitPerDayRows["target-horizon-shadow"]?.role,
-  "calibration",
-);
-assert.equal(
-  activeProfitPerDayRows["target-horizon-shadow"]?.label,
-  "Value-matched horizon (calibration)",
-);
+assert.equal(activeProfitPerDayRows["target-horizon-shadow"], undefined);
 assert.deepEqual(activeProfitPerDayDashboard.policy, {
   method: "profit-per-day",
 });
@@ -557,16 +542,10 @@ assert.ok(completedHorizonCurve);
 assert.ok(
   completedHorizonCurve.floorValue < completedHorizonCurve.ceilingValue,
 );
-assert.ok(
-  (completedInventoryDashboard.overall.valueMatchedHorizonDays ?? 0) > 0,
-  "a percentile policy exposes the value-matched calibration horizon",
-);
-
 assert.deepEqual(activeHorizonDashboard.policy, {
   method: "target-horizon",
   horizonDays: 20,
 });
-assert.equal(activeHorizonDashboard.overall.valueMatchedHorizonDays, null);
 const activeHorizonModel = activeHorizonDashboard.overall.horizonModel;
 assert.ok(activeHorizonModel?.curve);
 assert.equal(activeHorizonModel.minimumHorizonDays, 10);

--- a/app/features/inventory-strategy/services/inventoryStrategy.ts
+++ b/app/features/inventory-strategy/services/inventoryStrategy.ts
@@ -12,7 +12,6 @@ import {
   portfolioDecisions,
   readPricingDecision,
   readShadowPricingDecision,
-  resolveValueMatchedPortfolioPlan,
   toPricingCurve,
   type PortfolioCurveItem,
 } from "~/features/pricing/domain/pricingPolicy";
@@ -137,46 +136,14 @@ function toPortfolioItems(
   }));
 }
 
-interface InventoryHorizonDecisions {
-  decisions: ReadonlyMap<number, PricingDecision>;
-  valueMatchedHorizonDays: number | null;
-}
-
-/**
- * Horizon-policy decisions for the comparison row: the active horizon when
- * one is configured, otherwise the value-matched calibration plan.
- */
-function resolveInventoryHorizonDecisions(
-  key: string,
-  items: InventoryStrategySnapshotItem[],
+/** Decisions at the active target horizon; none under another policy. */
+function horizonDecisions(
   portfolioItems: readonly StrategyPortfolioItem[],
-  config: ServerPricingConfig,
-): InventoryHorizonDecisions {
-  const policy = activePricingPolicy(config.pricing);
-  if (policy.method === "target-horizon") {
-    return {
-      decisions: portfolioDecisions(portfolioItems, policy),
-      valueMatchedHorizonDays: null,
-    };
-  }
-  const latestPricingAt = items.reduce<Date | null>(
-    (latest, item) =>
-      item.strategyPricedAt &&
-      (!latest || item.strategyPricedAt.getTime() > latest.getTime())
-        ? item.strategyPricedAt
-        : latest,
-    null,
-  );
-  const resolved = resolveValueMatchedPortfolioPlan(portfolioItems, {
-    cohortId: `inventory-strategy:${items[0]?.sellerKey ?? "unknown"}:${key}`,
-    ...(latestPricingAt ? { createdAt: latestPricingAt } : {}),
-  });
-  return resolved.plan.modeledSkuCount > 0
-    ? {
-        decisions: resolved.decisionsBySku,
-        valueMatchedHorizonDays: resolved.plan.resolvedHorizonDays,
-      }
-    : { decisions: new Map(), valueMatchedHorizonDays: null };
+  policy: ActivePricingPolicy,
+): ReadonlyMap<number, PricingDecision> {
+  return policy.method === "target-horizon"
+    ? portfolioDecisions(portfolioItems, policy)
+    : new Map();
 }
 
 function weightedQuantile(values: WeightedValue[], quantile: number): number {
@@ -475,28 +442,20 @@ function buildPolicyComparisons(
       (decision) => decision.dailyReturnHurdle,
     );
     const planIds = distinct(decisions, (decision) => decision.planId);
-    const planMatchStatuses = distinct(
-      decisions,
-      (decision) => decision.planMatchStatus,
-    );
     const [profitPerDayHurdle] = hurdles;
     const role: InventoryStrategyPolicyComparison["role"] =
       key === "current"
         ? "current"
         : ROW_POLICY_METHOD[key] === activePolicy.method
           ? "active"
-          : key === "target-horizon-shadow"
-            ? "calibration"
-            : "benchmark";
+          : "benchmark";
     const label =
       key === "current"
         ? "Current listed prices"
         : key === "percentile"
           ? "Configured percentile"
           : key === "target-horizon-shadow"
-            ? activePolicy.method === "target-horizon"
-              ? `Target horizon (${activePolicy.horizonDays.toFixed(1)} days)`
-              : "Value-matched horizon"
+            ? `Target horizon (${activePolicy.method === "target-horizon" ? activePolicy.horizonDays.toFixed(1) : ""} days)`
             : hurdles.size > 1
               ? "Profit per day at product-line hurdles"
               : `Profit per day at ${(profitPerDayHurdle * 100).toFixed(
@@ -505,10 +464,7 @@ function buildPolicyComparisons(
 
     return {
       key,
-      label:
-        role === "benchmark" || role === "calibration"
-          ? `${label} (${role})`
-          : label,
+      label: role === "benchmark" ? `${label} (${role})` : label,
       role,
       planState:
         planIds.size > 1 || targetHorizons.size > 1
@@ -516,14 +472,6 @@ function buildPolicyComparisons(
           : planIds.size === 1 || targetHorizons.size === 1
             ? "single"
             : "none",
-      matchStatus:
-        planIds.size > 1 ||
-        targetHorizons.size > 1 ||
-        planMatchStatuses.size > 1
-          ? "mixed"
-          : planMatchStatuses.size === 1
-            ? [...planMatchStatuses][0]
-            : null,
       ...summarizeDecisions(decisions),
     };
   };
@@ -792,12 +740,7 @@ function buildProductLine(
     exactCandidatePercentiles,
   );
   const portfolioItems = toPortfolioItems(items, config);
-  const horizonDecisions = resolveInventoryHorizonDecisions(
-    key,
-    items,
-    portfolioItems,
-    config,
-  );
+  const activePolicy = activePricingPolicy(config.pricing);
   const profitPerDay = profitPerDayPolicy(config.pricing.profitPerDay);
   const configuredHurdle =
     productLineId === null
@@ -840,14 +783,14 @@ function buildProductLine(
     scenarios,
     policyComparisons: buildPolicyComparisons(
       items,
-      horizonDecisions.decisions,
+      horizonDecisions(portfolioItems, activePolicy),
       portfolioDecisions(portfolioItems, (item) =>
         productLinePricingPolicy(
           profitPerDay,
           config.productLinePricing.productLineSettings[item.productLineId],
         ),
       ),
-      activePricingPolicy(config.pricing),
+      activePolicy,
     ),
     hurdleSweep: buildHurdleSweep(
       items,
@@ -855,7 +798,6 @@ function buildProductLine(
       config,
       configuredHurdle,
     ),
-    valueMatchedHorizonDays: horizonDecisions.valueMatchedHorizonDays,
     horizonModel: buildHorizonModel(portfolioItems),
   };
 }

--- a/app/features/inventory-strategy/types/inventoryStrategy.ts
+++ b/app/features/inventory-strategy/types/inventoryStrategy.ts
@@ -94,14 +94,8 @@ export interface InventoryStrategyHurdleScenario extends InventoryStrategyDecisi
 export interface InventoryStrategyPolicyComparison extends InventoryStrategyDecisionSummary {
   key: "current" | "percentile" | "target-horizon-shadow" | "profit-per-day";
   label: string;
-  role: "current" | "active" | "benchmark" | "calibration";
+  role: "current" | "active" | "benchmark";
   planState: "none" | "single" | "mixed";
-  matchStatus:
-    | "matched"
-    | "boundary"
-    | "infeasible"
-    | "mixed"
-    | null;
 }
 
 export type InventoryStrategyConfidence =
@@ -141,7 +135,6 @@ export interface InventoryStrategyProductLine {
   scenarios: InventoryStrategyScenario[];
   policyComparisons: InventoryStrategyPolicyComparison[];
   hurdleSweep: InventoryStrategyHurdleScenario[];
-  valueMatchedHorizonDays: number | null;
   horizonModel: InventoryStrategyHorizonModel | null;
 }
 


### PR DESCRIPTION
The horizon section drew thirteen columns of value, marginal rate, elasticity, profit per day, and net proceeds for every product line, with fit coefficients in every row. It now draws the selected product line's fitted curve as physical value and cycle profit per day against horizon on a log axis, with the knee, best cycle, and active horizon marked, a crosshair tooltip that follows the pointer or the arrow keys, and a table twin of the sampled horizons on demand. A compact table lists each product line's fit, floor and ceiling, knee, and best cycle, and selects the chart's line.

The value-matched horizon calibration existed for the retired target-horizon policy; the dashboard no longer resolves it, so the target-horizon row appears only while that policy is active and the comparison rows lose their match status.

Verified: typecheck, 192 tests (strategy test updated for the removed calibration row), build, and a dev render against a seeded snapshot: the chart sizes to its container, no text overlaps or overflows, marks and tooltip render, the table twin toggles.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)