### PR TITLE
Show realized outcomes beside modeled forecasts on the strategy page

### DIFF
--- a/app/features/inventory-strategy/components/ForecastGrading.tsx
+++ b/app/features/inventory-strategy/components/ForecastGrading.tsx
@@ -50,9 +50,11 @@ export function ForecastGrading({
         <Typography variant="body2" color="text.secondary">
           Each forecast is graded over the SKUs that carried it, first priced
           between {grading.horizonDays} and {2 * grading.horizonDays} days ago
-          and followed for {grading.horizonDays} days. Brier score against
-          realized sales, lower is better; the base rate is the score of
-          forecasting every SKU at its cohort&apos;s sold share.
+          and followed for {grading.horizonDays} days. Sold is the share of the
+          cohort that realized a sale within the horizon; expected is the share
+          the forecast implied. Brier score against realized sales, lower is
+          better; the base rate is the score of forecasting every SKU at its
+          cohort&apos;s sold share.
         </Typography>
         {gradedForecasts.map(([label, grade]) => (
           <Typography
@@ -63,7 +65,7 @@ export function ForecastGrading({
           >
             {label}:{" "}
             {grade.count > 0
-              ? `${grade.count.toLocaleString()} SKUs, ${percentFormatter.format(grade.soldShare)} sold, Brier ${grade.brier.toFixed(4)} against a base rate of ${(grade.soldShare * (1 - grade.soldShare)).toFixed(4)}.`
+              ? `${grade.count.toLocaleString()} SKUs, ${percentFormatter.format(grade.soldShare)} sold against ${percentFormatter.format(grade.expectedShare)} expected, Brier ${grade.brier.toFixed(4)} against a base rate of ${(grade.soldShare * (1 - grade.soldShare)).toFixed(4)}.`
               : `no SKU has carried this forecast for ${grading.horizonDays} days yet.`}
           </Typography>
         ))}

--- a/app/features/inventory-strategy/components/StrategyVerdict.tsx
+++ b/app/features/inventory-strategy/components/StrategyVerdict.tsx
@@ -13,6 +13,7 @@ import {
   formatDays,
   formatDelta,
   formatHurdle,
+  percentFormatter,
 } from "./format";
 import { gradingStatus, hurdleReturns, type HurdleReturn } from "./verdict";
 
@@ -46,7 +47,7 @@ function policyLabel(dashboard: InventoryStrategyDashboard): string {
 function gradingLabel(report: ForecastGradingReport | undefined): string {
   const status = gradingStatus(report);
   if (status.graded) {
-    return `Forecasts graded: ${status.label} Brier ${status.grade.brier.toFixed(3)} against ${status.baseRate.toFixed(3)}`;
+    return `Forecasts graded: ${status.label} ${percentFormatter.format(status.grade.soldShare)} sold against ${percentFormatter.format(status.grade.expectedShare)} expected, Brier ${status.grade.brier.toFixed(3)} against ${status.baseRate.toFixed(3)}`;
   }
   return status.gradableAt
     ? `Forecasts ungraded until ${new Date(status.gradableAt).toLocaleDateString()}`

--- a/app/features/inventory-strategy/components/verdict.test.ts
+++ b/app/features/inventory-strategy/components/verdict.test.ts
@@ -59,6 +59,7 @@ const grade = (
 ): GradedForecast => ({
   count,
   soldShare: 0.25,
+  expectedShare: 0.3,
   brier,
   deciles: [],
   gradableAt,

--- a/app/features/inventory-strategy/services/forecastGrading.server.ts
+++ b/app/features/inventory-strategy/services/forecastGrading.server.ts
@@ -20,6 +20,7 @@ const DAY_MS = 24 * HOUR_MS;
 const NO_GRADE: ForecastGrade = {
   count: 0,
   soldShare: 0,
+  expectedShare: 0,
   brier: 0,
   deciles: [],
 };

--- a/app/features/pricing/domain/forecastGrading.test.ts
+++ b/app/features/pricing/domain/forecastGrading.test.ts
@@ -72,6 +72,10 @@ assert.ok(Math.abs(grade.soldShare - 2 / 6) < 1e-12);
 const fast = saleProbability(10, 21);
 const slow = saleProbability(40, 21);
 assert.ok(
+  Math.abs(grade.expectedShare - (5 * fast + slow) / 6) < 1e-12,
+  "expected share is the mean forecast probability over the cohort",
+);
+assert.ok(
   Math.abs(
     grade.brier - (2 * (1 - fast) ** 2 + 3 * fast ** 2 + slow ** 2) / 6,
   ) < 1e-12,

--- a/app/features/pricing/domain/forecastGrading.ts
+++ b/app/features/pricing/domain/forecastGrading.ts
@@ -26,7 +26,10 @@ export interface CohortMember {
 
 export interface ForecastGrade {
   count: number;
+  /** Share of the cohort that realized a sale within the horizon. */
   soldShare: number;
+  /** Share the forecast implied would sell within the horizon. */
+  expectedShare: number;
   brier: number;
   deciles: {
     count: number;
@@ -121,6 +124,7 @@ export function gradeForecast(
   return {
     count: members.length,
     soldShare: share(members, (member) => (member.sold ? 1 : 0)),
+    expectedShare: share(members, probability),
     brier: share(
       members,
       (member) => (probability(member) - (member.sold ? 1 : 0)) ** 2,

--- a/docs/pricing-operations-and-scaling-plan.md
+++ b/docs/pricing-operations-and-scaling-plan.md
@@ -116,6 +116,19 @@ The floor was market price less the fee. Realized sales showed it held liquid ca
 - The floor is the market-based minimum, lowered to the SKU's own-condition low sale in the last 90 days or, when the store's own listing is excluded from the search, to the second-cheapest competing ask in the same condition; both are recorded as `priceEvidence`. Own evidence releases the floor on liquid cards and keeps it where the card has none; without a market price there is no floor, as before. The cheapest ask is skipped because one listing in ten is mis-conditioned or thrown away; asks above the second are the ones that run insane.
 - A curve whose fastest point waits beyond a year holds the current price under every policy, or a reference price when the SKU has none, instead of trading price for a marginally shorter wait. The strategy page and the shadow plan leave such curves out for the same reason.
 
+## Inventory strategy page
+
+The page exists to judge the active pricing policy and the forecasts behind it, in this order:
+
+- A verdict header names the active policy and its parameter, its modeled physical value against the listed value, its median and P90 wait, the hurdle on the sweep whose portfolio compounds fastest under the capital-cycle inputs and what switching would change, and modeled coverage with curve freshness. A chip reports the best graded forecast's realized sold share against its expected share and Brier score, or the date the first forecast becomes gradable.
+- Forecast grading follows directly, one summary line per forecast and a decile table once a cohort exists.
+- The policy comparison lists the current listed prices, the active policy, and the benchmarks. The target-horizon row appears only while that policy is active; the value-matched calibration is gone.
+- The hurdle sweep evaluates the profit-per-day policy at a ladder of daily return hurdles per product line, the configured hurdle shaded, since the hurdle is the only parameter the active policy has.
+- The horizon curve draws the selected product line's fitted log-logistic curve as value and cycle profit per day against horizon, with the knee, best cycle, and active horizon marked, a crosshair tooltip, and a table twin on demand, above a compact per-line table of fit, floor and ceiling, knee, and best cycle.
+- The percentile explorer holds the scenario builder and the full matrix for the percentile policy, collapsed and unmounted until opened.
+
+The dashboard and the grading are served from a versioned cache that returns the last build at once when only the inventory or its curves moved and rebuilds in the background; a changed pricing configuration waits for its build. The pricing worker warms both after every batch that recorded curves.
+
 ## Execution record
 
 - [x] Audit production timing, queue shape, pricing failures, and publications.


### PR DESCRIPTION
Each forecast grade now carries the share of its cohort the forecast expected to sell within the horizon, so the grading section and the verdict header's chip read the realized sold share against the expected share beside the Brier score. Realized revenue stays out of scope until the listed price at sale time is recorded on the cohort. The operations plan describes the page as it now stands.

Verified: typecheck, 192 tests (domain test covers the expected share; verdict test covers the chip inputs), build, dev render of the grading section.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)