### PR TITLE
Resolve slab certificates with versioned identity decisions

### DIFF
--- a/app/features/ebay-slab-pricing/identity/altIdentityProvider.server.ts
+++ b/app/features/ebay-slab-pricing/identity/altIdentityProvider.server.ts
@@ -1,0 +1,124 @@
+import {
+  createProviderRequest,
+  ProviderRequestError,
+} from "../connections/providerRequest.server";
+import {
+  normalizeCertificate,
+  parseSlabIdentity,
+  type IdentityCandidate,
+} from "./slabIdentity";
+
+const CERT_QUERY = `query Cert($certNumber: String!) {
+  cert(certNumber: $certNumber) {
+    certNumber gradeNumber gradingCompany autograph qualifier
+    asset { id name year subject category brand variety attributes { cardNumber } }
+  }
+}`;
+
+export function parseAltCertificate(body: string): IdentityCandidate | null {
+  try {
+    const result = JSON.parse(body);
+    if (
+      result?.errors?.some?.(
+        (error: { extensions?: { code?: string } }) =>
+          error?.extensions?.code === "UNAUTHENTICATED",
+      )
+    ) {
+      throw new ProviderRequestError("reconnect-required");
+    }
+    if (result?.errors?.length || !result?.data || !("cert" in result.data))
+      throw new ProviderRequestError("invalid-response");
+    const cert = result.data.cert;
+    if (cert === null) return null;
+    const certificate = normalizeCertificate({
+      grader: cert.gradingCompany,
+      certificateNumber: cert.certNumber,
+    });
+    if (
+      typeof cert.gradeNumber !== "string" ||
+      !cert.gradeNumber ||
+      typeof cert.asset?.id !== "string" ||
+      !cert.asset.id
+    ) {
+      throw new ProviderRequestError("invalid-response");
+    }
+    const numeric = /^\d+(?:\.\d+)?$/.test(cert.gradeNumber)
+      ? Number(cert.gradeNumber)
+      : NaN;
+    // PSA's scale is verified. Other provider encodings need an explicit label decision.
+    const number =
+      certificate.grader === "PSA" &&
+      numeric >= 1 &&
+      numeric <= 10 &&
+      numeric !== 9.5 &&
+      (numeric * 2) % 1 === 0
+        ? numeric
+        : null;
+    return {
+      ...certificate,
+      identity: parseSlabIdentity({
+        card: {
+          name: cert.asset.subject ?? cert.asset.name,
+          game: cert.asset.category === "POKEMON_CARDS" ? "Pokemon" : null,
+          language: null,
+          set: cert.asset.brand ?? null,
+          cardNumber: cert.asset.attributes?.cardNumber ?? null,
+          year: cert.asset.year == null ? null : String(cert.asset.year),
+          edition: cert.asset.variety === "1st Edition" ? "1st Edition" : null,
+          finish: ["Reverse Holo", "Holo", "Non-Holo"].includes(
+            cert.asset.variety,
+          )
+            ? cert.asset.variety
+            : null,
+          stamp: null,
+        },
+        grading: {
+          grader: certificate.grader,
+          encoding: cert.gradeNumber,
+          number,
+          label: number === null ? null : `PSA ${number}`,
+          qualifier: cert.qualifier,
+          autograph: cert.autograph,
+        },
+        providerAsset: {
+          provider: "alt",
+          id: cert.asset.id,
+          title: cert.asset.name,
+        },
+      }),
+    };
+  } catch (error) {
+    throw error instanceof ProviderRequestError
+      ? error
+      : new ProviderRequestError("invalid-response");
+  }
+}
+
+export function createAltIdentityProvider(
+  request: ReturnType<typeof createProviderRequest>,
+) {
+  return async (
+    certificateNumber: string,
+    signal?: AbortSignal,
+  ): Promise<IdentityCandidate | null> => {
+    let candidate: IdentityCandidate | null = null;
+    await request(
+      "alt",
+      {
+        path: "/graphql/Cert",
+        body: JSON.stringify({
+          operationName: "Cert",
+          variables: { certNumber: certificateNumber },
+          query: CERT_QUERY,
+        }),
+      },
+      {
+        signal,
+        validate: (body) => {
+          candidate = parseAltCertificate(body);
+        },
+      },
+    );
+    return candidate;
+  };
+}

--- a/app/features/ebay-slab-pricing/identity/fixtures/alt-cert-110185364.json
+++ b/app/features/ebay-slab-pricing/identity/fixtures/alt-cert-110185364.json
@@ -1,0 +1,31 @@
+{
+  "data": {
+    "cert": {
+      "certNumber": "110185364",
+      "gradeNumber": "1.0",
+      "gradingCompany": "PSA",
+      "autograph": null,
+      "qualifier": null,
+      "centering": null,
+      "corners": null,
+      "edges": null,
+      "surfaces": null,
+      "asset": {
+        "id": "20c46c8c-4290-4953-b76f-5892bb442f87",
+        "name": "2002 Pokemon Legendary Collection Reverse Holo Hitmonlee #13",
+        "year": 2002,
+        "subject": "Hitmonlee",
+        "category": "POKEMON_CARDS",
+        "brand": "Pokemon Legendary Collection",
+        "variety": "Reverse Holo",
+        "attributes": {
+          "cardNumber": "13",
+          "printRun": null,
+          "__typename": "AssetAttributes"
+        },
+        "__typename": "Asset"
+      },
+      "__typename": "Cert"
+    }
+  }
+}

--- a/app/features/ebay-slab-pricing/identity/slabIdentities.server.ts
+++ b/app/features/ebay-slab-pricing/identity/slabIdentities.server.ts
@@ -1,0 +1,73 @@
+import { randomUUID } from "node:crypto";
+import { queryOne } from "~/core/db/database.server";
+import { createProviderRequest } from "../connections/providerRequest.server";
+import { providerRequestGate } from "../connections/providerConnections.server";
+import { createAltIdentityProvider } from "./altIdentityProvider.server";
+import {
+  createSlabIdentityService,
+  type IdentityStore,
+} from "./slabIdentityService.server";
+import type { StoredSlabIdentity } from "./slabIdentity";
+
+const COLUMNS = `id, grader, certificate_number AS "certificateNumber", candidate, identity, status,
+  review_reasons AS "reviewReasons", valuation_group_key AS "valuationGroupKey", revision,
+  decision_source AS "decisionSource", decision_note AS "decisionNote", updated_at AS "updatedAt"`;
+export const slabIdentityStore: IdentityStore = {
+  find: (certificate) =>
+    queryOne<StoredSlabIdentity>(
+      `SELECT ${COLUMNS} FROM slab_identities WHERE grader = $1 AND certificate_number = $2`,
+      [certificate.grader, certificate.certificateNumber],
+    ),
+  async saveCandidate(certificate, candidate, reasons, revision) {
+    let result: StoredSlabIdentity | null;
+    if (revision === undefined) {
+      result = await queryOne<StoredSlabIdentity>(
+        `INSERT INTO slab_identities (id, grader, certificate_number, candidate, review_reasons)
+        VALUES ($1, $2, $3, $4, $5) ON CONFLICT (grader, certificate_number) DO NOTHING RETURNING ${COLUMNS}`,
+        [
+          randomUUID(),
+          certificate.grader,
+          certificate.certificateNumber,
+          JSON.stringify(candidate),
+          JSON.stringify(reasons),
+        ],
+      );
+    } else {
+      result = await queryOne<StoredSlabIdentity>(
+        `UPDATE slab_identities SET candidate = $3, review_reasons = $4,
+        revision = revision + 1, updated_at = clock_timestamp() WHERE grader = $1 AND certificate_number = $2
+        AND revision = $5 AND status <> 'confirmed' RETURNING ${COLUMNS}`,
+        [
+          certificate.grader,
+          certificate.certificateNumber,
+          JSON.stringify(candidate),
+          JSON.stringify(reasons),
+          revision,
+        ],
+      );
+    }
+    return result ?? (await slabIdentityStore.find(certificate))!;
+  },
+  confirm: (certificate, revision, identity, key, note) =>
+    queryOne<StoredSlabIdentity>(
+      `UPDATE slab_identities
+    SET identity = $4, valuation_group_key = $5, status = 'confirmed', review_reasons = '[]',
+      revision = revision + 1, decision_source = 'manual', decision_note = $6, updated_at = clock_timestamp()
+    WHERE grader = $1 AND certificate_number = $2 AND revision = $3 RETURNING ${COLUMNS}`,
+      [
+        certificate.grader,
+        certificate.certificateNumber,
+        revision,
+        JSON.stringify(identity),
+        key,
+        note,
+      ],
+    ),
+};
+
+export const slabIdentityService = createSlabIdentityService({
+  store: slabIdentityStore,
+  lookupCertificate: createAltIdentityProvider(
+    createProviderRequest(providerRequestGate),
+  ),
+});

--- a/app/features/ebay-slab-pricing/identity/slabIdentity.integration.test.ts
+++ b/app/features/ebay-slab-pricing/identity/slabIdentity.integration.test.ts
@@ -1,0 +1,134 @@
+// Opt-in local PostgreSQL test. All records live in a disposable schema.
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import pg from "pg";
+import dotenv from "dotenv";
+import { getPool } from "~/core/db/database.server";
+import { slabIdentityStore } from "./slabIdentities.server";
+import { createSlabIdentityService } from "./slabIdentityService.server";
+import { parseAltCertificate } from "./altIdentityProvider.server";
+import { isCurrentIdentity } from "./slabIdentity";
+import fixture from "./fixtures/alt-cert-110185364.json";
+
+dotenv.config({
+  path: [".env.development.local", ".env.local", ".env.development", ".env"],
+  quiet: true,
+});
+const url = new URL(
+  process.env.DATABASE_URL ??
+    "postgresql://postgres:postgres@localhost:5433/tcgplayer_automation",
+);
+assert.ok(
+  ["localhost", "127.0.0.1"].includes(url.hostname) && url.port === "5433",
+  "Use the local development database",
+);
+const admin = new pg.Client({ connectionString: url.toString() });
+const schema = `slab_identity_test_${randomUUID().replaceAll("-", "")}`;
+await admin.connect();
+await admin.query(`CREATE SCHEMA "${schema}"`);
+url.searchParams.set("options", `-c search_path=${schema}`);
+process.env.DATABASE_URL = url.toString();
+const db = getPool();
+try {
+  await db.query(
+    await readFile("db/migrations/025_add_slab_identities.sql", "utf8"),
+  );
+  const candidate = parseAltCertificate(JSON.stringify(fixture))!;
+  const cert = {
+    grader: candidate.grader,
+    certificateNumber: candidate.certificateNumber,
+  };
+  const results = await Promise.all(
+    Array.from({ length: 4 }, () =>
+      slabIdentityStore.saveCandidate(cert, candidate, [
+        "confirmation-required",
+      ]),
+    ),
+  );
+  assert.equal(
+    new Set(results.map((result) => result.id)).size,
+    1,
+    "one physical item per grader/certificate",
+  );
+  const collision = await slabIdentityStore.saveCandidate(
+    { ...cert, grader: "CGC" },
+    candidate,
+    ["grader-mismatch"],
+  );
+  assert.notEqual(collision.id, results[0].id);
+  let remoteCalls = 0;
+  const service = createSlabIdentityService({
+    store: slabIdentityStore,
+    lookupCertificate: async () => {
+      remoteCalls++;
+      return candidate;
+    },
+  });
+  const confirmed = await service.confirm(
+    cert,
+    1,
+    candidate.identity,
+    "Verified fixture identity",
+  );
+  const loaded = await service.lookup(cert);
+  assert.equal(loaded.record.status, "confirmed");
+  assert.equal(remoteCalls, 0);
+  const old = {
+    slabId: confirmed.id,
+    revision: confirmed.revision,
+    valuationGroupKey: confirmed.valuationGroupKey!,
+  };
+  const decisions = await Promise.allSettled([
+    service.confirm(
+      cert,
+      confirmed.revision,
+      {
+        ...candidate.identity,
+        card: { ...candidate.identity.card, language: "English" },
+      },
+      "Verified language",
+    ),
+    service.confirm(
+      cert,
+      confirmed.revision,
+      {
+        ...candidate.identity,
+        card: { ...candidate.identity.card, language: "Japanese" },
+      },
+      "Competing stale correction",
+    ),
+  ]);
+  assert.equal(
+    decisions.filter((decision) => decision.status === "fulfilled").length,
+    1,
+  );
+  const rejected = decisions.find((decision) => decision.status === "rejected");
+  assert.ok(
+    rejected?.status === "rejected" && rejected.reason.code === "conflict",
+  );
+  const current = await slabIdentityStore.find(cert);
+  assert.ok(current);
+  assert.equal(isCurrentIdentity(current, old), false);
+  assert.notEqual(current.valuationGroupKey, old.valuationGroupKey);
+  const delayed = await slabIdentityStore.saveCandidate(
+    cert,
+    null,
+    ["certificate-not-found"],
+    1,
+  );
+  assert.equal(delayed.revision, current.revision);
+  assert.equal(delayed.status, "confirmed");
+  assert.equal(
+    delayed.candidate?.identity.grading.encoding,
+    "1.0",
+    "retain original provider provenance after manual correction",
+  );
+  console.log(
+    "PASS concurrent physical-item deduplication, grader collisions, cached mapping, optimistic corrections and stale-provider fencing",
+  );
+} finally {
+  await db.end();
+  await admin.query(`DROP SCHEMA "${schema}" CASCADE`);
+  await admin.end();
+}

--- a/app/features/ebay-slab-pricing/identity/slabIdentity.test.ts
+++ b/app/features/ebay-slab-pricing/identity/slabIdentity.test.ts
@@ -1,0 +1,301 @@
+import assert from "node:assert/strict";
+import { createSlabIdentityAction } from "../routes/api.slab-identities.server";
+import fixture from "./fixtures/alt-cert-110185364.json";
+import {
+  parseAltCertificate,
+  createAltIdentityProvider,
+} from "./altIdentityProvider.server";
+import {
+  createSlabIdentityService,
+  valuationGroupKey,
+  type IdentityStore,
+} from "./slabIdentityService.server";
+import {
+  identityConflicts,
+  isCurrentIdentity,
+  normalizeCertificate,
+  parseSlabIdentity,
+  type StoredSlabIdentity,
+} from "./slabIdentity";
+import { createProviderRequest } from "../connections/providerRequest.server";
+
+const candidate = parseAltCertificate(
+  JSON.stringify({ ...fixture, researchGrade: "10.0" }),
+)!;
+assert.equal(candidate.certificateNumber, "110185364");
+assert.equal(candidate.identity.grading.number, 1);
+assert.equal(candidate.identity.grading.encoding, "1.0");
+assert.equal(
+  candidate.identity.providerAsset?.id,
+  "20c46c8c-4290-4953-b76f-5892bb442f87",
+);
+assert.equal(candidate.identity.card.language, null);
+assert.equal(candidate.identity.card.edition, null);
+assert.equal(candidate.identity.card.finish, "Reverse Holo");
+assert.deepEqual(identityConflicts(candidate.identity, { gradeNumber: 10 }), [
+  "inventory-grade-mismatch",
+]);
+assert.equal(parseAltCertificate('{"data":{"cert":null}}'), null);
+for (const body of [
+  "null",
+  "{}",
+  '{"data":{"cert":{}}}',
+  '{"data":{},"errors":[{"message":"schema"}]}',
+]) {
+  assert.throws(() => parseAltCertificate(body), {
+    status: "invalid-response",
+  });
+}
+for (const gradingCompany of ["CGC", "BGS"]) {
+  for (const gradeNumber of ["0.0", "10.5", "10.0"]) {
+    const result = parseAltCertificate(
+      JSON.stringify({
+        data: { cert: { ...fixture.data.cert, gradingCompany, gradeNumber } },
+      }),
+    )!;
+    assert.equal(result.identity.grading.number, null);
+    assert.equal(result.identity.grading.label, null);
+    assert.equal(result.identity.grading.encoding, gradeNumber);
+  }
+}
+const grade = (label: string) => ({
+  ...candidate.identity,
+  grading: {
+    ...candidate.identity.grading,
+    grader: "CGC",
+    encoding: "10.0",
+    number: 10,
+    label,
+  },
+});
+assert.notEqual(
+  valuationGroupKey(grade("Gem Mint 10")),
+  valuationGroupKey(grade("Pristine 10")),
+);
+assert.notEqual(
+  valuationGroupKey(grade("BGS Pristine")),
+  valuationGroupKey(grade("BGS Black Label")),
+);
+for (const field of ["language", "edition", "stamp"] as const) {
+  assert.notEqual(
+    valuationGroupKey(candidate.identity),
+    valuationGroupKey({
+      ...candidate.identity,
+      card: { ...candidate.identity.card, [field]: "different" },
+    }),
+  );
+}
+assert.deepEqual(
+  identityConflicts(candidate.identity, {
+    language: "Japanese",
+    edition: "1st Edition",
+    stamp: "Promo",
+  }),
+  [
+    "inventory-language-mismatch",
+    "inventory-edition-mismatch",
+    "inventory-stamp-mismatch",
+  ],
+);
+assert.deepEqual(
+  normalizeCertificate({ grader: " psa ", certificateNumber: "001234" }),
+  { grader: "PSA", certificateNumber: "001234" },
+);
+assert.throws(() =>
+  parseSlabIdentity({
+    ...candidate.identity,
+    grading: { ...candidate.identity.grading, number: 10.5 },
+  }),
+);
+
+let record: StoredSlabIdentity | null = null;
+let calls = 0;
+const store: IdentityStore = {
+  find: async () => record,
+  saveCandidate: async (certificate, value, reasons) =>
+    (record = {
+      ...certificate,
+      id: "slab",
+      candidate: value,
+      identity: null,
+      status: "needs-review",
+      reviewReasons: reasons,
+      valuationGroupKey: null,
+      revision: 1,
+      decisionSource: "alt",
+      decisionNote: null,
+      updatedAt: new Date(),
+    }),
+  confirm: async (_certificate, revision, identity, groupKey, note) => {
+    if (!record || record.revision !== revision) return null;
+    return (record = {
+      ...record,
+      identity,
+      valuationGroupKey: groupKey,
+      revision: revision + 1,
+      status: "confirmed",
+      reviewReasons: [],
+      decisionNote: note,
+      decisionSource: "manual",
+    });
+  },
+};
+const service = createSlabIdentityService({
+  store,
+  lookupCertificate: async () => {
+    calls++;
+    return candidate;
+  },
+});
+const input = { grader: "PSA", certificateNumber: "110185364" };
+const found = await service.lookup(input);
+await assert.rejects(service.lookup({ ...input, certificateNumber: " " }), {
+  code: "invalid-input",
+});
+await assert.rejects(
+  service.lookup(input, { expected: { gradeNumber: Infinity } }),
+  { code: "invalid-input" },
+);
+assert.equal(found.record.status, "needs-review");
+assert.ok(found.reviewReasons.includes("confirmation-required"));
+const confirmed = await service.confirm(
+  input,
+  1,
+  candidate.identity,
+  "Checked certificate and card image",
+);
+await service.lookup(input);
+assert.equal(calls, 1);
+const conflict = await service.lookup(input, {
+  expected: { language: "Japanese" },
+});
+assert.ok(conflict.reviewReasons.includes("inventory-language-mismatch"));
+const oldReference = {
+  slabId: confirmed.id,
+  revision: confirmed.revision,
+  valuationGroupKey: confirmed.valuationGroupKey!,
+};
+assert.equal(isCurrentIdentity(confirmed, oldReference), true);
+const corrected = await service.confirm(
+  input,
+  confirmed.revision,
+  {
+    ...candidate.identity,
+    card: { ...candidate.identity.card, language: "English" },
+  },
+  "Verified language",
+);
+assert.equal(isCurrentIdentity(corrected, oldReference), false);
+await assert.rejects(
+  service.confirm(input, confirmed.revision, candidate.identity, "stale tab"),
+  { code: "conflict" },
+);
+record = null;
+const mismatch = await service.lookup({ ...input, grader: "CGC" });
+assert.ok(mismatch.reviewReasons.includes("grader-mismatch"));
+await assert.rejects(
+  service.confirm(
+    { ...input, grader: "CGC" },
+    1,
+    candidate.identity,
+    "wrong grader",
+  ),
+  { code: "invalid-input" },
+);
+record = null;
+const wrongCert = await createSlabIdentityService({
+  store,
+  lookupCertificate: async () => ({ ...candidate, certificateNumber: "other" }),
+}).lookup(input);
+assert.ok(wrongCert.reviewReasons.includes("certificate-mismatch"));
+record = null;
+const missing = await createSlabIdentityService({
+  store,
+  lookupCertificate: async () => null,
+}).lookup(input);
+assert.deepEqual(missing.reviewReasons, ["certificate-not-found"]);
+await service.confirm(
+  input,
+  1,
+  candidate.identity,
+  "Manual identity from the certificate and image",
+);
+
+let requestBody = "";
+const provider = createAltIdentityProvider(
+  createProviderRequest(
+    {
+      claim: async () => ({
+        id: "fixture",
+        revision: 1,
+        credential: "fixture",
+        userAgent: "",
+      }),
+      release: async () => {},
+    },
+    async (_url, init) => {
+      requestBody = String(init?.body);
+      return new Response(JSON.stringify(fixture));
+    },
+  ),
+);
+assert.equal(
+  (await provider(input.certificateNumber))?.identity.grading.number,
+  1,
+);
+assert.deepEqual(JSON.parse(requestBody).variables, {
+  certNumber: "110185364",
+});
+{
+  const action = createSlabIdentityAction(service);
+  const submit = (body: unknown, origin = "http://localhost") =>
+    action({
+      request: new Request("http://localhost/api/slab-identities", {
+        method: "POST",
+        headers: { Origin: origin, "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    });
+  assert.equal(
+    (await submit({ intent: "lookup", ...input }, "https://foreign.example"))
+      .init?.status,
+    403,
+  );
+  assert.equal(
+    (await submit({ intent: "lookup", ...input })).init?.status,
+    200,
+  );
+  assert.equal(
+    (
+      await submit({
+        intent: "confirm",
+        ...input,
+        revision: 1,
+        identity: candidate.identity,
+        note: "Stale decision",
+      })
+    ).init?.status,
+    409,
+  );
+  assert.equal(
+    (await submit({ intent: "lookup", ...input, expected: [] })).init?.status,
+    400,
+  );
+  const failed = await createSlabIdentityAction({
+    ...service,
+    lookup: async () => {
+      throw new Error("private response");
+    },
+  })({
+    request: new Request("http://localhost/api/slab-identities", {
+      method: "POST",
+      headers: { Origin: "http://localhost" },
+      body: JSON.stringify({ intent: "lookup", ...input }),
+    }),
+  });
+  assert.equal(failed.init?.status, 500);
+  assert.ok(!JSON.stringify(failed).includes("private response"));
+}
+console.log(
+  "PASS certificate identity, explicit grade labels, cached confirmation, conflicts and correction invalidation",
+);

--- a/app/features/ebay-slab-pricing/identity/slabIdentity.ts
+++ b/app/features/ebay-slab-pricing/identity/slabIdentity.ts
@@ -1,0 +1,209 @@
+export const CARD_FIELDS = [
+  "name",
+  "game",
+  "language",
+  "set",
+  "cardNumber",
+  "year",
+  "edition",
+  "finish",
+  "stamp",
+] as const;
+export type CardIdentity = Record<(typeof CARD_FIELDS)[number], string | null>;
+export type SlabIdentity = {
+  card: CardIdentity;
+  grading: {
+    grader: string;
+    encoding: string;
+    number: number | null;
+    label: string | null;
+    qualifier: string | null;
+    autograph: string | null;
+  };
+  providerAsset: { provider: "alt"; id: string; title: string | null } | null;
+};
+export type Certificate = { grader: string; certificateNumber: string };
+export type ExpectedSlabIdentity = Partial<CardIdentity> & {
+  gradeNumber?: number | null;
+  gradeLabel?: string | null;
+  qualifier?: string | null;
+  autograph?: string | null;
+};
+export type IdentityCandidate = Certificate & { identity: SlabIdentity };
+export type StoredSlabIdentity = Certificate & {
+  id: string;
+  candidate: IdentityCandidate | null;
+  identity: SlabIdentity | null;
+  status: "needs-review" | "confirmed";
+  reviewReasons: string[];
+  valuationGroupKey: string | null;
+  revision: number;
+  decisionSource: "alt" | "manual";
+  decisionNote: string | null;
+  updatedAt: Date;
+};
+export class SlabIdentityError extends Error {
+  constructor(
+    public readonly code: "invalid-input" | "conflict" | "not-found",
+    message: string,
+  ) {
+    super(message);
+  }
+}
+export function textField(value: unknown, max = 200): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (
+    typeof value !== "string" ||
+    value.length > max ||
+    /[\x00-\x1f]/.test(value)
+  ) {
+    throw new SlabIdentityError(
+      "invalid-input",
+      "Identity fields must be short text values.",
+    );
+  }
+  return value.trim() || null;
+}
+export function normalizeCertificate(value: Certificate): Certificate {
+  const grader = textField(value.grader, 40)?.toUpperCase();
+  const certificateNumber = textField(value.certificateNumber, 80);
+  if (
+    !grader ||
+    !certificateNumber ||
+    !/^[A-Z0-9 -]+$/.test(grader) ||
+    !/^[a-zA-Z0-9-]+$/.test(certificateNumber)
+  ) {
+    throw new SlabIdentityError(
+      "invalid-input",
+      "Enter a grader and certificate number.",
+    );
+  }
+  return { grader, certificateNumber };
+}
+export function parseSlabIdentity(value: unknown): SlabIdentity {
+  const input = value as SlabIdentity | null;
+  if (!input || typeof input !== "object" || !input.card || !input.grading) {
+    throw new SlabIdentityError(
+      "invalid-input",
+      "Provide card identity and grading details.",
+    );
+  }
+  const card = Object.fromEntries(
+    CARD_FIELDS.map((field) => [field, textField(input.card[field])]),
+  ) as CardIdentity;
+  const grader = textField(input.grading.grader, 40)?.toUpperCase();
+  const encoding = textField(input.grading.encoding, 40);
+  const number = input.grading.number ?? null;
+  if (
+    !card.name ||
+    !grader ||
+    !encoding ||
+    (number !== null &&
+      (typeof number !== "number" ||
+        !Number.isFinite(number) ||
+        number < 1 ||
+        number > 10 ||
+        (number * 2) % 1 !== 0))
+  ) {
+    throw new SlabIdentityError(
+      "invalid-input",
+      "Provide a card name, grader and original grade encoding. Numeric grades must be between 1 and 10.",
+    );
+  }
+  let providerAsset: SlabIdentity["providerAsset"] = null;
+  if (input.providerAsset) {
+    const id = textField(input.providerAsset.id, 80);
+    if (
+      input.providerAsset.provider !== "alt" ||
+      !id ||
+      !/^[a-zA-Z0-9-]+$/.test(id)
+    ) {
+      throw new SlabIdentityError(
+        "invalid-input",
+        "Provide a valid provider asset reference.",
+      );
+    }
+    providerAsset = {
+      provider: "alt",
+      id,
+      title: textField(input.providerAsset.title, 500),
+    };
+  }
+  return {
+    card,
+    grading: {
+      grader,
+      encoding,
+      number,
+      label: textField(input.grading.label),
+      qualifier: textField(input.grading.qualifier),
+      autograph: textField(input.grading.autograph),
+    },
+    providerAsset,
+  };
+}
+export function normalizeExpectedIdentity(
+  expected: ExpectedSlabIdentity = {},
+): ExpectedSlabIdentity {
+  const gradeNumber = expected.gradeNumber ?? null;
+  if (
+    gradeNumber !== null &&
+    (typeof gradeNumber !== "number" ||
+      !Number.isFinite(gradeNumber) ||
+      gradeNumber < 1 ||
+      gradeNumber > 10)
+  ) {
+    throw new SlabIdentityError(
+      "invalid-input",
+      "Expected numeric grade must be between 1 and 10.",
+    );
+  }
+  return {
+    ...Object.fromEntries(
+      CARD_FIELDS.map((field) => [field, textField(expected[field])]),
+    ),
+    gradeNumber,
+    gradeLabel: textField(expected.gradeLabel),
+    qualifier: textField(expected.qualifier),
+    autograph: textField(expected.autograph),
+  };
+}
+export function identityConflicts(
+  identity: SlabIdentity | null,
+  expected: ExpectedSlabIdentity = {},
+): string[] {
+  const conflicts = CARD_FIELDS.flatMap((field) => {
+    const wanted = textField(expected[field]);
+    if (!wanted) return [];
+    const actual = identity?.card[field];
+    return actual?.toLowerCase() === wanted.toLowerCase()
+      ? []
+      : [`inventory-${field}-mismatch`];
+  });
+  if (
+    expected.gradeNumber != null &&
+    identity?.grading.number !== expected.gradeNumber
+  )
+    conflicts.push("inventory-grade-mismatch");
+  for (const [field, actual] of [
+    ["gradeLabel", identity?.grading.label],
+    ["qualifier", identity?.grading.qualifier],
+    ["autograph", identity?.grading.autograph],
+  ] as const) {
+    const wanted = textField(expected[field]);
+    if (wanted && actual?.toLowerCase() !== wanted.toLowerCase())
+      conflicts.push(`inventory-${field}-mismatch`);
+  }
+  return conflicts;
+}
+export function isCurrentIdentity(
+  record: StoredSlabIdentity,
+  reference: { slabId: string; revision: number; valuationGroupKey: string },
+): boolean {
+  return (
+    record.status === "confirmed" &&
+    record.id === reference.slabId &&
+    record.revision === reference.revision &&
+    record.valuationGroupKey === reference.valuationGroupKey
+  );
+}

--- a/app/features/ebay-slab-pricing/identity/slabIdentityService.server.ts
+++ b/app/features/ebay-slab-pricing/identity/slabIdentityService.server.ts
@@ -1,0 +1,145 @@
+import { createHash } from "node:crypto";
+import {
+  CARD_FIELDS,
+  identityConflicts,
+  normalizeCertificate,
+  normalizeExpectedIdentity,
+  parseSlabIdentity,
+  SlabIdentityError,
+  textField,
+  type ExpectedSlabIdentity,
+  type Certificate,
+  type IdentityCandidate,
+  type SlabIdentity,
+  type StoredSlabIdentity,
+} from "./slabIdentity";
+
+export type IdentityStore = {
+  find(certificate: Certificate): Promise<StoredSlabIdentity | null>;
+  saveCandidate(
+    certificate: Certificate,
+    candidate: IdentityCandidate | null,
+    reasons: string[],
+    revision?: number,
+  ): Promise<StoredSlabIdentity>;
+  confirm(
+    certificate: Certificate,
+    revision: number,
+    identity: SlabIdentity,
+    groupKey: string,
+    note: string,
+  ): Promise<StoredSlabIdentity | null>;
+};
+
+export function valuationGroupKey(identity: SlabIdentity): string {
+  // Ordered fields, explicit nulls and label/qualifier distinctions; no certificate/listing IDs.
+  const normalized = (value: string | null) =>
+    value?.trim().toLowerCase() ?? null;
+  const fields = [
+    ...CARD_FIELDS.map((field) => normalized(identity.card[field])),
+    identity.providerAsset?.provider ?? null,
+    identity.providerAsset?.id ?? null,
+    identity.grading.grader,
+    identity.grading.number ?? identity.grading.encoding,
+    normalized(identity.grading.label),
+    normalized(identity.grading.qualifier),
+    normalized(identity.grading.autograph),
+  ];
+  return createHash("sha256").update(JSON.stringify(fields)).digest("hex");
+}
+
+export function createSlabIdentityService(dependencies: {
+  store: IdentityStore;
+  lookupCertificate: (
+    certificateNumber: string,
+    signal?: AbortSignal,
+  ) => Promise<IdentityCandidate | null>;
+}) {
+  return {
+    async lookup(
+      input: Certificate,
+      options: {
+        expected?: ExpectedSlabIdentity;
+        refresh?: boolean;
+        signal?: AbortSignal;
+      } = {},
+    ) {
+      const certificate = normalizeCertificate(input);
+      const expected = normalizeExpectedIdentity(options.expected);
+      let record = await dependencies.store.find(certificate);
+      if (!record || (options.refresh && record.status !== "confirmed")) {
+        const candidate = await dependencies.lookupCertificate(
+          certificate.certificateNumber,
+          options.signal,
+        );
+        const reasons =
+          candidate === null
+            ? ["certificate-not-found"]
+            : [
+                ...(candidate.certificateNumber !==
+                certificate.certificateNumber
+                  ? ["certificate-mismatch"]
+                  : []),
+                ...(candidate.grader !== certificate.grader
+                  ? ["grader-mismatch"]
+                  : []),
+                ...(candidate.identity.grading.label === null
+                  ? ["grade-label-unresolved"]
+                  : []),
+                "confirmation-required",
+              ];
+        record = await dependencies.store.saveCandidate(
+          certificate,
+          candidate,
+          reasons,
+          record?.revision,
+        );
+      }
+      return {
+        record,
+        reviewReasons: [
+          ...record.reviewReasons,
+          ...identityConflicts(
+            record.identity ?? record.candidate?.identity ?? null,
+            expected,
+          ),
+        ],
+      };
+    },
+    async confirm(
+      input: Certificate,
+      revision: number,
+      value: unknown,
+      reason: unknown,
+    ) {
+      const certificate = normalizeCertificate(input);
+      const identity = parseSlabIdentity(value);
+      const note = textField(reason, 1000);
+      if (
+        !Number.isSafeInteger(revision) ||
+        revision < 1 ||
+        !note ||
+        identity.grading.grader !== certificate.grader ||
+        !identity.grading.label
+      ) {
+        throw new SlabIdentityError(
+          "invalid-input",
+          "Confirm the grader and exact grade label, and record the reason for this identity decision.",
+        );
+      }
+      const record = await dependencies.store.confirm(
+        certificate,
+        revision,
+        identity,
+        valuationGroupKey(identity),
+        note,
+      );
+      if (!record)
+        throw new SlabIdentityError(
+          "conflict",
+          "The identity changed. Reload it before confirming.",
+        );
+      return record;
+    },
+  };
+}

--- a/app/features/ebay-slab-pricing/routes/api.slab-identities.server.ts
+++ b/app/features/ebay-slab-pricing/routes/api.slab-identities.server.ts
@@ -1,0 +1,78 @@
+import { data } from "react-router";
+import { ProviderRequestError } from "../connections/providerRequest.server";
+import { CONNECTION_MESSAGES } from "../connections/providerConnection";
+import { SlabIdentityError } from "../identity/slabIdentity";
+import { slabIdentityService } from "../identity/slabIdentities.server";
+
+export function createSlabIdentityAction(service = slabIdentityService) {
+  return async ({ request }: { request: Request }) => {
+    const respond = (body: unknown, status = 200) =>
+      data(body, { status, headers: { "Cache-Control": "no-store" } });
+    if (request.method !== "POST")
+      return respond({ error: "Method not allowed." }, 405);
+    if (request.headers.get("Origin") !== new URL(request.url).origin)
+      return respond(
+        { error: "Submit this request from the application." },
+        403,
+      );
+    try {
+      const input = await request.json();
+      if (!input || typeof input !== "object")
+        throw new SlabIdentityError(
+          "invalid-input",
+          "Provide an identity request.",
+        );
+      const certificate = {
+        grader: input.grader,
+        certificateNumber: input.certificateNumber,
+      };
+      if (input.intent === "lookup") {
+        if (
+          input.expected !== undefined &&
+          (!input.expected ||
+            typeof input.expected !== "object" ||
+            Array.isArray(input.expected))
+        ) {
+          throw new SlabIdentityError(
+            "invalid-input",
+            "Expected card fields must be an object.",
+          );
+        }
+        return respond(
+          await service.lookup(certificate, {
+            expected: input.expected,
+            refresh: input.refresh === true,
+            signal: request.signal,
+          }),
+        );
+      }
+      if (input.intent === "confirm")
+        return respond({
+          record: await service.confirm(
+            certificate,
+            input.revision,
+            input.identity,
+            input.note,
+          ),
+        });
+      throw new SlabIdentityError("invalid-input", "Choose lookup or confirm.");
+    } catch (error) {
+      if (error instanceof SlabIdentityError)
+        return respond(
+          { error: error.message, code: error.code },
+          error.code === "conflict" ? 409 : 400,
+        );
+      if (error instanceof ProviderRequestError)
+        return respond(
+          { error: CONNECTION_MESSAGES[error.status], code: error.status },
+          503,
+        );
+      if (error instanceof SyntaxError)
+        return respond({ error: "Provide valid JSON." }, 400);
+      return respond(
+        { error: "Unable to resolve the identity. Try again." },
+        500,
+      );
+    }
+  };
+}

--- a/app/features/ebay-slab-pricing/routes/api.slab-identities.ts
+++ b/app/features/ebay-slab-pricing/routes/api.slab-identities.ts
@@ -1,0 +1,3 @@
+import { createSlabIdentityAction } from "./api.slab-identities.server";
+
+export const action = createSlabIdentityAction();

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,6 +1,10 @@
 import { type RouteConfig, index } from "@react-router/dev/routes";
 
 export default [
+  {
+    path: "/api/slab-identities",
+    file: "features/ebay-slab-pricing/routes/api.slab-identities.ts",
+  },
   index("routes/dashboard.tsx"),
   {
     path: "/pricer",

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -70,3 +70,4 @@ import "../features/inventory-strategy/services/forecastGrading.server.test";
 import "../features/pricing/algorithms/getSuggestedPriceFromLatestSales.test";
 import "../features/shipping-export/components/steps/PackStep.test";
 import "../features/ebay-slab-pricing/connections/providerConnections.test";
+import "../features/ebay-slab-pricing/identity/slabIdentity.test";

--- a/db/migrations/025_add_slab_identities.sql
+++ b/db/migrations/025_add_slab_identities.sql
@@ -1,0 +1,16 @@
+CREATE TABLE slab_identities (
+  id uuid PRIMARY KEY,
+  grader text NOT NULL,
+  certificate_number text NOT NULL,
+  candidate jsonb,
+  identity jsonb,
+  status text NOT NULL DEFAULT 'needs-review' CHECK (status IN ('needs-review', 'confirmed')),
+  review_reasons jsonb NOT NULL DEFAULT '[]',
+  valuation_group_key text,
+  revision integer NOT NULL DEFAULT 1,
+  decision_source text NOT NULL DEFAULT 'alt' CHECK (decision_source IN ('alt', 'manual')),
+  decision_note text,
+  updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+  UNIQUE (grader, certificate_number),
+  CHECK (status <> 'confirmed' OR (identity IS NOT NULL AND valuation_group_key IS NOT NULL))
+);

--- a/docs/ebay-slab-identities.md
+++ b/docs/ebay-slab-identities.md
@@ -1,0 +1,29 @@
+# Slab identities
+
+The identity slice distinguishes a physical slab (`grader` + `certificateNumber`), a provider's card/variant asset, and a valuation group. eBay listing IDs and seller SKUs belong to the later inventory slice; they are not certificate or card IDs. Migration 025 adds one table with a unique physical-item key and versioned identity decisions.
+
+Alt's `Cert` operation supplies a candidate, never a confirmed inventory identity. The included market-only fixture for certificate `110185364` resolves PSA 1 and asset `20c46c8c-4290-4953-b76f-5892bb442f87`. Its separate research page selection of PSA 10 does not enter this path. A live read through the configured host transport reproduced that result on September 5, 2026.
+
+Known fields are preserved; unknown language, edition and stamp stay null. Alt's variety is assigned to edition/finish only for exact known values, without title guessing. The original provider title, asset ID, certificate grade encoding and candidate remain stored when a user confirms or corrects an identity. Numeric PSA grades follow the [PSA scale](https://www.psacard.com/gradingstandards), excluding 9.5. CGC/BGS provider encodings are not converted to numeric grades automatically. In particular, CGC 0.0/10.5 remain unresolved, and [CGC's distinct Gem Mint and Pristine 10 labels](https://www.cgccards.com/card-grading/grading-scale/) require an explicit label decision. A manual numeric grade and exact label can be recorded without rewriting the original candidate.
+
+## Use-case contract
+
+`slabIdentityService.lookup({ grader, certificateNumber }, { expected?, refresh?, signal? })` returns `{ record, reviewReasons }`. First lookup stores the candidate (including not-found); repeated lookup reads PostgreSQL. Explicit refresh retries an unconfirmed candidate. Confirmed decisions are never silently refreshed from a provider. Inventory expectations can include card fields plus gradeNumber, gradeLabel, qualifier and autograph. A mismatch is returned even when the stored identity is confirmed; callers must check `reviewReasons` before using it for that inventory row.
+
+`slabIdentityService.confirm(certificate, revision, identity, note)` records explicit confirmation or correction. It requires the known grader, an exact grade label and a decision note. Unknown card fields can remain null. Confirmation is not proof that enough evidence exists to price the group. A stale revision produces a conflict rather than overwriting another decision.
+
+Both operations are exposed by same-origin `POST /api/slab-identities`, using JSON with `intent: "lookup"` or `intent: "confirm"`, `grader`, `certificateNumber`, and the operation's remaining fields. Lookup takes `expected` and `refresh`; confirmation takes `revision`, `identity`, and `note`. The review UI is tracked separately in #28.
+
+Valuation groups hash ordered card fields, provider asset reference, grader, resolved grade/label, qualifiers and autograph. Certificates are excluded so identical slabs share evidence. Unknown fields remain distinct from specified fields. Every decision advances `revision`; later recommendations must store `{ slabId, revision, valuationGroupKey }` and use `isCurrentIdentity` before displaying them as current or publishing. Corrections therefore invalidate older references, including a correction that later returns to the original group. No unused recommendation table is introduced here.
+
+## Verification
+
+`npm test` covers the certificate fixture, unsupported grade encodings, label distinctions, inventory mismatches, manual fallback, confirmed-cache reuse, stale decisions, API validation and correction invalidation.
+
+Run the optional PostgreSQL test with:
+
+```sh
+npx tsx app/features/ebay-slab-pricing/identity/slabIdentity.integration.test.ts
+```
+
+It uses a disposable schema in the local development database and verifies concurrent duplicate imports, grader collisions, competing corrections, confirmed mapping reuse, original provenance retention and stale-provider fencing. It makes no network requests and uses no real session credentials.


### PR DESCRIPTION
A certificate lookup must identify the owned slab independently of the research page's selected grade. This adds an Alt Cert adapter, stored identity candidates, explicit confirmation/correction, and a same-origin API. Certificate 110185364 resolves PSA 1 even when research is set to PSA 10.

Physical items use a unique grader/certificate pair. Confirmed mappings are reused without another provider request, ambiguous labels and inventory conflicts stay visible, and revision-checked corrections invalidate older valuation references. Valuation groups include card variants, grader, exact grade label and qualifiers, while excluding certificate/listing IDs. The feature uses one PostgreSQL table and small injected functions; no dependencies or new services.

Validation: full tests, typecheck, production build, and isolated PostgreSQL tests passed. Live Alt lookup and the app API reproduced PSA 1 and flagged a conflicting inventory grade of 10. Tests cover missing/mismatched certs, grader collisions, CGC/BGS label distinctions, duplicate imports, stale concurrent corrections, metadata conflicts, cache reuse and original provenance retention.

Adversarial review corrected the initial treatment of Alt variety as finish, added inventory grade/label checks alongside language/edition/stamp checks, moved invalid-input validation before provider I/O, and kept the route's implementation server-only. Regression checks passed; the final pass found no remaining actionable issues across composability, simplicity, design, performance and footprint.

Apply migration 025 through the existing runner. The UI follows in #28; this PR provides its lookup and manual-decision API. Later recommendations must retain the slab revision/group reference and use the supplied current-identity check. Setup and contracts are documented in `docs/ebay-slab-identities.md`.

Fixes #21.
