### PR TITLE
Add isolated Alt and eBay Research connections

### DIFF
--- a/app/features/ebay-slab-pricing/connections/checkProviderConnection.server.ts
+++ b/app/features/ebay-slab-pricing/connections/checkProviderConnection.server.ts
@@ -1,0 +1,95 @@
+import type { SlabProvider } from "./providerConnection";
+import { providerRequestGate } from "./providerConnections.server";
+import {
+  createProviderRequest,
+  ProviderRequestError,
+} from "./providerRequest.server";
+
+export const requestSlabProvider = createProviderRequest(providerRequestGate);
+
+export function validateAltConnection(body: string): void {
+  let result;
+  try {
+    result = JSON.parse(body);
+  } catch {
+    throw new ProviderRequestError("invalid-response");
+  }
+  if (
+    result?.errors?.some?.(
+      (error: { extensions?: { code?: string } }) =>
+        error?.extensions?.code === "UNAUTHENTICATED",
+    ) ||
+    result?.data?.me === null
+  ) {
+    throw new ProviderRequestError("reconnect-required");
+  }
+  if (
+    result?.errors?.length ||
+    typeof result?.data?.me?.id !== "string" ||
+    !result.data.me.id
+  ) {
+    throw new ProviderRequestError("invalid-response");
+  }
+}
+
+export function validateEbayConnection(body: string): void {
+  let modules: Array<{ _type?: string; tabs?: Array<{ active?: boolean }> }>;
+  try {
+    modules = body
+      .trim()
+      .split(/\r?\n\s*\r?\n/)
+      .map((line) => JSON.parse(line));
+  } catch {
+    throw new ProviderRequestError("invalid-response");
+  }
+  if (
+    !modules.some(
+      (module) =>
+        module?._type === "ResultsHeaderModule" &&
+        Array.isArray(module.tabs) &&
+        module.tabs.some((tab) => tab?.active === true),
+    )
+  ) {
+    throw new ProviderRequestError("invalid-response");
+  }
+}
+
+export async function checkProviderConnection(
+  provider: SlabProvider,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (provider === "alt") {
+    await requestSlabProvider(
+      provider,
+      {
+        path: "/graphql/Me",
+        body: JSON.stringify({
+          operationName: "Me",
+          variables: {},
+          query: "query Me { me { id } }",
+        }),
+      },
+      { signal, validate: validateAltConnection },
+    );
+    return;
+  }
+  const end = Date.now();
+  const params = new URLSearchParams({
+    marketplace: "EBAY-US",
+    keywords: "Ponyta 60 1st PSA 9",
+    dayRange: "90",
+    startDate: String(end - 90 * 86_400_000),
+    endDate: String(end),
+    categoryId: "0",
+    offset: "0",
+    limit: "1",
+    tabName: "SOLD",
+    tz: "America/Chicago",
+    modules: "resultsHeader",
+  });
+  await requestSlabProvider(
+    provider,
+    { path: `/sh/research/api/search?${params}` },
+    { signal, validate: validateEbayConnection },
+  );
+}

--- a/app/features/ebay-slab-pricing/connections/providerConnection.ts
+++ b/app/features/ebay-slab-pricing/connections/providerConnection.ts
@@ -1,0 +1,28 @@
+export const SLAB_PROVIDERS = ["alt", "ebayResearch"] as const;
+export type SlabProvider = (typeof SLAB_PROVIDERS)[number];
+
+export const CONNECTION_MESSAGES = {
+  "not-configured": "Add a connection to check access.",
+  unchecked: "Connection saved. Check access to verify it.",
+  connected: "Connection verified.",
+  "reconnect-required":
+    "Sign in to the provider and replace the saved connection.",
+  busy: "Another request is running or this provider is cooling down. Try again shortly.",
+  "rate-limited":
+    "The provider asked us to wait. Try again after its cooldown.",
+  unavailable: "The provider is temporarily unavailable. Try again shortly.",
+  "invalid-response":
+    "The provider returned an unexpected response. The adapter may need updating.",
+  cancelled: "Connection check cancelled or timed out.",
+} as const;
+export type ConnectionStatus = keyof typeof CONNECTION_MESSAGES;
+export type ProviderConnectionStatus = {
+  provider: SlabProvider;
+  configured: boolean;
+  status: ConnectionStatus;
+  checkedAt: Date | null;
+};
+
+export function isSlabProvider(value: unknown): value is SlabProvider {
+  return SLAB_PROVIDERS.some((provider) => provider === value);
+}

--- a/app/features/ebay-slab-pricing/connections/providerConnections.integration.test.ts
+++ b/app/features/ebay-slab-pricing/connections/providerConnections.integration.test.ts
@@ -1,0 +1,139 @@
+// Opt-in: npx tsx app/features/ebay-slab-pricing/connections/providerConnections.integration.test.ts
+// Creates an isolated schema in the local development database; no real credentials or HTTP.
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import pg from "pg";
+import dotenv from "dotenv";
+import { getPool } from "~/core/db/database.server";
+import {
+  clearProviderConnection,
+  getProviderConnections,
+  providerRequestGate,
+  saveProviderConnection,
+} from "./providerConnections.server";
+import { ProviderRequestError } from "./providerRequest.server";
+
+if (process.argv.includes("--claim")) {
+  try {
+    await providerRequestGate.claim("alt");
+    console.log("claimed");
+  } catch (error) {
+    if (!(error instanceof ProviderRequestError)) throw error;
+    console.log(error.status);
+  } finally {
+    await getPool().end();
+  }
+} else {
+  dotenv.config({
+    path: [".env.development.local", ".env.local", ".env.development", ".env"],
+    quiet: true,
+  });
+  const url = new URL(
+    process.env.DATABASE_URL ??
+      "postgresql://postgres:postgres@localhost:5433/tcgplayer_automation",
+  );
+  assert.ok(
+    ["localhost", "127.0.0.1"].includes(url.hostname) && url.port === "5433",
+    "Use the local development database",
+  );
+  const admin = new pg.Client({ connectionString: url.toString() });
+  const schema = `slab_connections_test_${randomUUID().replaceAll("-", "")}`;
+  await admin.connect();
+  await admin.query(`CREATE SCHEMA "${schema}"`);
+  url.searchParams.set("options", `-c search_path=${schema}`);
+  process.env.DATABASE_URL = url.toString();
+  const db = getPool();
+  try {
+    await db.query(
+      await readFile(
+        "db/migrations/024_add_slab_provider_connections.sql",
+        "utf8",
+      ),
+    );
+    await saveProviderConnection("alt", "fixture", "");
+    const claimInProcess = () =>
+      new Promise<string>((resolve, reject) => {
+        const child = spawn(
+          process.execPath,
+          ["--import", "tsx", fileURLToPath(import.meta.url), "--claim"],
+          { env: process.env, windowsHide: true },
+        );
+        let output = "";
+        child.stdout.on("data", (chunk) => {
+          output += chunk;
+        });
+        child.stderr.on("data", (chunk) => {
+          output += chunk;
+        });
+        child.on("error", reject);
+        child.on("close", (code) =>
+          code === 0
+            ? resolve(output.trim().split(/\r?\n/).at(-1)!)
+            : reject(new Error(output)),
+        );
+      });
+    const results = await Promise.all(
+      Array.from({ length: 4 }, claimInProcess),
+    );
+    assert.equal(results.filter((result) => result === "claimed").length, 1);
+    assert.equal(results.filter((result) => result === "busy").length, 3);
+    await db.query(
+      "UPDATE slab_provider_connections SET lease_until = clock_timestamp() - interval '1 second'",
+    );
+    const oldLease = await providerRequestGate.claim("alt");
+    await saveProviderConnection("alt", "replacement", "");
+    await assert.rejects(providerRequestGate.claim("alt"), { status: "busy" });
+    await providerRequestGate.release("alt", oldLease, {
+      status: "reconnect-required",
+      retryAt: Date.now() + 60000,
+    });
+    assert.equal((await getProviderConnections())[0].status, "unchecked");
+    await assert.rejects(providerRequestGate.claim("alt"), { status: "busy" });
+    await db.query(
+      "UPDATE slab_provider_connections SET next_request_at = '-infinity'",
+    );
+    const lease = await providerRequestGate.claim("alt");
+    assert.equal(lease.credential, "replacement");
+    await providerRequestGate.release("alt", oldLease, {
+      status: "unavailable",
+      retryAt: Date.now(),
+    });
+    await assert.rejects(providerRequestGate.claim("alt"), { status: "busy" });
+    await clearProviderConnection("alt");
+    await providerRequestGate.release("alt", lease, {
+      status: "connected",
+      retryAt: Date.now(),
+    });
+    assert.equal((await getProviderConnections())[0].status, "not-configured");
+    await assert.rejects(providerRequestGate.claim("alt"), {
+      status: "not-configured",
+    });
+    await saveProviderConnection("alt", "replacement", "");
+    const authLease = await providerRequestGate.claim("alt");
+    await providerRequestGate.release("alt", authLease, {
+      status: "reconnect-required",
+      retryAt: Date.now(),
+    });
+    await assert.rejects(providerRequestGate.claim("alt"), {
+      status: "reconnect-required",
+    });
+    await saveProviderConnection("alt", "reconnected", "");
+    const reconnected = await providerRequestGate.claim("alt");
+    assert.equal(reconnected.credential, "reconnected");
+    const publicState = JSON.stringify(await getProviderConnections());
+    assert.ok(
+      !publicState.includes("reconnected") &&
+        !publicState.includes("userAgent"),
+    );
+    console.log(
+      "PASS four-process exclusion, cooldown, expiry recovery, lease fencing, masked status and reconnect without restart",
+    );
+  } finally {
+    await db.end();
+    await admin.query(`DROP SCHEMA "${schema}" CASCADE`);
+    await admin.end();
+  }
+}

--- a/app/features/ebay-slab-pricing/connections/providerConnections.server.ts
+++ b/app/features/ebay-slab-pricing/connections/providerConnections.server.ts
@@ -1,0 +1,133 @@
+import { randomUUID } from "node:crypto";
+import { execute, query, getPool } from "~/core/db/database.server";
+import {
+  SLAB_PROVIDERS,
+  type SlabProvider,
+  type ProviderConnectionStatus,
+} from "./providerConnection";
+import {
+  ProviderRequestError,
+  PROVIDER_TIMEOUT_MS,
+  type ProviderLease,
+  type ProviderRequestGate,
+} from "./providerRequest.server";
+
+// pg supports per-query deadlines, but its QueryConfig type omits this option.
+const QUERY_DEADLINE = { query_timeout: 5_000 };
+
+export async function getProviderConnections(): Promise<
+  ProviderConnectionStatus[]
+> {
+  const rows =
+    await query<ProviderConnectionStatus>(`SELECT provider, credential <> '' AS configured,
+    status, checked_at AS "checkedAt" FROM slab_provider_connections`);
+  return SLAB_PROVIDERS.map(
+    (provider) =>
+      rows.find((row) => row.provider === provider) ?? {
+        provider,
+        configured: false,
+        status: "not-configured",
+        checkedAt: null,
+      },
+  );
+}
+
+export function validateCredential(
+  provider: SlabProvider,
+  credential: string,
+  userAgent: string,
+): string {
+  const normalized =
+    provider === "alt"
+      ? credential.trim().replace(/^Bearer\s+/i, "")
+      : credential.trim();
+  if (
+    !normalized ||
+    normalized.length > 32_768 ||
+    /[\r\n]/.test(normalized) ||
+    userAgent.length > 512 ||
+    /[\r\n]/.test(userAgent) ||
+    (provider === "alt" && !/^[\w.\-]+$/.test(normalized)) ||
+    (provider === "ebayResearch" &&
+      (!normalized.includes("=") || !userAgent.trim()))
+  ) {
+    throw new Error(
+      "Enter a valid connection value and browser user agent for eBay.",
+    );
+  }
+  return normalized;
+}
+
+export async function saveProviderConnection(
+  provider: SlabProvider,
+  credential: string,
+  userAgent: string,
+): Promise<void> {
+  const normalized = validateCredential(provider, credential, userAgent);
+  await execute(
+    `INSERT INTO slab_provider_connections (provider, credential, user_agent, revision, status)
+    VALUES ($1, $2, $3, 1, 'unchecked') ON CONFLICT (provider) DO UPDATE
+    SET credential = EXCLUDED.credential, user_agent = EXCLUDED.user_agent,
+        revision = slab_provider_connections.revision + 1, status = 'unchecked', checked_at = NULL`,
+    [provider, normalized, provider === "alt" ? "" : userAgent.trim()],
+  );
+}
+
+export async function clearProviderConnection(
+  provider: SlabProvider,
+): Promise<void> {
+  // Keep an in-flight lease/cooldown: clearing credentials must not admit a second request.
+  await execute(
+    `UPDATE slab_provider_connections SET credential = '', user_agent = '',
+    revision = revision + 1, status = 'not-configured', checked_at = NULL WHERE provider = $1`,
+    [provider],
+  );
+}
+
+export const providerRequestGate: ProviderRequestGate = {
+  async claim(provider) {
+    const result = await getPool().query<ProviderLease>({
+      ...QUERY_DEADLINE,
+      text: `UPDATE slab_provider_connections
+      SET lease_id = $2, lease_until = clock_timestamp() + $3 * interval '1 millisecond'
+      WHERE provider = $1 AND credential <> '' AND status <> 'reconnect-required'
+        AND next_request_at <= clock_timestamp()
+        AND (lease_until IS NULL OR lease_until <= clock_timestamp())
+      RETURNING lease_id AS id, revision, credential, user_agent AS "userAgent"`,
+      values: [provider, randomUUID(), PROVIDER_TIMEOUT_MS + 5_000],
+    });
+    const lease = result.rows[0];
+    if (lease) return lease;
+    const {
+      rows: [row],
+    } = await getPool().query<{ configured: boolean; status: string }>({
+      ...QUERY_DEADLINE,
+      text: `SELECT credential <> '' AS configured, status FROM slab_provider_connections WHERE provider = $1`,
+      values: [provider],
+    });
+    throw new ProviderRequestError(
+      !row?.configured
+        ? "not-configured"
+        : row.status === "reconnect-required"
+          ? "reconnect-required"
+          : "busy",
+    );
+  },
+  async release(provider, lease, result) {
+    await getPool().query({
+      ...QUERY_DEADLINE,
+      text: `UPDATE slab_provider_connections SET lease_id = NULL, lease_until = NULL,
+      next_request_at = GREATEST(next_request_at, $4::timestamptz),
+      status = CASE WHEN revision = $3 THEN $5 ELSE status END,
+      checked_at = CASE WHEN revision = $3 THEN clock_timestamp() ELSE checked_at END
+      WHERE provider = $1 AND lease_id = $2`,
+      values: [
+        provider,
+        lease.id,
+        lease.revision,
+        new Date(result.retryAt),
+        result.status,
+      ],
+    });
+  },
+};

--- a/app/features/ebay-slab-pricing/connections/providerConnections.test.ts
+++ b/app/features/ebay-slab-pricing/connections/providerConnections.test.ts
@@ -1,0 +1,328 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import {
+  createProviderRequest,
+  ProviderRequestError,
+  retryAfterMs,
+  type ProviderRequestGate,
+} from "./providerRequest.server";
+import {
+  validateAltConnection,
+  validateEbayConnection,
+} from "./checkProviderConnection.server";
+import { validateCredential } from "./providerConnections.server";
+import { createProviderConnectionsAction } from "./providerConnectionsAction.server";
+
+const lease = {
+  id: "lease",
+  revision: 1,
+  credential: "private=value",
+  userAgent: "test-agent",
+};
+const path = "/sh/research/api/search";
+const fails = (status: string) => (error: unknown) =>
+  error instanceof ProviderRequestError && error.status === status;
+function harness(
+  fetcher: typeof fetch,
+  overrides: Partial<ProviderRequestGate> = {},
+) {
+  const releases: Array<Parameters<ProviderRequestGate["release"]>[2]> = [];
+  let claims = 0;
+  return {
+    releases,
+    claims: () => claims,
+    request: createProviderRequest(
+      {
+        claim: async () => {
+          claims++;
+          return lease;
+        },
+        release: async (_provider, _lease, result) => {
+          releases.push(result);
+        },
+        ...overrides,
+      },
+      fetcher,
+    ),
+  };
+}
+
+for (const provider of ["alt", "ebayResearch"] as const) {
+  const h = harness(async (url, init) => {
+    assert.equal(
+      new URL(String(url)).hostname,
+      provider === "alt"
+        ? "alt-platform-server.production.internal.onlyalt.com"
+        : "www.ebay.com",
+    );
+    const headers = new Headers(init?.headers);
+    assert.equal(
+      headers.get("authorization"),
+      provider === "alt" ? `Bearer ${lease.credential}` : null,
+    );
+    assert.equal(
+      headers.get("cookie"),
+      provider === "ebayResearch" ? lease.credential : null,
+    );
+    assert.equal(init?.redirect, "manual");
+    return new Response("{}");
+  });
+  await h.request(provider, {
+    path: provider === "alt" ? "/graphql/Me" : path,
+  });
+  assert.equal(h.releases[0].status, "connected");
+}
+for (const status of [302, 401, 403]) {
+  let calls = 0;
+  const h = harness(async () => {
+    calls++;
+    return new Response("", {
+      status,
+      headers: { location: "https://attacker.example/" },
+    });
+  });
+  await assert.rejects(
+    h.request("ebayResearch", { path }),
+    fails("reconnect-required"),
+  );
+  assert.equal(calls, 1);
+  assert.equal(h.releases[0].status, "reconnect-required");
+}
+{
+  const h = harness(async () => new Response("<html>Sign in</html>"));
+  await assert.rejects(
+    h.request("ebayResearch", { path }),
+    fails("reconnect-required"),
+  );
+}
+{
+  const h = harness(async () => new Response("x".repeat(2 * 1024 * 1024 + 1)));
+  await assert.rejects(
+    h.request("ebayResearch", { path }),
+    fails("invalid-response"),
+  );
+}
+{
+  let calls = 0;
+  const h = harness(async () => {
+    calls++;
+    return new Response("", {
+      status: 429,
+      headers: { "retry-after": "3600" },
+    });
+  });
+  const start = Date.now();
+  await assert.rejects(
+    h.request("ebayResearch", { path }),
+    fails("rate-limited"),
+  );
+  assert.equal(calls, 1);
+  assert.ok(h.releases[0].retryAt >= start + 3600000);
+  assert.equal(retryAfterMs("garbage"), 2000);
+  assert.equal(
+    retryAfterMs(
+      "Wed, 01 Jan 2025 00:01:00 GMT",
+      Date.parse("2025-01-01T00:00:00Z"),
+    ),
+    60000,
+  );
+}
+{
+  let calls = 0;
+  const h = harness(async () => {
+    calls++;
+    return new Response("{}");
+  });
+  for (const badPath of [
+    "//attacker.example/sh/research/api/search",
+    "https://attacker.example/",
+    "/signin",
+  ]) {
+    await assert.rejects(
+      h.request("ebayResearch", { path: badPath }),
+      fails("invalid-response"),
+    );
+  }
+  for (const timeoutMs of [-1, NaN, Infinity]) {
+    await assert.rejects(
+      h.request("ebayResearch", { path }, { timeoutMs }),
+      fails("invalid-response"),
+    );
+  }
+  await assert.rejects(
+    h.request("ebayResearch", { path }, { signal: AbortSignal.abort() }),
+    fails("cancelled"),
+  );
+  assert.equal(h.claims(), 0);
+  assert.equal(calls, 0);
+}
+{
+  const controller = new AbortController();
+  const h = harness(
+    async (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          "abort",
+          () => reject(new Error("secret headers")),
+          { once: true },
+        );
+        controller.abort();
+      }),
+  );
+  await assert.rejects(
+    h.request("ebayResearch", { path }, { signal: controller.signal }),
+    fails("cancelled"),
+  );
+  assert.equal(h.releases[0].status, "cancelled");
+}
+{
+  const h = harness(async () => new Response("{}"), {
+    release: async () => {
+      throw new Error("private database detail");
+    },
+  });
+  await assert.rejects(
+    h.request("ebayResearch", { path }),
+    fails("unavailable"),
+  );
+}
+validateAltConnection('{"data":{"me":{"id":"fixture"}}}');
+assert.throws(
+  () => validateAltConnection('{"data":{"me":null}}'),
+  fails("reconnect-required"),
+);
+assert.throws(
+  () =>
+    validateAltConnection(
+      '{"errors":[{"extensions":{"code":"UNAUTHENTICATED"}}]}',
+    ),
+  fails("reconnect-required"),
+);
+for (const body of [
+  "null",
+  "{}",
+  '{"errors":[{"message":"schema changed"}]}',
+]) {
+  assert.throws(() => validateAltConnection(body), fails("invalid-response"));
+}
+validateEbayConnection(
+  '{"_type":"PageErrorModule"}\n\n{"_type":"ResultsHeaderModule","tabs":[{"active":true}]}',
+);
+for (const body of [
+  "null",
+  "{}",
+  '{"_type":"ResultsHeaderModule","tabs":{}}',
+]) {
+  assert.throws(() => validateEbayConnection(body), fails("invalid-response"));
+}
+assert.equal(
+  validateCredential("alt", "Bearer token.value", ""),
+  "token.value",
+);
+assert.throws(() =>
+  validateCredential("ebayResearch", "cookie=value\r\nInjected: true", "agent"),
+);
+assert.throws(() => validateCredential("ebayResearch", "cookie=value", ""));
+
+{
+  let saved = 0;
+  const action = createProviderConnectionsAction({
+    save: async () => {
+      saved++;
+    },
+    clear: async () => {},
+    check: async () => {
+      throw new Error("private provider response");
+    },
+  });
+  const submit = (intent: string, origin = "http://localhost:5153") =>
+    action({
+      request: new Request("http://localhost:5153/slab-connections", {
+        method: "POST",
+        headers: { Origin: origin },
+        body: new URLSearchParams({
+          provider: "alt",
+          intent,
+          credential: "secret",
+        }),
+      }),
+    });
+  assert.equal(
+    (await submit("save", "https://foreign.example")).init?.status,
+    403,
+  );
+  assert.equal(saved, 0);
+  assert.equal((await submit("save")).data.ok, true);
+  assert.equal(saved, 1);
+  const failed = await submit("check");
+  assert.equal(failed.data.ok, false);
+  assert.ok(!JSON.stringify(failed).includes("private provider"));
+  assert.equal(
+    failed.init?.headers &&
+      new Headers(failed.init.headers).get("Cache-Control"),
+    "no-store",
+  );
+}
+{
+  const action = createProviderConnectionsAction({
+    save: async () => {},
+    clear: async () => {},
+    check: async () => {
+      throw new ProviderRequestError("reconnect-required");
+    },
+  });
+  const result = await action({
+    request: new Request("http://localhost/slab-connections", {
+      method: "POST",
+      headers: { Origin: "http://localhost" },
+      body: new URLSearchParams({ provider: "alt", intent: "check" }),
+    }),
+  });
+  assert.equal(result.data.ok, false);
+  assert.equal(
+    result.init?.status,
+    200,
+    "completed checks must revalidate the stored connection status",
+  );
+}
+{
+  let received = false;
+  const server = createServer((_request, response) => {
+    received = true;
+    response.writeHead(200);
+    response.write('{"data":');
+    // Deliberately leave the response body open.
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    const h = harness((_url, init) =>
+      fetch(`http://127.0.0.1:${address.port}`, init),
+    );
+    await assert.rejects(
+      h.request("ebayResearch", { path }, { timeoutMs: 250 }),
+      fails("cancelled"),
+    );
+    assert.equal(received, true);
+    assert.equal(h.releases[0].status, "cancelled");
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+{
+  let calls = 0;
+  const h = harness(async () => {
+    calls++;
+    return new Response("", { status: 429, headers: { "retry-after": "0" } });
+  });
+  await assert.rejects(
+    h.request("ebayResearch", { path }),
+    fails("rate-limited"),
+  );
+  assert.equal(calls, 3);
+}
+console.log(
+  "PASS slab provider isolation, auth failures, bounds, cancellation, validation and masked actions",
+);

--- a/app/features/ebay-slab-pricing/connections/providerConnectionsAction.server.ts
+++ b/app/features/ebay-slab-pricing/connections/providerConnectionsAction.server.ts
@@ -1,0 +1,79 @@
+import { data } from "react-router";
+import { checkProviderConnection } from "./checkProviderConnection.server";
+import {
+  clearProviderConnection,
+  saveProviderConnection,
+} from "./providerConnections.server";
+import { CONNECTION_MESSAGES, isSlabProvider } from "./providerConnection";
+import { ProviderRequestError } from "./providerRequest.server";
+
+export function createProviderConnectionsAction(
+  dependencies = {
+    save: saveProviderConnection,
+    clear: clearProviderConnection,
+    check: checkProviderConnection,
+  },
+) {
+  return async ({ request }: { request: Request }) => {
+    const respond = (result: { ok: boolean; message: string }, status = 200) =>
+      data(result, { status, headers: { "Cache-Control": "no-store" } });
+    if (request.method !== "POST")
+      return respond({ ok: false, message: "Method not allowed." }, 405);
+    if (request.headers.get("Origin") !== new URL(request.url).origin) {
+      return respond(
+        { ok: false, message: "Submit this form from the application." },
+        403,
+      );
+    }
+    try {
+      const form = await request.formData();
+      const provider = form.get("provider");
+      const intent = form.get("intent");
+      if (!isSlabProvider(provider))
+        return respond(
+          { ok: false, message: "Choose a supported provider." },
+          400,
+        );
+      if (intent === "save") {
+        const credential = form.get("credential");
+        const userAgent = form.get("userAgent");
+        if (
+          typeof credential !== "string" ||
+          (userAgent !== null && typeof userAgent !== "string")
+        ) {
+          return respond(
+            { ok: false, message: "Enter a valid connection." },
+            400,
+          );
+        }
+        await dependencies.save(provider, credential, userAgent ?? "");
+        return respond({ ok: true, message: CONNECTION_MESSAGES.unchecked });
+      }
+      if (intent === "clear") {
+        await dependencies.clear(provider);
+        return respond({ ok: true, message: "Connection removed." });
+      }
+      if (intent === "check") {
+        await dependencies.check(provider, request.signal);
+        return respond({ ok: true, message: CONNECTION_MESSAGES.connected });
+      }
+      return respond({ ok: false, message: "Choose a supported action." }, 400);
+    } catch (error) {
+      if (error instanceof ProviderRequestError) {
+        // A completed check can report unavailable access. Revalidate its stored status.
+        return respond({
+          ok: false,
+          message: CONNECTION_MESSAGES[error.status],
+        });
+      }
+      return respond(
+        {
+          ok: false,
+          message:
+            "Unable to update the connection. Check the input and try again.",
+        },
+        400,
+      );
+    }
+  };
+}

--- a/app/features/ebay-slab-pricing/connections/providerRequest.server.ts
+++ b/app/features/ebay-slab-pricing/connections/providerRequest.server.ts
@@ -1,0 +1,209 @@
+import { setTimeout as delay } from "node:timers/promises";
+import type { SlabProvider, ConnectionStatus } from "./providerConnection";
+
+export class ProviderRequestError extends Error {
+  constructor(public readonly status: ConnectionStatus) {
+    // Never attach transport errors: they can contain authorization headers.
+    super(status);
+    this.name = "ProviderRequestError";
+  }
+}
+
+export type ProviderLease = {
+  id: string;
+  revision: number;
+  credential: string;
+  userAgent: string;
+};
+export type ProviderRequestGate = {
+  claim(provider: SlabProvider): Promise<ProviderLease>;
+  release(
+    provider: SlabProvider,
+    lease: ProviderLease,
+    result: {
+      status: ConnectionStatus;
+      retryAt: number;
+    },
+  ): Promise<void>;
+};
+
+const ORIGINS = {
+  alt: "https://alt-platform-server.production.internal.onlyalt.com",
+  ebayResearch: "https://www.ebay.com",
+} as const;
+export const PROVIDER_TIMEOUT_MS = 30_000;
+const MAX_RESPONSE_BYTES = 2 * 1024 * 1024;
+const REQUEST_GAP_MS = 2_000;
+
+function providerUrl(provider: SlabProvider, path: string): URL {
+  const url = new URL(path, ORIGINS[provider]);
+  const validPath =
+    provider === "alt"
+      ? url.pathname.startsWith("/graphql/")
+      : url.pathname === "/sh/research/api/search";
+  if (
+    !path.startsWith("/") ||
+    path.startsWith("//") ||
+    url.origin !== ORIGINS[provider] ||
+    !validPath ||
+    url.username ||
+    url.password
+  ) {
+    throw new ProviderRequestError("invalid-response");
+  }
+  return url;
+}
+
+async function readText(
+  response: Response,
+  signal: AbortSignal,
+): Promise<string> {
+  const reader = response.body?.getReader();
+  if (!reader) throw new ProviderRequestError("invalid-response");
+  const decoder = new TextDecoder();
+  let size = 0;
+  let text = "";
+  try {
+    for (;;) {
+      signal.throwIfAborted();
+      const { value, done } = await reader.read();
+      if (done) return text + decoder.decode();
+      size += value.byteLength;
+      if (size > MAX_RESPONSE_BYTES)
+        throw new ProviderRequestError("invalid-response");
+      text += decoder.decode(value, { stream: true });
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}
+
+export function retryAfterMs(header: string | null, now = Date.now()): number {
+  if (!header) return REQUEST_GAP_MS;
+  const seconds = /^\d+(\.\d+)?$/.test(header) ? Number(header) : null;
+  const value = seconds === null ? Date.parse(header) - now : seconds * 1000;
+  return Number.isFinite(value) && value >= 0 && value < 8.64e15 - now
+    ? Math.max(REQUEST_GAP_MS, value)
+    : REQUEST_GAP_MS;
+}
+
+/** Fixed-origin, read-only provider transport. The gate coordinates every process. */
+export function createProviderRequest(
+  gate: ProviderRequestGate,
+  fetcher: typeof fetch = fetch,
+) {
+  return async function requestProvider(
+    provider: SlabProvider,
+    request: { path: string; body?: string },
+    options: {
+      signal?: AbortSignal;
+      timeoutMs?: number;
+      validate?: (body: string) => void;
+    } = {},
+  ): Promise<string> {
+    const url = providerUrl(provider, request.path);
+    const requestedTimeout = options.timeoutMs ?? PROVIDER_TIMEOUT_MS;
+    if (!Number.isFinite(requestedTimeout) || requestedTimeout <= 0) {
+      throw new ProviderRequestError("invalid-response");
+    }
+    const timeoutMs = Math.min(
+      Math.ceil(requestedTimeout),
+      PROVIDER_TIMEOUT_MS,
+    );
+    const deadline = Date.now() + timeoutMs;
+    const signal = AbortSignal.any([
+      AbortSignal.timeout(timeoutMs),
+      ...(options.signal ? [options.signal] : []),
+    ]);
+    let lease: ProviderLease | undefined;
+    let status: ConnectionStatus = "unavailable";
+    let retryAt = 0;
+    try {
+      signal.throwIfAborted();
+      lease = await gate.claim(provider);
+      signal.throwIfAborted();
+      const headers: Record<string, string> =
+        provider === "alt"
+          ? {
+              Authorization: `Bearer ${lease.credential}`,
+              "Content-Type": "application/json",
+              Origin: "https://alt.xyz",
+              Referer: "https://alt.xyz/",
+            }
+          : {
+              Cookie: lease.credential,
+              "User-Agent": lease.userAgent,
+              Referer: "https://www.ebay.com/sh/research",
+            };
+      for (let attempt = 0; attempt < 3; attempt++) {
+        signal.throwIfAborted();
+        let response: Response;
+        try {
+          response = await fetcher(url, {
+            method: request.body === undefined ? "GET" : "POST",
+            headers,
+            body: request.body,
+            redirect: "manual",
+            signal,
+          });
+        } catch {
+          if (signal.aborted) throw new ProviderRequestError("cancelled");
+          if (attempt === 2) throw new ProviderRequestError("unavailable");
+          await delay(REQUEST_GAP_MS * (attempt + 1), undefined, { signal });
+          continue;
+        }
+        if ([301, 302, 303, 307, 308, 401, 403].includes(response.status)) {
+          await response.body?.cancel();
+          throw new ProviderRequestError("reconnect-required");
+        }
+        if ([429, 502, 503, 504].includes(response.status)) {
+          await response.body?.cancel();
+          const wait = retryAfterMs(response.headers.get("retry-after"));
+          retryAt = Date.now() + wait;
+          if (attempt === 2 || wait >= deadline - Date.now()) {
+            throw new ProviderRequestError(
+              response.status === 429 ? "rate-limited" : "unavailable",
+            );
+          }
+          await delay(wait, undefined, { signal });
+          continue;
+        }
+        if (!response.ok) {
+          await response.body?.cancel();
+          throw new ProviderRequestError("invalid-response");
+        }
+        const body = await readText(response, signal);
+        if (/^\s*</.test(body))
+          throw new ProviderRequestError("reconnect-required");
+        options.validate?.(body);
+        status = "connected";
+        return body;
+      }
+      throw new ProviderRequestError("unavailable");
+    } catch (error) {
+      status = signal.aborted
+        ? "cancelled"
+        : error instanceof ProviderRequestError
+          ? error.status
+          : "unavailable";
+      throw new ProviderRequestError(status);
+    } finally {
+      if (lease) {
+        const cooldown =
+          status === "unavailable" || status === "invalid-response"
+            ? 30_000
+            : REQUEST_GAP_MS;
+        try {
+          await gate.release(provider, lease, {
+            status,
+            retryAt: Math.max(retryAt, Date.now() + cooldown),
+          });
+        } catch {
+          // A lost database connection leaves the lease to expire. Never expose its error.
+          throw new ProviderRequestError("unavailable");
+        }
+      }
+    }
+  };
+}

--- a/app/features/ebay-slab-pricing/routes/slab-connections.tsx
+++ b/app/features/ebay-slab-pricing/routes/slab-connections.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { data, useFetcher, useLoaderData } from "react-router";
+import { getProviderConnections } from "../connections/providerConnections.server";
+import { createProviderConnectionsAction } from "../connections/providerConnectionsAction.server";
+import {
+  CONNECTION_MESSAGES,
+  type ProviderConnectionStatus,
+} from "../connections/providerConnection";
+
+export async function loader() {
+  return data(
+    { connections: await getProviderConnections() },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}
+export const action = createProviderConnectionsAction();
+
+function ConnectionForm({
+  connection,
+}: {
+  connection: ProviderConnectionStatus;
+}) {
+  const fetcher = useFetcher<typeof action>();
+  const form = useRef<HTMLFormElement>(null);
+  const isAlt = connection.provider === "alt";
+  const pending = fetcher.state !== "idle";
+  useEffect(() => {
+    if (fetcher.state === "idle" && fetcher.data?.ok) form.current?.reset();
+  }, [fetcher.state, fetcher.data]);
+  return (
+    <Paper sx={{ p: 3 }}>
+      <Stack spacing={2}>
+        <Typography variant="h6">
+          {isAlt ? "Alt" : "eBay Product Research"}
+        </Typography>
+        <Typography>
+          {connection.configured
+            ? CONNECTION_MESSAGES[connection.status]
+            : CONNECTION_MESSAGES["not-configured"]}
+        </Typography>
+        {connection.checkedAt && (
+          <Typography variant="body2" color="text.secondary">
+            Last check: {new Date(connection.checkedAt).toISOString()}
+          </Typography>
+        )}
+        <Typography variant="body2" color="text.secondary">
+          {isAlt
+            ? "Use the authorization token from your signed-in Alt session."
+            : "Use the Cookie header and User-Agent from your signed-in eBay Research session. Developer API keys do not grant this access."}{" "}
+          Saved credentials are never displayed. Replace them after signing in
+          again if access expires.
+        </Typography>
+        <fetcher.Form method="post" ref={form} autoComplete="off">
+          <input type="hidden" name="provider" value={connection.provider} />
+          <Stack spacing={2}>
+            <TextField
+              name="credential"
+              type="password"
+              label={
+                isAlt
+                  ? "Alt authorization token"
+                  : "eBay research Cookie header"
+              }
+              autoComplete="new-password"
+              fullWidth
+              inputProps={{ maxLength: 32768 }}
+            />
+            {!isAlt && (
+              <TextField
+                name="userAgent"
+                label="Browser User-Agent"
+                fullWidth
+                inputProps={{ maxLength: 512 }}
+              />
+            )}
+            <Stack direction="row" spacing={1}>
+              <Button
+                type="submit"
+                name="intent"
+                value="save"
+                variant="contained"
+                disabled={pending}
+              >
+                Save connection
+              </Button>
+              <Button
+                type="submit"
+                name="intent"
+                value="check"
+                disabled={pending || !connection.configured}
+              >
+                Check access
+              </Button>
+              <Button
+                type="submit"
+                name="intent"
+                value="clear"
+                disabled={pending || !connection.configured}
+              >
+                Remove
+              </Button>
+            </Stack>
+          </Stack>
+        </fetcher.Form>
+        {fetcher.data && (
+          <Alert severity={fetcher.data.ok ? "success" : "warning"}>
+            {fetcher.data.message}
+          </Alert>
+        )}
+      </Stack>
+    </Paper>
+  );
+}
+
+export default function SlabConnections() {
+  const { connections } = useLoaderData<typeof loader>();
+  return (
+    <Box sx={{ maxWidth: 850, mx: "auto", p: 3 }}>
+      <Stack spacing={3}>
+        <Typography variant="h4">Slab data connections</Typography>
+        <Typography>
+          Connect the sources used to research graded cards. Checking access
+          only reads data.
+        </Typography>
+        {connections.map((connection) => (
+          <ConnectionForm key={connection.provider} connection={connection} />
+        ))}
+      </Stack>
+    </Box>
+  );
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -43,6 +43,10 @@ export default [
     file: "routes/http-configuration.tsx",
   },
   {
+    path: "/slab-connections",
+    file: "features/ebay-slab-pricing/routes/slab-connections.tsx",
+  },
+  {
     path: "/shipping-configuration",
     file: "features/shipping-export/routes/shipping-configuration.tsx",
   },

--- a/app/shared/appNavigation.ts
+++ b/app/shared/appNavigation.ts
@@ -59,6 +59,7 @@ export const primaryNavigationItems: NavigationItem[] = [
 ];
 
 export const settingsNavigationItems: NavigationItem[] = [
+  { label: "Slab data connections", to: "/slab-connections", icon: HttpIcon },
   { label: "Configuration", to: "/configuration", icon: SettingsIcon },
   {
     label: "Inventory Publication",

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -69,3 +69,4 @@ import "../features/pricing/domain/forecastGrading.test";
 import "../features/inventory-strategy/services/forecastGrading.server.test";
 import "../features/pricing/algorithms/getSuggestedPriceFromLatestSales.test";
 import "../features/shipping-export/components/steps/PackStep.test";
+import "../features/ebay-slab-pricing/connections/providerConnections.test";

--- a/db/migrations/024_add_slab_provider_connections.sql
+++ b/db/migrations/024_add_slab_provider_connections.sql
@@ -1,0 +1,11 @@
+CREATE TABLE slab_provider_connections (
+  provider text PRIMARY KEY CHECK (provider IN ('alt', 'ebayResearch')),
+  credential text NOT NULL DEFAULT '',
+  user_agent text NOT NULL DEFAULT '',
+  revision integer NOT NULL DEFAULT 0,
+  status text NOT NULL DEFAULT 'not-configured',
+  checked_at timestamptz,
+  next_request_at timestamptz NOT NULL DEFAULT '-infinity',
+  lease_id uuid,
+  lease_until timestamptz
+);

--- a/docs/ebay-slab-connections.md
+++ b/docs/ebay-slab-connections.md
@@ -1,0 +1,38 @@
+# Slab data connections
+
+Settings → Slab data connections configures Alt and eBay Product Research independently. Apply migration `024_add_slab_provider_connections.sql` through the existing migration runner before serving this route. This slice only checks access; certificate resolution, evidence, valuation and publication are separate backlog issues.
+
+## Connect and reconnect
+
+Sign in normally to the provider in Chrome. In DevTools → Network, select a request to the endpoint below and copy the specified request headers into the connection form. Save, then select **Check access**. The form clears successful submissions and never loads a saved secret back into the browser.
+
+| Provider | Observed endpoint | Form values | Read used to check access |
+| --- | --- | --- | --- |
+| Alt | `alt-platform-server.production.internal.onlyalt.com/graphql/Me` | Authorization token, with or without `Bearer ` | GraphQL `Me`, requesting only `id`; discard the response |
+| eBay Product Research | `www.ebay.com/sh/research/api/search` | Cookie header and the same browser's User-Agent | A one-result sold search, requesting only the results header module |
+
+The transport supplies Alt's Content-Type, Origin and Referer, and eBay's Research Referer. These headers plus the configured session material were sufficient in the verified calls. No Typesense search key, idempotency key, browser extension or seller OAuth configuration is needed for these checks. Seller API OAuth for later listing publication is a different connection.
+
+Session lifetimes are controlled by the providers; no fixed renewal interval is assumed. HTTP redirects/401/403, HTML login responses, and Alt's unauthenticated/null-user response stop access with a reconnect message. Sign in again and replace the saved value. Credentials are read for each request, so no app or worker restart is needed. Removing a connection clears its credentials. An already running read may finish, but its result cannot overwrite the replacement/removal status.
+
+The database stores credentials server-side, following the application's existing configuration model. Run this personal settings surface within the app's trusted access boundary; database backups contain these credentials. There is no new credential manager or application authentication system in this slice.
+
+## Request ownership and bounds
+
+All future interactive and worker adapters must compose `createProviderRequest` with `providerRequestGate`, using the same application database. The database row admits **one in-flight request per provider across all processes**, with at least two seconds between requests. Separate providers have independent rows; TCGplayer uses its existing path. Busy callers return immediately and future jobs should reschedule them rather than poll.
+
+Requests use a fixed provider origin, manual redirects, a maximum 30-second HTTP deadline (including retries and body reads), at most three attempts, and a two-MiB decompressed response limit. Retry-After can defer the provider beyond the current request deadline; it is persisted without holding a process asleep for that duration. Transient/invalid responses impose a 30-second cooldown. Authentication failures stay blocked until credentials are replaced. Database gate queries have five-second read timeouts, in addition to the existing pool's connection timeout; database acquisition/cleanup can extend the elapsed operation beyond its HTTP deadline.
+
+A 35-second lease recovers after a process exits. Lease IDs fence late cleanup, and credential revisions prevent old requests from changing a new connection's status. Saving/removing credentials preserves the current lease and cooldown. No Redis, extra worker, timer service, browser runtime or dependency is added.
+
+## Verification
+
+On September 5, 2026, authenticated reads succeeded through native fetch on the Windows host (Node 24.15.0) and a fresh `node:20-alpine` container (Node 20.20.2). Both used the same captured sessions; no production containers were modified. Invalid Alt credentials returned HTTP 200 with `me: null`, which is treated as reconnect-required.
+
+Run normal tests with `npm test` and the isolated PostgreSQL test with:
+
+```sh
+npx tsx app/features/ebay-slab-pricing/connections/providerConnections.integration.test.ts
+```
+
+The integration test accepts only the local development database on port 5433 and creates/drops its own random schema. It verifies four-process exclusion, cooldown, lease expiry/fencing, replacement/removal, credential masking and reconnect without restart. Unit tests cover origin/credential isolation, redirects/authentication, throttling, stalled response deadlines, cancellation, response-size limits, provider response validation and masked form errors. No real credentials are required by committed tests.


### PR DESCRIPTION
Alt and eBay Research need independent browser-session credentials before slab evidence can be fetched. Add a Slab data connections settings page with masked status, replacement/removal, and read-only access checks. An expired connection stops requests until replaced, without restarting the app or workers.

The feature composes a fixed-origin native-fetch transport with a PostgreSQL request gate. One lease and cooldown per provider apply across web and worker processes; lease IDs and credential revisions fence stale requests. Requests have cancellation, bounded retries/body size/deadlines, persisted Retry-After, manual redirects and sanitized errors. There are no new dependencies, services or background jobs, and existing TCGplayer callers are unchanged.

Validation completed:

- `npm test`, `npm run typecheck`, `npm run build` and `git diff --cached --check` passed. The build still reports existing MUI namespace warnings.
- Isolated PostgreSQL integration test passed with four separate Node processes, covering exclusion, expiry recovery, cooldown, stale release protection and reconnect.
- Real Alt and eBay Research reads succeeded on the Windows Node 24 host and in a fresh Node 20 Alpine container.
- Chrome verified the settings form, eBay access, an invalid Alt token, refreshed reconnect status, and successful credential replacement without restarting the app.
- Checked staged files, generated client bundles, settings HTML and data responses against the configured credentials: no leaks.

Adversarial self-review was repeated across composability, simplicity, design, performance and footprint. Fixed remaining-deadline retry handling, database error sanitization/query bounds, provider response classification, and a failed-check revalidation bug found in Chrome. Added regression coverage, reran checks, and completed a final pass with no remaining actionable findings in this slice.

Deployment requires migration 024 through the existing runner. Session credentials remain server-side in the app database and must be replaced when the provider expires them; setup, headers and process ownership are documented in `docs/ebay-slab-connections.md`. This PR establishes connections only; certificate resolution and pricing follow in the dependent issues.

Fixes #20.
