### PR TITLE
Provide capped Alt slab sales and lazy evidence enrichment

### DIFF
--- a/app/features/ebay-slab-pricing/evidence/altEvidenceProvider.server.ts
+++ b/app/features/ebay-slab-pricing/evidence/altEvidenceProvider.server.ts
@@ -1,0 +1,357 @@
+import {
+  ProviderRequestError,
+  type createProviderRequest,
+} from "../connections/providerRequest.server";
+import {
+  altCard,
+  altGrading as parseGrading,
+} from "../identity/altIdentityFields.server";
+import type {
+  EvidenceWindow,
+  Money,
+  SaleEvidence,
+  SalesEvidenceResult,
+  SupplyEvidence,
+} from "./slabEvidence";
+
+const TRANSACTIONS = `query AssetMarketTransactions($id: ID!, $marketTransactionFilter: MarketTransactionFilter!) {
+  asset(id: $id) { id marketTransactions(marketTransactionFilter: $marketTransactionFilter) {
+    id date auctionHouse auctionType price label subjectToChange consolidatedSkippedReason
+    attributes { gradeNumber gradingCompany url autograph }
+  } }
+}`;
+const DETAIL = `query SoldListing($id: ID!) { externalTransaction(id: $id) {
+  id date auctionHouse auctionName auctionType displayPrice label fees shipping usdAmount currency
+  consolidatedSkippedReason subjectToChange
+  asset { id name year subject category brand variety attributes { cardNumber } }
+  attributes { grade gradingCompany cert url autograph }
+} }`;
+const SUPPLY = `query AssetDetails($id: ID!) { asset(id: $id) { id activeListings {
+  id listPrice state createdAt type expiresAt
+  items { id attributes { gradeNumber gradingCompany autograph qualifier } asset { id } }
+} } }`;
+const MAX_ROWS = 2000;
+const MAX_DETAILS = 32;
+type ObjectValue = Record<string, unknown>;
+const invalid = () => new ProviderRequestError("invalid-response");
+function altGrading(...args: Parameters<typeof parseGrading>) {
+  try {
+    return parseGrading(...args);
+  } catch {
+    throw invalid();
+  }
+}
+function object(value: unknown): ObjectValue {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw invalid();
+  return value as ObjectValue;
+}
+function text(value: unknown): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (typeof value !== "string" || value.length > 2000) throw invalid();
+  return value.trim() || null;
+}
+function id(value: unknown): string {
+  const result = text(value);
+  if (!result || !/^[a-zA-Z0-9-]{1,80}$/.test(result)) throw invalid();
+  return result;
+}
+function boolean(value: unknown): boolean | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "boolean") throw invalid();
+  return value;
+}
+function money(value: unknown, currency: string | null): Money | null {
+  if (value === null || value === undefined || value === "") return null;
+  if (
+    typeof value !== "number" &&
+    (typeof value !== "string" || !/^\d+(?:\.\d+)?$/.test(value))
+  )
+    throw invalid();
+  const amount = Number(value);
+  if (
+    !Number.isFinite(amount) ||
+    amount < 0 ||
+    amount > Number.MAX_SAFE_INTEGER / 100
+  )
+    throw invalid();
+  return { amount, currency };
+}
+function date(value: unknown): string | null {
+  const result = text(value);
+  if (result === null) return null;
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(result) ||
+    !Number.isFinite(Date.parse(result)) ||
+    new Date(result).toISOString().slice(0, 10) !== result
+  )
+    throw invalid();
+  return result;
+}
+function rows(value: unknown): unknown[] {
+  if (!Array.isArray(value) || value.length > MAX_ROWS) throw invalid();
+  return value;
+}
+function data(body: string): ObjectValue {
+  let result;
+  try {
+    result = object(JSON.parse(body));
+  } catch {
+    throw invalid();
+  }
+  if (
+    Array.isArray(result.errors) &&
+    result.errors.some(
+      (error) =>
+        object(object(error).extensions ?? {}).code === "UNAUTHENTICATED",
+    )
+  )
+    throw new ProviderRequestError("reconnect-required");
+  if (
+    result.errors !== undefined &&
+    (!Array.isArray(result.errors) || result.errors.length)
+  )
+    throw invalid();
+  return object(result.data);
+}
+function source(
+  value: unknown,
+): Pick<SaleEvidence, "sourceUrl" | "sourceItemId"> {
+  const raw = text(value);
+  if (!raw) return { sourceUrl: null, sourceItemId: null };
+  try {
+    const url = new URL(raw);
+    if (
+      !["https:", "http:"].includes(url.protocol) ||
+      url.username ||
+      url.password
+    )
+      return { sourceUrl: null, sourceItemId: null };
+    const ebay = /(^|\.)ebay\.com$/i.test(url.hostname);
+    return {
+      sourceUrl: url.toString(),
+      sourceItemId: ebay
+        ? (url.pathname.match(/\/itm\/(?:[^/]+\/)?(\d+)(?:\/|$)/)?.[1] ?? null)
+        : null,
+    };
+  } catch {
+    return { sourceUrl: null, sourceItemId: null };
+  }
+}
+function sale(value: unknown, assetId: string, detail = false): SaleEvidence {
+  const row = object(value);
+  const attributes = row.attributes == null ? {} : object(row.attributes);
+  const currency = detail ? (text(row.currency)?.toUpperCase() ?? null) : null;
+  if (currency !== null && !/^[A-Z]{3}$/.test(currency)) throw invalid();
+  return {
+    provider: "alt",
+    providerId: id(row.id),
+    assetId,
+    ...source(attributes.url),
+    sourceReference: text(attributes.url),
+    venue: text(row.auctionHouse),
+    kind: "transaction",
+    date: date(row.date),
+    format: text(row.auctionType),
+    title: detail ? text(row.auctionName) : null,
+    card: null,
+    grading: altGrading(attributes, row.label),
+    certificateNumber: detail ? text(attributes.cert) : null,
+    price: money(detail ? row.displayPrice : row.price, currency),
+    convertedPrice: detail ? money(row.usdAmount, "USD") : null,
+    shipping: detail ? money(row.shipping, currency) : null,
+    fees: detail ? money(row.fees, currency) : null,
+    shippingIncluded: null,
+    buyerPremiumIncluded: null,
+    quantity: null,
+    subjectToChange: boolean(row.subjectToChange),
+    skippedReason: text(row.consolidatedSkippedReason),
+  };
+}
+
+export function parseAltSales(
+  body: string,
+  assetId: string,
+  window: EvidenceWindow,
+  limitPerGrade: number,
+  asOf: string,
+): SalesEvidenceResult {
+  const asset = object(data(body).asset);
+  if (asset.id !== assetId) throw invalid();
+  const observations = rows(asset.marketTransactions).map((row) =>
+    sale(row, assetId),
+  );
+  const dates = observations
+    .flatMap((row) => (row.date ? [row.date] : []))
+    .sort();
+  return {
+    // Missing dates remain reviewable but cannot establish window coverage.
+    sales: observations.filter(
+      (row) =>
+        row.date === null || (row.date >= window.from && row.date <= window.to),
+    ),
+    asOf,
+    coverage: {
+      requestedWindow: window,
+      observedWindow: dates.length
+        ? { from: dates[0], to: dates[dates.length - 1] }
+        : null,
+      complete: false,
+      reason: "capped-per-grade",
+      sourceCount: observations.length,
+      limitPerGrade,
+    },
+  };
+}
+export function parseAltSaleDetail(
+  body: string,
+  transactionId: string,
+): SaleEvidence | null {
+  const result = data(body);
+  if (result.externalTransaction === null) return null;
+  const row = object(result.externalTransaction);
+  if (row.id !== transactionId) throw invalid();
+  const asset = object(row.asset);
+  const normalized = sale(row, id(asset.id), true);
+  try {
+    normalized.card = altCard(asset);
+  } catch {
+    throw invalid();
+  }
+  return normalized;
+}
+export function parseAltSupply(
+  body: string,
+  assetId: string,
+): SupplyEvidence[] {
+  const asset = object(data(body).asset);
+  if (asset.id !== assetId) throw invalid();
+  return rows(asset.activeListings).map((value) => {
+    const row = object(value);
+    return {
+      provider: "alt",
+      providerId: id(row.id),
+      assetId,
+      venue: "Alt",
+      sourceUrl: null,
+      format: text(row.type),
+      state: text(row.state),
+      price: money(row.listPrice, null),
+      priceKind: "unknown",
+      shipping: null,
+      quantity: null,
+      startedAt: text(row.createdAt),
+      endsAt: text(row.expiresAt),
+      items: rows(row.items).map((value) => {
+        const item = object(value);
+        return {
+          assetId: item.asset == null ? null : id(object(item.asset).id),
+          grading: altGrading(
+            item.attributes == null ? {} : object(item.attributes),
+          ),
+        };
+      }),
+    };
+  });
+}
+
+/** Create once per valuation run: bounded detail memoization shares that run's cancellation. */
+export function createAltEvidenceProvider(
+  request: ReturnType<typeof createProviderRequest>,
+  options: { signal?: AbortSignal; now?: () => Date } = {},
+) {
+  const details = new Map<string, Promise<SaleEvidence | null>>();
+  const asOf = () => (options.now?.() ?? new Date()).toISOString();
+  async function read<T>(
+    operation: string,
+    query: string,
+    variables: object,
+    parse: (body: string) => T,
+  ): Promise<T> {
+    let result: T;
+    await request(
+      "alt",
+      {
+        path: `/graphql/${operation}`,
+        body: JSON.stringify({ operationName: operation, variables, query }),
+      },
+      {
+        signal: options.signal,
+        validate: (body) => {
+          result = parse(body);
+        },
+      },
+    );
+    return result!;
+  }
+  return {
+    async getSales(
+      assetId: string,
+      window: EvidenceWindow,
+      limitPerGrade = 16,
+    ) {
+      assetId = id(assetId);
+      const from = date(window.from);
+      const to = date(window.to);
+      if (
+        !from ||
+        !to ||
+        from > to ||
+        !Number.isInteger(limitPerGrade) ||
+        limitPerGrade < 1 ||
+        limitPerGrade > 16
+      )
+        throw invalid();
+      window = { from, to };
+      const capturedAt = asOf();
+      return read(
+        "AssetMarketTransactions",
+        TRANSACTIONS,
+        {
+          id: assetId,
+          marketTransactionFilter: {
+            allGrades: true,
+            showSkipped: true,
+            maxTransactionsPerGrade: limitPerGrade,
+          },
+        },
+        (body) =>
+          parseAltSales(body, assetId, window, limitPerGrade, capturedAt),
+      );
+    },
+    getSaleDetail(transactionId: string): Promise<SaleEvidence | null> {
+      transactionId = id(transactionId);
+      if (options.signal?.aborted) throw new ProviderRequestError("cancelled");
+      const existing = details.get(transactionId);
+      if (existing) return existing;
+      if (details.size >= MAX_DETAILS) throw new ProviderRequestError("busy");
+      const pending = read(
+        "SoldListing",
+        DETAIL,
+        { id: transactionId },
+        (body) => parseAltSaleDetail(body, transactionId),
+      );
+      details.set(transactionId, pending);
+      pending.catch(() => {
+        details.delete(transactionId);
+      });
+      return pending;
+    },
+    async getSupply(assetId: string) {
+      assetId = id(assetId);
+      const capturedAt = asOf();
+      const listings = await read(
+        "AssetDetails",
+        SUPPLY,
+        { id: assetId },
+        (body) => parseAltSupply(body, assetId),
+      );
+      return {
+        listings,
+        asOf: capturedAt,
+        scope: "alt-only" as const,
+        complete: false as const,
+      };
+    },
+  };
+}

--- a/app/features/ebay-slab-pricing/evidence/altEvidenceProvider.test.ts
+++ b/app/features/ebay-slab-pricing/evidence/altEvidenceProvider.test.ts
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import salesFixture from "./fixtures/alt-sales.json";
+import detailFixture from "./fixtures/alt-sale-detail.json";
+import {
+  createAltEvidenceProvider,
+  parseAltSales,
+  parseAltSaleDetail,
+  parseAltSupply,
+} from "./altEvidenceProvider.server";
+import { createProviderRequest } from "../connections/providerRequest.server";
+
+const assetId = salesFixture.data.asset.id;
+const window = { from: "2020-01-01", to: "2026-09-05" };
+const capturedAt = "2026-09-05T22:00:00Z";
+const parsed = parseAltSales(
+  JSON.stringify(salesFixture),
+  assetId,
+  window,
+  16,
+  capturedAt,
+);
+assert.equal(parsed.coverage.complete, false);
+assert.equal(parsed.coverage.limitPerGrade, 16);
+assert.equal(parsed.coverage.reason, "capped-per-grade");
+assert.ok(parsed.sales.some((row) => row.skippedReason));
+assert.ok(
+  parsed.sales.some(
+    (row) => row.grading.encoding === "10.5" && row.grading.number === null,
+  ),
+);
+assert.ok(
+  parsed.sales.every(
+    (row) => row.price?.currency === null && row.shipping === null,
+  ),
+);
+assert.ok(parsed.sales.some((row) => row.sourceItemId));
+const narrow = parseAltSales(
+  JSON.stringify(salesFixture),
+  assetId,
+  { from: "2026-09-04", to: "2026-09-05" },
+  16,
+  capturedAt,
+);
+assert.ok(
+  narrow.sales.every((row) => row.date === null || row.date >= "2026-09-04"),
+);
+assert.equal(narrow.coverage.sourceCount, parsed.coverage.sourceCount);
+assert.deepEqual(
+  narrow.coverage.observedWindow,
+  parsed.coverage.observedWindow,
+);
+const detailId = detailFixture.data.externalTransaction.id;
+const detail = parseAltSaleDetail(JSON.stringify(detailFixture), detailId)!;
+assert.equal(detail.price?.amount, 27.46);
+assert.equal(detail.price?.currency, null);
+assert.deepEqual(detail.convertedPrice, { amount: 27.46, currency: "USD" });
+assert.deepEqual(detail.shipping, { amount: 17.59, currency: null });
+assert.equal(detail.fees, null);
+assert.equal(detail.shippingIncluded, null);
+assert.equal(detail.buyerPremiumIncluded, null);
+assert.equal(detail.card?.edition, "1st Edition");
+assert.equal(detail.sourceItemId, "335037487554");
+assert.equal(
+  parseAltSaleDetail('{"data":{"externalTransaction":null}}', detailId),
+  null,
+);
+for (const fixture of [
+  { data: { asset: { id: assetId, marketTransactions: null } } },
+  { data: salesFixture.data, errors: [{ message: "partial response" }] },
+  { data: { asset: { id: "wrong", marketTransactions: [] } } },
+]) {
+  assert.throws(
+    () =>
+      parseAltSales(JSON.stringify(fixture), assetId, window, 16, capturedAt),
+    { status: "invalid-response" },
+  );
+}
+assert.throws(
+  () =>
+    parseAltSales(
+      '{"errors":[{"extensions":{"code":"UNAUTHENTICATED"}}]}',
+      assetId,
+      window,
+      16,
+      capturedAt,
+    ),
+  { status: "reconnect-required" },
+);
+const incomplete = structuredClone(salesFixture);
+Object.assign(incomplete.data.asset.marketTransactions[0], {
+  date: null,
+  price: null,
+  subjectToChange: true,
+});
+const incompleteRow = parseAltSales(
+  JSON.stringify(incomplete),
+  assetId,
+  window,
+  16,
+  capturedAt,
+).sales[0];
+assert.equal(incompleteRow.date, null);
+assert.equal(incompleteRow.price, null);
+assert.equal(incompleteRow.subjectToChange, true);
+const unsafeUrl = structuredClone(salesFixture);
+unsafeUrl.data.asset.marketTransactions[0].attributes.url =
+  "javascript:alert(1)";
+assert.equal(
+  parseAltSales(JSON.stringify(unsafeUrl), assetId, window, 16, capturedAt)
+    .sales[0].sourceUrl,
+  null,
+);
+assert.deepEqual(
+  parseAltSupply(
+    JSON.stringify({ data: { asset: { id: assetId, activeListings: [] } } }),
+    assetId,
+  ),
+  [],
+);
+const supplied = parseAltSupply(
+  JSON.stringify({
+    data: {
+      asset: {
+        id: assetId,
+        activeListings: [
+          {
+            id: "listing",
+            state: "ACTIVE",
+            type: "unknown-new-format",
+            listPrice: "123.45",
+            items: [
+              {
+                asset: { id: assetId },
+                attributes: { gradingCompany: "PSA", gradeNumber: "9.0" },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  }),
+  assetId,
+)[0];
+assert.equal(supplied.priceKind, "unknown");
+assert.equal(supplied.price?.currency, null);
+assert.equal(supplied.quantity, null);
+
+let calls = 0;
+const provider = createAltEvidenceProvider(
+  createProviderRequest(
+    {
+      claim: async () => ({
+        id: "fixture",
+        revision: 1,
+        credential: "fixture",
+        userAgent: "",
+      }),
+      release: async () => {},
+    },
+    async (_url, init) => {
+      calls++;
+      const operation = JSON.parse(String(init?.body));
+      if (operation.operationName === "SoldListing")
+        return new Response(JSON.stringify(detailFixture));
+      assert.equal(operation.variables.marketTransactionFilter.allGrades, true);
+      assert.equal(
+        operation.variables.marketTransactionFilter.showSkipped,
+        true,
+      );
+      assert.equal(
+        operation.variables.marketTransactionFilter.maxTransactionsPerGrade,
+        16,
+      );
+      assert.ok(!("tsFilter" in operation.variables));
+      return new Response(JSON.stringify(salesFixture));
+    },
+  ),
+  { now: () => new Date(capturedAt) },
+);
+await provider.getSales(assetId, window);
+assert.equal(calls, 1, "history does not fetch details eagerly");
+const [first, second] = await Promise.all([
+  provider.getSaleDetail(detailId),
+  provider.getSaleDetail(detailId),
+]);
+assert.equal(first, second);
+assert.equal(calls, 2, "concurrent detail requests share one read");
+await provider.getSaleDetail(detailId);
+assert.equal(calls, 2);
+await provider.getSaleDetail(` ${detailId} `);
+assert.equal(calls, 2, "normalized detail IDs share the same memoized read");
+let attempts = 0;
+const limited = createAltEvidenceProvider(
+  createProviderRequest(
+    {
+      claim: async () => ({
+        id: "fixture",
+        revision: 1,
+        credential: "fixture",
+        userAgent: "",
+      }),
+      release: async () => {},
+    },
+    async () => {
+      attempts++;
+      return new Response('{"data":{"externalTransaction":null}}');
+    },
+  ),
+);
+for (let index = 0; index < 32; index++)
+  await limited.getSaleDetail(`detail-${index}`);
+assert.throws(() => limited.getSaleDetail("detail-33"), { status: "busy" });
+assert.equal(attempts, 32);
+await assert.rejects(
+  provider.getSales(assetId, { from: "2026-02-30", to: "2026-09-05" }),
+  { status: "invalid-response" },
+);
+{
+  let failures = 0;
+  const retrying = createAltEvidenceProvider(
+    createProviderRequest(
+      {
+        claim: async () => ({
+          id: "fixture",
+          revision: 1,
+          credential: "fixture",
+          userAgent: "",
+        }),
+        release: async () => {},
+      },
+      async () => {
+        failures++;
+        return new Response(
+          JSON.stringify(
+            failures === 1
+              ? { data: detailFixture.data, errors: [{ message: "partial" }] }
+              : detailFixture,
+          ),
+        );
+      },
+    ),
+  );
+  await assert.rejects(retrying.getSaleDetail(detailId), {
+    status: "invalid-response",
+  });
+  await retrying.getSaleDetail(detailId);
+  assert.equal(failures, 2, "failed details are not cached");
+  const cancelled = createAltEvidenceProvider(
+    createProviderRequest({
+      claim: async () => {
+        throw Error("Must not fetch");
+      },
+      release: async () => {},
+    }),
+    { signal: AbortSignal.abort("private cancellation reason") },
+  );
+  assert.throws(() => cancelled.getSaleDetail(detailId), {
+    status: "cancelled",
+  });
+}
+console.log(
+  "PASS capped Alt evidence, explicit monetary uncertainty, lazy bounded details, partial errors and supply separation",
+);

--- a/app/features/ebay-slab-pricing/evidence/fixtures/alt-sale-detail.json
+++ b/app/features/ebay-slab-pricing/evidence/fixtures/alt-sale-detail.json
@@ -1,0 +1,39 @@
+{
+  "data": {
+    "externalTransaction": {
+      "date": "2026-09-05",
+      "id": "11020cc4-2783-494b-86b8-7d90c3ecc298",
+      "auctionHouse": "eBay",
+      "auctionName": "1999 Ponyta 60/102 Base Set 1st Edition PSA 4 VG-EX Pokemon TCG",
+      "auctionType": "BEST_OFFER",
+      "displayPrice": 27.46,
+      "label": "",
+      "fees": null,
+      "shipping": 17.59,
+      "usdAmount": 27.46,
+      "consolidatedSkippedReason": null,
+      "currency": null,
+      "asset": {
+        "id": "cd3ecabf-7d43-4375-9428-1a7cdfe66426",
+        "name": "1999 Pokemon Base Set 1st Edition Ponyta #60",
+        "year": 1999,
+        "subject": "Ponyta",
+        "category": "POKEMON_CARDS",
+        "brand": "Pokemon Base Set",
+        "variety": "1st Edition",
+        "attributes": {
+          "cardNumber": "60",
+          "printRun": null
+        }
+      },
+      "attributes": {
+        "grade": "4.0",
+        "gradingCompany": "PSA",
+        "cert": null,
+        "url": "https://www.ebay.com/itm/335037487554",
+        "autograph": null
+      },
+      "subjectToChange": false
+    }
+  }
+}

--- a/app/features/ebay-slab-pricing/evidence/fixtures/alt-sales.json
+++ b/app/features/ebay-slab-pricing/evidence/fixtures/alt-sales.json
@@ -1,0 +1,73 @@
+{
+  "data": {
+    "asset": {
+      "id": "cd3ecabf-7d43-4375-9428-1a7cdfe66426",
+      "marketTransactions": [
+        {
+          "id": "d7bcc0d1-1305-48e4-ab06-b17451f02780",
+          "date": "2026-09-04",
+          "auctionHouse": "Alt",
+          "auctionType": "AUCTION",
+          "price": "79.20",
+          "attributes": {
+            "gradeNumber": "9.0",
+            "gradingCompany": "PSA",
+            "url": "ab984d1c-d1ad-44ab-961e-fb3b3a63bba2",
+            "autograph": null
+          },
+          "subjectToChange": false,
+          "consolidatedSkippedReason": "PENDING",
+          "label": ""
+        },
+        {
+          "id": "52d35b8b-c1d8-438d-96f0-4b58c9addba2",
+          "date": "2026-08-02",
+          "auctionHouse": "PWCC Weekly Auctions",
+          "auctionType": "AUCTION",
+          "price": "15.60",
+          "attributes": {
+            "gradeNumber": "0.0",
+            "gradingCompany": "CGC",
+            "url": "https://www.fanaticscollect.com/weekly/1d1e4946-879c-11f1-be85-0ad68bfbd9dd",
+            "autograph": null
+          },
+          "subjectToChange": false,
+          "consolidatedSkippedReason": null,
+          "label": ""
+        },
+        {
+          "id": "1eb317f0-3048-467c-81e5-e6000cbc548c",
+          "date": "2024-11-03",
+          "auctionHouse": "PWCC Weekly Auctions",
+          "auctionType": "AUCTION",
+          "price": "336.00",
+          "attributes": {
+            "gradeNumber": "10.5",
+            "gradingCompany": "CGC",
+            "url": "https://www.fanaticscollect.com/weekly/b09db9dc-868a-11ef-b578-0a58a9feac02",
+            "autograph": null
+          },
+          "subjectToChange": false,
+          "consolidatedSkippedReason": null,
+          "label": ""
+        },
+        {
+          "id": "11020cc4-2783-494b-86b8-7d90c3ecc298",
+          "date": "2026-09-05",
+          "auctionHouse": "eBay",
+          "auctionType": "BEST_OFFER",
+          "price": "27.46",
+          "attributes": {
+            "gradeNumber": "4.0",
+            "gradingCompany": "PSA",
+            "url": "https://www.ebay.com/itm/335037487554",
+            "autograph": null
+          },
+          "subjectToChange": false,
+          "consolidatedSkippedReason": null,
+          "label": ""
+        }
+      ]
+    }
+  }
+}

--- a/app/features/ebay-slab-pricing/evidence/slabEvidence.server.ts
+++ b/app/features/ebay-slab-pricing/evidence/slabEvidence.server.ts
@@ -1,0 +1,9 @@
+import { createProviderRequest } from "../connections/providerRequest.server";
+import { providerRequestGate } from "../connections/providerConnections.server";
+import { createAltEvidenceProvider } from "./altEvidenceProvider.server";
+
+export function createAltEvidenceForRun(signal?: AbortSignal) {
+  return createAltEvidenceProvider(createProviderRequest(providerRequestGate), {
+    signal,
+  });
+}

--- a/app/features/ebay-slab-pricing/evidence/slabEvidence.ts
+++ b/app/features/ebay-slab-pricing/evidence/slabEvidence.ts
@@ -1,0 +1,57 @@
+import type { SlabIdentity } from "../identity/slabIdentity";
+
+export type EvidenceWindow = { from: string; to: string };
+export type Money = { amount: number; currency: string | null };
+export type SaleEvidence = {
+  provider: "alt" | "ebayResearch";
+  providerId: string;
+  assetId: string | null;
+  sourceUrl: string | null;
+  sourceReference: string | null;
+  sourceItemId: string | null;
+  venue: string | null;
+  kind: "transaction" | "listing-average";
+  date: string | null;
+  format: string | null;
+  title: string | null;
+  card: SlabIdentity["card"] | null;
+  grading: SlabIdentity["grading"];
+  certificateNumber: string | null;
+  price: Money | null;
+  convertedPrice: Money | null;
+  shipping: Money | null;
+  fees: Money | null;
+  shippingIncluded: boolean | null;
+  buyerPremiumIncluded: boolean | null;
+  quantity: number | null;
+  subjectToChange: boolean | null;
+  skippedReason: string | null;
+};
+export type SalesEvidenceResult = {
+  sales: SaleEvidence[];
+  asOf: string;
+  coverage: {
+    requestedWindow: EvidenceWindow;
+    observedWindow: EvidenceWindow | null;
+    complete: false;
+    reason: "capped-per-grade" | "paged-search";
+    sourceCount: number;
+    limitPerGrade: number | null;
+  };
+};
+export type SupplyEvidence = {
+  provider: "alt" | "ebayResearch";
+  providerId: string;
+  assetId: string | null;
+  venue: string;
+  sourceUrl: string | null;
+  format: string | null;
+  state: string | null;
+  price: Money | null;
+  priceKind: "ask" | "bid" | "unknown";
+  shipping: Money | null;
+  quantity: number | null;
+  startedAt: string | null;
+  endsAt: string | null;
+  items: Array<{ assetId: string | null; grading: SlabIdentity["grading"] }>;
+};

--- a/app/features/ebay-slab-pricing/identity/altIdentityFields.server.ts
+++ b/app/features/ebay-slab-pricing/identity/altIdentityFields.server.ts
@@ -1,0 +1,68 @@
+import {
+  CARD_FIELDS,
+  SlabIdentityError,
+  textField,
+  type CardIdentity,
+  type SlabIdentity,
+} from "./slabIdentity";
+
+export function altGrading(
+  attributes: Record<string, unknown>,
+  label?: unknown,
+): SlabIdentity["grading"] {
+  const grader =
+    textField(attributes.gradingCompany, 40)?.toUpperCase() ?? "UNKNOWN";
+  const encoding =
+    textField(attributes.gradeNumber ?? attributes.grade, 40) ?? "unknown";
+  const numeric = /^\d+(?:\.\d+)?$/.test(encoding) ? Number(encoding) : NaN;
+  // Only PSA's ordinary numeric encoding is verified. Preserve other encodings verbatim.
+  const number =
+    grader === "PSA" &&
+    numeric >= 1 &&
+    numeric <= 10 &&
+    numeric !== 9.5 &&
+    (numeric * 2) % 1 === 0
+      ? numeric
+      : null;
+  return {
+    grader,
+    encoding,
+    number,
+    label: textField(label) ?? (number === null ? null : `PSA ${number}`),
+    qualifier: textField(attributes.qualifier),
+    autograph: textField(attributes.autograph),
+  };
+}
+
+export function altCard(asset: Record<string, unknown>): CardIdentity {
+  const attributes = asset.attributes as Record<string, unknown> | null;
+  if (
+    attributes != null &&
+    (typeof attributes !== "object" || Array.isArray(attributes))
+  )
+    throw new SlabIdentityError("invalid-input", "Invalid card attributes.");
+  if (
+    asset.year != null &&
+    (typeof asset.year !== "number" || !Number.isSafeInteger(asset.year))
+  )
+    throw new SlabIdentityError("invalid-input", "Invalid card year.");
+  const fields = {
+    name: asset.subject ?? asset.name,
+    game: asset.category === "POKEMON_CARDS" ? "Pokemon" : null,
+    language: null,
+    set: asset.brand,
+    cardNumber: attributes?.cardNumber,
+    year: asset.year == null ? null : String(asset.year),
+    edition: asset.variety === "1st Edition" ? "1st Edition" : null,
+    finish: ["Reverse Holo", "Holo", "Non-Holo"].includes(String(asset.variety))
+      ? asset.variety
+      : null,
+    stamp: null,
+  };
+  const card = Object.fromEntries(
+    CARD_FIELDS.map((field) => [field, textField(fields[field])]),
+  ) as CardIdentity;
+  if (!card.name)
+    throw new SlabIdentityError("invalid-input", "Missing card name.");
+  return card;
+}

--- a/app/features/ebay-slab-pricing/identity/altIdentityProvider.server.ts
+++ b/app/features/ebay-slab-pricing/identity/altIdentityProvider.server.ts
@@ -7,6 +7,7 @@ import {
   parseSlabIdentity,
   type IdentityCandidate,
 } from "./slabIdentity";
+import { altCard, altGrading } from "./altIdentityFields.server";
 
 const CERT_QUERY = `query Cert($certNumber: String!) {
   cert(certNumber: $certNumber) {
@@ -42,44 +43,11 @@ export function parseAltCertificate(body: string): IdentityCandidate | null {
     ) {
       throw new ProviderRequestError("invalid-response");
     }
-    const numeric = /^\d+(?:\.\d+)?$/.test(cert.gradeNumber)
-      ? Number(cert.gradeNumber)
-      : NaN;
-    // PSA's scale is verified. Other provider encodings need an explicit label decision.
-    const number =
-      certificate.grader === "PSA" &&
-      numeric >= 1 &&
-      numeric <= 10 &&
-      numeric !== 9.5 &&
-      (numeric * 2) % 1 === 0
-        ? numeric
-        : null;
     return {
       ...certificate,
       identity: parseSlabIdentity({
-        card: {
-          name: cert.asset.subject ?? cert.asset.name,
-          game: cert.asset.category === "POKEMON_CARDS" ? "Pokemon" : null,
-          language: null,
-          set: cert.asset.brand ?? null,
-          cardNumber: cert.asset.attributes?.cardNumber ?? null,
-          year: cert.asset.year == null ? null : String(cert.asset.year),
-          edition: cert.asset.variety === "1st Edition" ? "1st Edition" : null,
-          finish: ["Reverse Holo", "Holo", "Non-Holo"].includes(
-            cert.asset.variety,
-          )
-            ? cert.asset.variety
-            : null,
-          stamp: null,
-        },
-        grading: {
-          grader: certificate.grader,
-          encoding: cert.gradeNumber,
-          number,
-          label: number === null ? null : `PSA ${number}`,
-          qualifier: cert.qualifier,
-          autograph: cert.autograph,
-        },
+        card: altCard(cert.asset),
+        grading: altGrading(cert),
         providerAsset: {
           provider: "alt",
           id: cert.asset.id,

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -71,3 +71,4 @@ import "../features/pricing/algorithms/getSuggestedPriceFromLatestSales.test";
 import "../features/shipping-export/components/steps/PackStep.test";
 import "../features/ebay-slab-pricing/connections/providerConnections.test";
 import "../features/ebay-slab-pricing/identity/slabIdentity.test";
+import "../features/ebay-slab-pricing/evidence/altEvidenceProvider.test";

--- a/docs/ebay-slab-alt-evidence.md
+++ b/docs/ebay-slab-alt-evidence.md
@@ -1,0 +1,21 @@
+# Alt sale and supply evidence
+
+`createAltEvidenceForRun(signal)` composes the configured Alt transport with three small reads: `getSales(assetId, window, limitPerGrade = 16)`, `getSaleDetail(transactionId)`, and `getSupply(assetId)`. Create one instance per valuation run so detail deduplication and cancellation have the same lifetime. There is no global detail cache, polling loop, image download or additional service.
+
+The all-grades history request uses `allGrades: true`, `showSkipped: true`, and `maxTransactionsPerGrade`. The adapter permits 1–16 records per grader/grade group. It filters the returned sample to the requested inclusive date window locally; it does not pretend a time-series filter constrains transactions. Missing dates remain review candidates. Coverage includes the requested window, min/max observed dates before local filtering, source count, cap and `complete: false`. Neither returned count nor observed date span establishes market-wide sales volume.
+
+History, detailed sales and active listings use separate result types. No Alt estimated values or population counts enter these observations. Sale facts retain provider/source references, venue, date, format, original grade encoding and label, correction/skip flags, and monetary uncertainty. Unsafe source references are retained as text but are not exposed as clickable source URLs. eBay item IDs are extracted only from eBay URLs. Shared Alt identity-field functions keep certificate and sale parsing consistent.
+
+Unknown shipping, fees and currency remain null. The history price has no verified currency field, so its currency remains unknown. A detail's explicit `usdAmount` is stored separately as a USD conversion; this does not establish the currency of shipping or fees. Shipping/buyer-premium inclusion flags remain unknown. Downstream screening must resolve these facts before comparing landed prices. Zero is retained only when the source explicitly supplies zero.
+
+Details are lazy: reading history does not fetch individual transactions or images. Concurrent reads of the same normalized transaction ID share one promise. A run allows at most 32 distinct detail reads; completed results, including a missing detail, are memoized, while failures are removed so a later attempt can recover. All operations still obey the PostgreSQL provider lease/cooldown. Busy callers should reschedule rather than spin. The persisted evidence cache/jobs follow in #25.
+
+Supply reads only `asset.activeListings` on Alt, reporting `scope: "alt-only"`, capture time and incomplete coverage. It retains listing/item identities, raw format/state, list-price value, dates and grading. Quantity, currency and ask-versus-bid semantics remain unknown unless separately verified; a list-price field is not treated as a confirmed executable ask. External/eBay supply is a separate provider. Population and estimated-value series are intentionally not requested. Typesense search is also unnecessary for these reads against resolved asset IDs.
+
+## Verification on September 5, 2026
+
+- Live native-fetch adapter reads reproduced 214 Ponyta and 194 Hitmonlee transactions at a cap of 16 per grade.
+- A cap of one returned 25 Ponyta records spanning September 2024–September 2026, demonstrating why a per-grade limit is not a recent-date window or complete volume.
+- The known Ponyta sale detail retained 27.46 as an explicit USD amount and shipping 17.59 with unknown currency; fees were null.
+- Both sample assets returned an empty Alt active-listings array. This says nothing about their eBay supply. Populated-listing contract tests are synthetic; no populated live Alt supply sample was verified.
+- Contract tests use four sanitized real history records plus one detail. They cover special CGC encodings, skip/correction flags, missing fields, partial GraphQL errors, malformed responses, local window filtering, bounded lazy details, failed-detail recovery, cancellation and supply separation. The underlying transport's byte/deadline limits still apply.


### PR DESCRIPTION
Alt history is capped per grader/grade and cannot represent complete market volume. Add a small Alt evidence provider that returns capped sale observations with requested/observed windows, lazily enriches individual sales, and reads Alt-only active listings separately.

Preserve source IDs/URLs, original grades/labels, skip/correction flags and monetary uncertainty. An explicit USD amount does not assign USD to unknown shipping or fees. Detail reads share a bounded cache within one valuation run and use that run's cancellation signal. Shared Alt card/grade parsing keeps certificate and sale identities consistent. No dependencies, schema changes, images, population queries, search tokens or estimated-value series are added.

Validation: full tests, typecheck, production build and diff checks passed. Live configured reads reproduced 214 Ponyta and 194 Hitmonlee observations; a cap of one returned 25 Ponyta records across two years. The known detail reproduced 27.46 USD and 17.59 shipping with unknown currency. Both assets returned empty Alt active-listing arrays. Populated Alt supply is contract-tested synthetically and remains unverified live; ask/bid, quantity and currency are kept unknown rather than inferred.

Adversarial review consolidated duplicated identity parsing, preserved opaque source references, normalized request IDs/date windows before I/O, and checked partial GraphQL failures, malformed money/dates, capped coverage, cancellation and bounded detail memoization. Regression checks passed; the final pass found no further actionable issues across composition, simplicity, design, performance and footprint. Operational limits and evidence are documented in `docs/ebay-slab-alt-evidence.md`.

Fixes #22.
