### PR TITLE
Collapse the percentile scenario builder and matrix into an explorer

### DIFF
--- a/app/features/inventory-strategy/components/PercentileExplorer.tsx
+++ b/app/features/inventory-strategy/components/PercentileExplorer.tsx
@@ -1,0 +1,93 @@
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Typography,
+} from "@mui/material";
+import { useEffect, useMemo, useState } from "react";
+import type { InventoryStrategyDashboard } from "../types/inventoryStrategy";
+import { PercentileMatrix } from "./PercentileMatrix";
+import { ScenarioBuilder } from "./ScenarioBuilder";
+import {
+  defaultSelection,
+  findScenario,
+  formatKneeEstimate,
+} from "./scenarioSelection";
+
+/**
+ * The percentile policy's scenario builder and matrix, collapsed by default
+ * with each product line's knee estimate as the summary.
+ */
+export function PercentileExplorer({
+  dashboard,
+}: {
+  dashboard: InventoryStrategyDashboard;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [selections, setSelections] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    setSelections(
+      Object.fromEntries(
+        dashboard.productLines.map((productLine) => [
+          productLine.key,
+          defaultSelection(productLine),
+        ]),
+      ),
+    );
+  }, [dashboard.generatedAt, dashboard.productLines]);
+
+  const selectedProductLines = useMemo(
+    () =>
+      dashboard.productLines.map((productLine) => {
+        const percentile =
+          selections[productLine.key] ?? defaultSelection(productLine);
+        return {
+          productLine,
+          percentile,
+          scenario: findScenario(productLine, percentile),
+        };
+      }),
+    [dashboard.productLines, selections],
+  );
+  const kneeSummary = dashboard.productLines
+    .map(
+      (productLine) =>
+        `${productLine.productLine} ${formatKneeEstimate(productLine).replace("Estimated ", "")}`,
+    )
+    .join(" · ");
+
+  return (
+    <Accordion
+      variant="outlined"
+      expanded={expanded}
+      onChange={(_, isExpanded) => setExpanded(isExpanded)}
+      slotProps={{ transition: { unmountOnExit: true } }}
+      disableGutters
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Box>
+          <Typography variant="h6">Percentile explorer</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {kneeSummary
+              ? `Knee estimates: ${kneeSummary}`
+              : "Scenarios and the full matrix for the percentile policy"}
+          </Typography>
+        </Box>
+      </AccordionSummary>
+      <AccordionDetails sx={{ p: 2, pt: 0 }}>
+        <ScenarioBuilder
+          selections={selectedProductLines}
+          onSelect={(key, percentile) =>
+            setSelections((current) => ({ ...current, [key]: percentile }))
+          }
+        />
+        <PercentileMatrix
+          productLines={[dashboard.overall, ...dashboard.productLines]}
+        />
+      </AccordionDetails>
+    </Accordion>
+  );
+}

--- a/app/features/inventory-strategy/components/ScenarioBuilder.tsx
+++ b/app/features/inventory-strategy/components/ScenarioBuilder.tsx
@@ -25,28 +25,13 @@ import {
   formatDelta,
   formatPercentile,
 } from "./format";
-import { findScenario } from "./scenarioSelection";
+import { findScenario, formatKneeEstimate } from "./scenarioSelection";
 
 /** One product line with the percentile the reader chose and its scenario. */
 export interface ScenarioSelection {
   productLine: InventoryStrategyProductLine;
   percentile: number;
   scenario: InventoryStrategyScenario | undefined;
-}
-
-function formatKneeEstimate(productLine: InventoryStrategyProductLine): string {
-  if (productLine.estimatedPercentile === null) {
-    return "Estimate unavailable";
-  }
-  const estimate = formatPercentile(productLine.estimatedPercentile);
-  if (
-    productLine.kneeRangeMinimum === null ||
-    productLine.kneeRangeMaximum === null ||
-    productLine.kneeRangeMinimum === productLine.kneeRangeMaximum
-  ) {
-    return `Estimated ${estimate}`;
-  }
-  return `Estimated ${estimate} · ${formatPercentile(productLine.kneeRangeMinimum)}–${formatPercentile(productLine.kneeRangeMaximum)} range`;
 }
 
 export function ScenarioBuilder({

--- a/app/features/inventory-strategy/components/scenarioSelection.ts
+++ b/app/features/inventory-strategy/components/scenarioSelection.ts
@@ -4,6 +4,25 @@ import {
   type InventoryStrategyProductLine,
   type InventoryStrategyScenario,
 } from "../types/inventoryStrategy";
+import { formatPercentile } from "./format";
+
+/** The product line's estimated knee percentile with its range, or that none is available. */
+export function formatKneeEstimate(
+  productLine: InventoryStrategyProductLine,
+): string {
+  if (productLine.estimatedPercentile === null) {
+    return "Estimate unavailable";
+  }
+  const estimate = formatPercentile(productLine.estimatedPercentile);
+  if (
+    productLine.kneeRangeMinimum === null ||
+    productLine.kneeRangeMaximum === null ||
+    productLine.kneeRangeMinimum === productLine.kneeRangeMaximum
+  ) {
+    return `Estimated ${estimate}`;
+  }
+  return `Estimated ${estimate} · ${formatPercentile(productLine.kneeRangeMinimum)}–${formatPercentile(productLine.kneeRangeMaximum)} range`;
+}
 
 export function findScenario(
   productLine: InventoryStrategyProductLine,

--- a/app/features/inventory-strategy/routes/inventory-strategy.tsx
+++ b/app/features/inventory-strategy/routes/inventory-strategy.tsx
@@ -19,14 +19,9 @@ import { DEFAULT_CAPITAL_CYCLE_INPUTS } from "../components/capitalCycleInputs";
 import { ForecastGrading } from "../components/ForecastGrading";
 import { HorizonCurve } from "../components/HorizonCurve";
 import { HurdleSweep } from "../components/HurdleSweep";
-import { PercentileMatrix } from "../components/PercentileMatrix";
+import { PercentileExplorer } from "../components/PercentileExplorer";
 import { PolicyComparison } from "../components/PolicyComparison";
-import { ScenarioBuilder } from "../components/ScenarioBuilder";
 import { StrategyVerdict } from "../components/StrategyVerdict";
-import {
-  defaultSelection,
-  findScenario,
-} from "../components/scenarioSelection";
 import { loadForecastGrading } from "../services/forecastGrading.server";
 import { loadInventoryStrategyDashboard } from "../services/inventoryStrategyDashboard.server";
 import { queueInventoryStrategyAnalysis } from "../services/inventoryStrategyAnalysis.server";
@@ -122,7 +117,6 @@ export default function InventoryStrategyRoute() {
     status?: string;
   }>();
   const { revalidate } = useRevalidator();
-  const [selections, setSelections] = useState<Record<string, number>>({});
   const [cycleInputs, setCycleInputs] = useState(DEFAULT_CAPITAL_CYCLE_INPUTS);
   const economics = useMemo<CapitalCycleEconomics>(
     () => ({
@@ -135,17 +129,6 @@ export default function InventoryStrategyRoute() {
   const busy = fetcher.state !== "idle";
   const analysisActive =
     latestAnalysis?.status === "queued" || latestAnalysis?.status === "pricing";
-
-  useEffect(() => {
-    setSelections(
-      Object.fromEntries(
-        dashboard.productLines.map((productLine) => [
-          productLine.key,
-          defaultSelection(productLine),
-        ]),
-      ),
-    );
-  }, [dashboard.generatedAt, dashboard.productLines]);
 
   useEffect(() => {
     if (fetcher.state === "idle" && fetcher.data?.success) void revalidate();
@@ -172,24 +155,6 @@ export default function InventoryStrategyRoute() {
     if (polledStatus && polledStatus !== "queued" && polledStatus !== "pricing")
       void revalidate();
   }, [polledStatus, revalidate]);
-
-  const selectedProductLines = useMemo(
-    () =>
-      dashboard.productLines.map((productLine) => {
-        const percentile =
-          selections[productLine.key] ?? defaultSelection(productLine);
-        return {
-          productLine,
-          percentile,
-          scenario: findScenario(productLine, percentile),
-        };
-      }),
-    [dashboard.productLines, selections],
-  );
-  const allProductLines = useMemo(
-    () => [dashboard.overall, ...dashboard.productLines],
-    [dashboard.overall, dashboard.productLines],
-  );
 
   const submit = (intent: "refresh_inventory" | "queue_analysis") =>
     fetcher.submit(
@@ -289,13 +254,7 @@ export default function InventoryStrategyRoute() {
         cycleInputs={cycleInputs}
         onCycleInputsChange={setCycleInputs}
       />
-      <ScenarioBuilder
-        selections={selectedProductLines}
-        onSelect={(key, percentile) =>
-          setSelections((current) => ({ ...current, [key]: percentile }))
-        }
-      />
-      <PercentileMatrix productLines={allProductLines} />
+      <PercentileExplorer dashboard={dashboard} />
 
       <Alert severity="info" sx={{ mt: 3 }}>
         Expected wait estimates the next sale/listing position, not liquidation


### PR DESCRIPTION
The scenario builder and the full percentile matrix sweep the retired percentile policy's parameter, and every slider opened at its configured value. Both now sit in one collapsed percentile explorer at the foot of the page, mounted only when expanded, with each product line's knee estimate as the summary line. The explorer owns the scenario selections, so the route keeps only the capital-cycle inputs and the analysis controls. The selected-scenario metric card was already replaced by the verdict header in #11.

Verified: typecheck, 192 tests, build, and a dev render: collapsed, the page holds no sliders and 72 table cells; expanded, the sliders and the 148 matrix cells mount.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)