### PR TITLE
Provide bounded eBay Research sales and active supply

### DIFF
--- a/app/features/ebay-slab-pricing/connections/providerRequest.server.ts
+++ b/app/features/ebay-slab-pricing/connections/providerRequest.server.ts
@@ -57,21 +57,35 @@ function providerUrl(provider: SlabProvider, path: string): URL {
 async function readText(
   response: Response,
   signal: AbortSignal,
+  onText?: (chunk: string) => void,
 ): Promise<string> {
   const reader = response.body?.getReader();
   if (!reader) throw new ProviderRequestError("invalid-response");
   const decoder = new TextDecoder();
   let size = 0;
   let text = "";
+  let started = false;
+  const consume = (chunk: string) => {
+    if (!started && chunk.trim()) {
+      started = true;
+      if (chunk.trimStart().startsWith("<"))
+        throw new ProviderRequestError("reconnect-required");
+    }
+    if (onText) onText(chunk);
+    else text += chunk;
+  };
   try {
     for (;;) {
       signal.throwIfAborted();
       const { value, done } = await reader.read();
-      if (done) return text + decoder.decode();
+      if (done) {
+        consume(decoder.decode());
+        return text;
+      }
       size += value.byteLength;
       if (size > MAX_RESPONSE_BYTES)
         throw new ProviderRequestError("invalid-response");
-      text += decoder.decode(value, { stream: true });
+      consume(decoder.decode(value, { stream: true }));
     }
   } finally {
     await reader.cancel().catch(() => {});
@@ -100,6 +114,8 @@ export function createProviderRequest(
       signal?: AbortSignal;
       timeoutMs?: number;
       validate?: (body: string) => void;
+      /** Consume decoded chunks without retaining the complete response string. */
+      onText?: (chunk: string) => void;
     } = {},
   ): Promise<string> {
     const url = providerUrl(provider, request.path);
@@ -173,7 +189,7 @@ export function createProviderRequest(
           await response.body?.cancel();
           throw new ProviderRequestError("invalid-response");
         }
-        const body = await readText(response, signal);
+        const body = await readText(response, signal, options.onText);
         if (/^\s*</.test(body))
           throw new ProviderRequestError("reconnect-required");
         options.validate?.(body);

--- a/app/features/ebay-slab-pricing/evidence/ebayResearchProvider.server.ts
+++ b/app/features/ebay-slab-pricing/evidence/ebayResearchProvider.server.ts
@@ -1,0 +1,446 @@
+import {
+  ProviderRequestError,
+  type createProviderRequest,
+} from "../connections/providerRequest.server";
+import {
+  createResearchStream,
+  researchText as display,
+  type ResearchModule,
+} from "./ebayResearchStream.server";
+import type {
+  EvidenceWindow,
+  Money,
+  SaleEvidence,
+  SalesEvidenceResult,
+  SupplyEvidence,
+} from "./slabEvidence";
+import type { SlabIdentity } from "../identity/slabIdentity";
+
+type JsonObject = Record<string, unknown>;
+export type ResearchQuery = {
+  keywords: string;
+  window: EvidenceWindow;
+  offset?: number;
+  limit?: 10 | 20 | 50;
+  timezone?: string;
+};
+type PageInfo = {
+  offset: number;
+  limit: number;
+  nextOffset: number | null;
+  partial: boolean;
+};
+const invalid = () => new ProviderRequestError("invalid-response");
+const unknownGrading: SlabIdentity["grading"] = {
+  grader: "UNKNOWN",
+  encoding: "unknown",
+  number: null,
+  label: null,
+  qualifier: null,
+  autograph: null,
+};
+function object(value: unknown): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw invalid();
+  return value as JsonObject;
+}
+function money(value: unknown, shipping = false): Money | null {
+  const text = display(value);
+  if (!text || text === "-") return null;
+  if (shipping && /^free shipping$/i.test(text))
+    return { amount: 0, currency: "USD" };
+  const match =
+    /^\+?\$((?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d{2})?)(?: shipping)?$/.exec(text);
+  if (!match) throw invalid();
+  const amount = Number(match[1].replaceAll(",", ""));
+  if (!Number.isFinite(amount) || amount > Number.MAX_SAFE_INTEGER / 100)
+    throw invalid();
+  return { amount, currency: "USD" };
+}
+function count(value: unknown): number | null {
+  const text = display(value);
+  if (!text || text === "-") return null;
+  if (!/^(?:\d{1,3}(?:,\d{3})+|\d+)$/.test(text)) throw invalid();
+  const number = Number(text.replaceAll(",", ""));
+  if (!Number.isSafeInteger(number)) throw invalid();
+  return number;
+}
+function day(value: string): string {
+  if (
+    !/^\d{4}-\d{2}-\d{2}$/.test(value) ||
+    !Number.isFinite(Date.parse(value)) ||
+    new Date(value).toISOString().slice(0, 10) !== value
+  )
+    throw invalid();
+  return value;
+}
+function humanDate(text: string | null): string | null {
+  if (!text || text === "-") return null;
+  const match =
+    /^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{1,2}), (\d{4})$/.exec(
+      text,
+    );
+  if (!match) throw invalid();
+  const month =
+    [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec",
+    ].indexOf(match[1]) + 1;
+  return day(
+    `${match[3]}-${String(month).padStart(2, "0")}-${match[2].padStart(2, "0")}`,
+  );
+}
+function sourceDate(value: unknown) {
+  return humanDate(display(value));
+}
+export function researchMidnight(date: string, timezone: string): number {
+  const target = Date.parse(day(date));
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  });
+  let guess = target;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const parts = Object.fromEntries(
+      formatter
+        .formatToParts(new Date(guess))
+        .map((part) => [part.type, part.value]),
+    );
+    const shown = Date.UTC(
+      Number(parts.year),
+      Number(parts.month) - 1,
+      Number(parts.day),
+      Number(parts.hour),
+      Number(parts.minute),
+      Number(parts.second),
+    );
+    if (shown === target) return guess;
+    guess += target - shown;
+  }
+  throw invalid();
+}
+function listing(value: unknown) {
+  const row = object(value);
+  const listing = object(row.listing);
+  const itemId = display(listing.itemId);
+  const title = display(listing.title);
+  if (!itemId || !/^\d{9,15}$/.test(itemId) || !title) throw invalid();
+  const format = Array.isArray(listing.formatList)
+    ? listing.formatList.map(display).filter(Boolean).join(", ") || null
+    : null;
+  return {
+    row,
+    itemId,
+    title,
+    extendedTitle: display(listing.extendedTitle),
+    format,
+    sourceUrl: `https://www.ebay.com/itm/${itemId}`,
+  };
+}
+function sale(value: unknown): SaleEvidence {
+  const entry = listing(value);
+  const price = object(entry.row.avgsalesprice);
+  const shipping =
+    entry.row.avgshipping == null
+      ? null
+      : object(entry.row.avgshipping).avgshipping;
+  return {
+    provider: "ebayResearch",
+    providerId: entry.itemId,
+    assetId: null,
+    sourceItemId: entry.itemId,
+    sourceUrl: entry.sourceUrl,
+    sourceReference: entry.sourceUrl,
+    venue: "eBay",
+    kind: "listing-average",
+    date: sourceDate(entry.row.datelastsold),
+    format: display(price.format) ?? entry.format,
+    title: entry.title,
+    extendedTitle: entry.extendedTitle,
+    card: null,
+    grading: { ...unknownGrading },
+    certificateNumber: null,
+    price: money(price.avgsalesprice),
+    convertedPrice: null,
+    shipping: money(shipping, true),
+    fees: null,
+    shippingIncluded: false,
+    buyerPremiumIncluded: null,
+    quantity: count(entry.row.itemssold),
+    subjectToChange: null,
+    skippedReason: null,
+  };
+}
+function supply(value: unknown): SupplyEvidence {
+  const entry = listing(value);
+  const price = object(entry.row.listingPrice);
+  const format = entry.format?.toLowerCase();
+  return {
+    provider: "ebayResearch",
+    providerId: entry.itemId,
+    assetId: null,
+    venue: "eBay",
+    sourceUrl: entry.sourceUrl,
+    title: entry.title,
+    extendedTitle: entry.extendedTitle,
+    format: entry.format,
+    state: "ACTIVE",
+    price: money(price.listingPrice),
+    priceKind:
+      format === "auction"
+        ? "bid"
+        : format === "fixed price" ||
+            format === "fixed price, best offer accepted"
+          ? "ask"
+          : "unknown",
+    shipping: money(price.listingShipping, true),
+    quantity: null,
+    startedAt: sourceDate(entry.row.startDate),
+    endsAt: null,
+    items: [],
+  };
+}
+function summary(module: ResearchModule) {
+  if (!Array.isArray(module.sections)) throw invalid();
+  return module.sections.flatMap((section) => {
+    const row = object(section);
+    if (!Array.isArray(row.dataItems)) throw invalid();
+    return row.dataItems.map((value) => {
+      const item = object(value);
+      return {
+        label: display(item.header),
+        value: display(item.value),
+        description: display(item.tooltip),
+      };
+    });
+  });
+}
+function pageInfo(
+  module: ResearchModule,
+  offset: number,
+  limit: number,
+): PageInfo {
+  const pagination = object(module.pagination);
+  const next = object(pagination.next).disabled;
+  if (
+    typeof next !== "boolean" ||
+    pagination.currentPageNum !== offset / limit + 1
+  )
+    throw invalid();
+  const pageSize = object(pagination.itemsPerPage).options;
+  if (!Array.isArray(pageSize)) throw invalid();
+  const selected = pageSize.filter((value) => object(value).selected === true);
+  if (selected.length !== 1 || object(selected[0]).value !== String(limit))
+    throw invalid();
+  const rows = module.results as unknown[];
+  if (rows.length > limit || (!next && rows.length === 0)) throw invalid();
+  const range = display(pagination.summary)?.match(
+    /^Results:\s*([\d,]+)\s*-\s*([\d,]+)$/,
+  );
+  if (
+    !range ||
+    Number(range[1].replaceAll(",", "")) !== offset + 1 ||
+    Number(range[2].replaceAll(",", "")) !== offset + rows.length
+  )
+    throw invalid();
+  return {
+    offset,
+    limit,
+    nextOffset: next ? null : offset + limit,
+    partial: !next && rows.length < limit,
+  };
+}
+
+export function buildResearchKeywords(
+  identity: SlabIdentity,
+  broadening: "none" | "omit-set" = "none",
+): string {
+  // Broadening is explicit and never drops known language, edition, finish, stamp or grading.
+  const parts = [
+    identity.card.year,
+    identity.card.game,
+    identity.card.name,
+    identity.card.cardNumber,
+    broadening === "none" ? identity.card.set : null,
+    identity.card.language,
+    identity.card.edition,
+    identity.card.finish,
+    identity.card.stamp,
+    identity.grading.grader,
+    identity.grading.number === null
+      ? identity.grading.encoding
+      : String(identity.grading.number),
+    identity.grading.grader === "PSA" ? null : identity.grading.label,
+    identity.grading.qualifier,
+    identity.grading.autograph,
+  ];
+  return parts.filter(Boolean).join(" ");
+}
+
+export function createEbayResearchProvider(
+  request: ReturnType<typeof createProviderRequest>,
+  options: {
+    signal?: AbortSignal;
+    maxRequests?: number;
+    now?: () => Date;
+  } = {},
+) {
+  let remaining = options.maxRequests ?? 3;
+  if (!Number.isInteger(remaining) || remaining < 1 || remaining > 10)
+    throw invalid();
+  async function read(query: ResearchQuery, tab: "SOLD" | "ACTIVE") {
+    const keywords = query.keywords.trim();
+    const offset = query.offset ?? 0;
+    const limit = query.limit ?? 50;
+    const timezone = query.timezone ?? "America/Chicago";
+    const from = day(query.window.from);
+    const to = day(query.window.to);
+    if (
+      !keywords ||
+      keywords.length > 500 ||
+      /[\x00-\x1f]/.test(keywords) ||
+      from > to ||
+      ![10, 20, 50].includes(limit) ||
+      !Number.isInteger(offset) ||
+      offset < 0 ||
+      offset > 10000 ||
+      offset % limit !== 0
+    )
+      throw invalid();
+    try {
+      new Intl.DateTimeFormat("en-US", { timeZone: timezone });
+    } catch {
+      throw invalid();
+    }
+    if (options.signal?.aborted) throw new ProviderRequestError("cancelled");
+    if (remaining === 0) throw new ProviderRequestError("busy");
+    remaining--;
+    const nextDay = new Date(Date.parse(to) + 86400000)
+      .toISOString()
+      .slice(0, 10);
+    const params = new URLSearchParams({
+      marketplace: "EBAY-US",
+      keywords,
+      dayRange: String(
+        Math.max(1, (Date.parse(to) - Date.parse(from)) / 86400000),
+      ),
+      startDate: String(researchMidnight(from, timezone)),
+      endDate: String(researchMidnight(nextDay, timezone) - 1),
+      categoryId: "0",
+      offset: String(offset),
+      limit: String(limit),
+      tabName: tab,
+      tz: timezone,
+    });
+    for (const module of ["aggregates", "searchResults", "resultsHeader"])
+      params.append("modules", module);
+    const stream = createResearchStream(keywords);
+    let parsed: ReturnType<typeof stream.finish>;
+    let page: PageInfo;
+    let aggregates: ReturnType<typeof summary>;
+    let observations: SaleEvidence[] | SupplyEvidence[];
+    const asOf = (options.now?.() ?? new Date()).toISOString();
+    await request(
+      "ebayResearch",
+      { path: `/sh/research/api/search?${params}` },
+      {
+        signal: options.signal,
+        onText: stream.push,
+        validate: () => {
+          parsed = stream.finish();
+          page = parsed.empty
+            ? { offset, limit, nextOffset: null, partial: false }
+            : pageInfo(parsed.results, offset, limit);
+          aggregates = summary(parsed.aggregate);
+          if (parsed.state === "sold") {
+            const range = display(parsed.header.dateRange)
+              ?.split("–")
+              .map((value) => humanDate(value.trim()));
+            if (
+              !range ||
+              range.length !== 2 ||
+              range[0] !== from ||
+              range[1] !== to
+            )
+              throw invalid();
+          }
+          observations =
+            parsed.state === "sold"
+              ? (parsed.results.results as unknown[]).map(sale)
+              : (parsed.results.results as unknown[]).map(supply);
+        },
+      },
+    );
+    return {
+      state: parsed!.state,
+      observations: observations!,
+      page: page!,
+      summary: aggregates!,
+      asOf,
+      requestedWindow: { from, to },
+      keywords,
+    };
+  }
+  return {
+    async getSalesPage(query: ResearchQuery) {
+      const result = await read(query, "SOLD");
+      if (result.state !== "sold")
+        return {
+          status: "active-fallback" as const,
+          asOf: result.asOf,
+          keywords: result.keywords,
+        };
+      const sales = result.observations as SaleEvidence[];
+      const dates = sales.flatMap((row) => (row.date ? [row.date] : [])).sort();
+      const coverage: SalesEvidenceResult["coverage"] = {
+        requestedWindow: result.requestedWindow,
+        observedWindow: dates.length
+          ? { from: dates[0], to: dates[dates.length - 1] }
+          : null,
+        complete: false,
+        reason: "paged-search",
+        sourceCount: sales.length,
+        limitPerGrade: null,
+      };
+      return {
+        status: "sold" as const,
+        sales,
+        coverage,
+        asOf: result.asOf,
+        page: result.page,
+        summary: result.summary,
+        keywords: result.keywords,
+      };
+    },
+    async getSupplyPage(query: ResearchQuery) {
+      const result = await read(query, "ACTIVE");
+      if (result.state !== "active") throw invalid();
+      return {
+        status: "active" as const,
+        listings: result.observations as SupplyEvidence[],
+        asOf: result.asOf,
+        page: result.page,
+        summary: result.summary,
+        scope: "ebay-search" as const,
+        complete: false as const,
+        keywords: result.keywords,
+      };
+    },
+  };
+}

--- a/app/features/ebay-slab-pricing/evidence/ebayResearchProvider.test.ts
+++ b/app/features/ebay-slab-pricing/evidence/ebayResearchProvider.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import soldFixture from "./fixtures/ebay-sold.json";
+import activeFixture from "./fixtures/ebay-active.json";
+import emptyFixture from "./fixtures/ebay-empty.json";
+import emptyActiveFixture from "./fixtures/ebay-empty-active.json";
+import identityFixture from "../identity/fixtures/alt-cert-110185364.json";
+import { createResearchStream } from "./ebayResearchStream.server";
+import {
+  buildResearchKeywords,
+  createEbayResearchProvider,
+  researchMidnight,
+} from "./ebayResearchProvider.server";
+import { createProviderRequest } from "../connections/providerRequest.server";
+import { parseAltCertificate } from "../identity/altIdentityProvider.server";
+
+const query = {
+  keywords: "Ponyta 60 1st PSA 9",
+  window: { from: "2026-06-07", to: "2026-09-05" },
+};
+const encode = (modules: unknown[]) =>
+  modules.map((module) => JSON.stringify(module)).join("\r\n\r\n");
+const wire = encode(soldFixture);
+for (const size of [1, 2, 7, 97, wire.length]) {
+  const stream = createResearchStream(query.keywords);
+  for (let offset = 0; offset < wire.length; offset += size)
+    stream.push(wire.slice(offset, offset + size));
+  const result = stream.finish();
+  assert.equal(result.state, "sold");
+  assert.equal((result.results.results as unknown[]).length, 3);
+}
+const streamFailure = (modules: unknown[], status: string) => {
+  assert.throws(
+    () => {
+      const stream = createResearchStream(query.keywords);
+      stream.push(encode(modules));
+      stream.finish();
+    },
+    { status },
+  );
+};
+streamFailure(soldFixture.slice(0, -1), "invalid-response");
+streamFailure([...soldFixture, soldFixture[1]], "invalid-response");
+streamFailure(
+  [
+    {
+      _type: "PageErrorModule",
+      severity: "ERROR",
+      messages: [{ textSpans: [{ text: "Backend failed" }] }],
+    },
+    ...soldFixture.slice(1),
+  ],
+  "unavailable",
+);
+streamFailure(
+  [
+    {
+      _type: "PageErrorModule",
+      severity: "WARNING",
+      messages: [{ textSpans: [{ text: "Partial data unavailable" }] }],
+    },
+    ...soldFixture.slice(1),
+  ],
+  "unavailable",
+);
+assert.throws(() => createResearchStream().push("<html>Sign in</html>"), {
+  status: "reconnect-required",
+});
+assert.throws(
+  () => createResearchStream().push("x".repeat(2 * 1024 * 1024 + 1)),
+  { status: "invalid-response" },
+);
+assert.throws(
+  () => {
+    const stream = createResearchStream();
+    stream.push(wire.slice(0, -4));
+    stream.finish();
+  },
+  { status: "invalid-response" },
+);
+streamFailure(
+  Array.from({ length: 17 }, () => ({ _type: "UnusedModule" })),
+  "invalid-response",
+);
+
+function provider(modules: unknown[], maxRequests = 3) {
+  let calls = 0;
+  const requests: URL[] = [];
+  const gate = {
+    claim: async () => ({
+      id: "fixture",
+      revision: 1,
+      credential: "fixture",
+      userAgent: "fixture",
+    }),
+    release: async () => {},
+  };
+  const client = createEbayResearchProvider(
+    createProviderRequest(gate, async (url) => {
+      calls++;
+      requests.push(new URL(String(url)));
+      const bytes = new TextEncoder().encode(encode(modules));
+      // Byte chunks split both JSON frames and multi-byte characters in extended titles.
+      return new Response(
+        new ReadableStream({
+          start(controller) {
+            for (let offset = 0; offset < bytes.length; offset += 7)
+              controller.enqueue(bytes.slice(offset, offset + 7));
+            controller.close();
+          },
+        }),
+      );
+    }),
+    { maxRequests },
+  );
+  return { client, calls: () => calls, requests };
+}
+const sold = provider(soldFixture);
+const result = await sold.client.getSalesPage(query);
+assert.equal(result.status, "sold");
+assert.ok(result.status === "sold");
+assert.equal(result.sales.length, 3);
+assert.equal(result.sales[0].kind, "listing-average");
+assert.equal(result.sales[0].quantity, 1);
+assert.equal(
+  result.sales[0].assetId,
+  null,
+  "query identity is not assigned to search candidates",
+);
+assert.equal(result.sales[0].grading.grader, "UNKNOWN");
+assert.deepEqual(result.sales[0].price, { amount: 124.99, currency: "USD" });
+assert.deepEqual(result.sales[0].shipping, { amount: 0, currency: "USD" });
+assert.equal(result.sales[0].date, "2026-06-21");
+assert.ok(result.sales[0].extendedTitle?.includes("Pokémon"));
+assert.equal(result.sales[0].shippingIncluded, false);
+assert.equal(result.coverage.complete, false);
+assert.equal(result.page.nextOffset, null);
+assert.deepEqual(sold.requests[0].searchParams.getAll("modules"), [
+  "aggregates",
+  "searchResults",
+  "resultsHeader",
+]);
+assert.equal(sold.requests[0].searchParams.get("marketplace"), "EBAY-US");
+assert.equal(sold.calls(), 1);
+const fallback = await provider(activeFixture).client.getSalesPage(query);
+assert.equal(fallback.status, "active-fallback");
+assert.ok(
+  !("sales" in fallback),
+  "active fallback cannot return sale observations",
+);
+const active = await provider(activeFixture).client.getSupplyPage(query);
+assert.equal(active.listings[0].priceKind, "bid");
+assert.deepEqual(active.listings[0].price, { amount: 9.5, currency: "USD" });
+assert.equal(active.listings[0].quantity, null);
+assert.equal(active.listings[1].priceKind, "ask");
+assert.equal(
+  active.listings[2].priceKind,
+  "ask",
+  "Best Offer availability is still an asking price in active results",
+);
+const empty = await provider(emptyFixture).client.getSalesPage({
+  ...query,
+  keywords: "Ponyta nonexistent-cert-0000000000",
+});
+assert.equal(empty.status, "sold");
+assert.ok(empty.status === "sold");
+assert.deepEqual(empty.sales, []);
+assert.equal(empty.page.nextOffset, null);
+const emptyActive = await provider(emptyActiveFixture).client.getSupplyPage({
+  ...query,
+  keywords: "Ponyta nonexistent-cert-0000000000",
+});
+assert.deepEqual(emptyActive.listings, []);
+await assert.rejects(
+  provider(emptyFixture).client.getSalesPage(query),
+  { status: "unavailable" },
+  "an unrelated empty-search message is not accepted",
+);
+
+const multi = structuredClone(soldFixture) as any[];
+multi.at(-1).results[0].itemssold.textSpans[0].text = "3";
+const aggregated = await provider(multi).client.getSalesPage(query);
+assert.ok(aggregated.status === "sold");
+assert.equal(aggregated.sales[0].quantity, 3);
+assert.equal(aggregated.sales[0].kind, "listing-average");
+assert.equal(
+  aggregated.sales.length,
+  3,
+  "an average is never expanded into individual sales",
+);
+const mismatch = structuredClone(soldFixture) as any[];
+mismatch.at(-1).pagination.currentPageNum = 2;
+await assert.rejects(provider(mismatch).client.getSalesPage(query), {
+  status: "invalid-response",
+});
+const missingRows = structuredClone(soldFixture) as any[];
+missingRows.at(-1).results.pop();
+await assert.rejects(provider(missingRows).client.getSalesPage(query), {
+  status: "invalid-response",
+});
+const wrongWindow = structuredClone(soldFixture) as any[];
+wrongWindow[1].dateRange.textSpans[0].text = "Jun 8, 2026";
+await assert.rejects(provider(wrongWindow).client.getSalesPage(query), {
+  status: "invalid-response",
+});
+const limited = provider(soldFixture, 1);
+await limited.client.getSalesPage(query);
+await assert.rejects(limited.client.getSalesPage(query), { status: "busy" });
+assert.equal(limited.calls(), 1);
+await assert.rejects(
+  provider(soldFixture).client.getSalesPage({ ...query, offset: 1 }),
+  { status: "invalid-response" },
+);
+const partial = structuredClone(soldFixture) as any[];
+partial.at(-1).pagination.next.disabled = false;
+const partialPage = await provider(partial).client.getSalesPage(query);
+assert.ok(partialPage.status === "sold");
+assert.equal(partialPage.page.partial, true);
+assert.equal(partialPage.page.nextOffset, 50);
+assert.equal(
+  researchMidnight("2026-03-09", "America/Chicago") -
+    researchMidnight("2026-03-08", "America/Chicago"),
+  23 * 3600000,
+);
+assert.equal(
+  researchMidnight("2026-11-02", "America/Chicago") -
+    researchMidnight("2026-11-01", "America/Chicago"),
+  25 * 3600000,
+);
+const identity = parseAltCertificate(JSON.stringify(identityFixture))!.identity;
+identity.card.language = "English";
+identity.card.stamp = "Promo";
+const keywords = buildResearchKeywords(identity, "omit-set");
+assert.ok(
+  keywords.includes("English") &&
+    keywords.includes("Promo") &&
+    keywords.includes("PSA 1"),
+);
+assert.ok(!keywords.includes("Legendary Collection"));
+console.log(
+  "PASS eBay streaming, explicit sold state, empty/error distinction, aggregates, bid/ask separation, paging bounds and timezone windows",
+);

--- a/app/features/ebay-slab-pricing/evidence/ebayResearchStream.server.ts
+++ b/app/features/ebay-slab-pricing/evidence/ebayResearchStream.server.ts
@@ -1,0 +1,187 @@
+import { ProviderRequestError } from "../connections/providerRequest.server";
+
+export type ResearchModule = Record<string, unknown> & { _type: string };
+const REQUIRED_TYPES = new Set([
+  "ResultsHeaderModule",
+  "ResearchAggregateModule",
+  "SearchResultsModule",
+  "ActiveSearchResultsModule",
+]);
+const fail = () => new ProviderRequestError("invalid-response");
+
+export function researchText(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value !== "object" || Array.isArray(value)) throw fail();
+  const row = value as Record<string, unknown>;
+  if (typeof row.value === "string") return row.value.trim() || null;
+  if (!Array.isArray(row.textSpans)) throw fail();
+  const text = row.textSpans
+    .map((span) => {
+      if (!span || typeof span !== "object") throw fail();
+      if (span.text === undefined) return "";
+      if (typeof span.text !== "string") throw fail();
+      return span.text;
+    })
+    .join("")
+    .trim();
+  return text || null;
+}
+
+/** JSON frames split by blank lines; transport chunks need not align with UTF-8 or frames. */
+export function createResearchStream(keywords = "") {
+  let buffer = "";
+  let bytes = 0;
+  let count = 0;
+  let emptyState: "sold" | "active" | null = null;
+  let pendingNewline: number | null = null;
+  let previousWasCR = false;
+  let started = false;
+  const modules = new Map<string, ResearchModule>();
+  function consume(frame: string) {
+    if (!frame.trim()) return;
+    if (++count > 16) throw fail();
+    let module: ResearchModule;
+    try {
+      module = JSON.parse(frame);
+    } catch {
+      throw fail();
+    }
+    if (
+      !module ||
+      typeof module !== "object" ||
+      Array.isArray(module) ||
+      typeof module._type !== "string"
+    )
+      throw fail();
+    if (module._type === "PageErrorModule") {
+      // eBay sends an ERROR-severity placeholder even in successful sold responses.
+      const payload = Object.entries(module).filter(
+        ([key]) => !["_type", "severity", "meta", "debugUrl"].includes(key),
+      );
+      if (
+        payload.some(
+          ([, value]) =>
+            value != null &&
+            value !== "" &&
+            !(Array.isArray(value) && value.length === 0),
+        )
+      ) {
+        const messages = module.messages;
+        const message =
+          Array.isArray(messages) && messages.length === 1 ? messages[0] : null;
+        const text = researchText(message);
+        if (
+          module.severity === "WARNING" &&
+          keywords &&
+          payload.length === 1 &&
+          payload[0][0] === "messages" &&
+          text === `No sold results found for "${keywords}"`
+        )
+          emptyState = "sold";
+        else if (
+          module.severity === "ERROR" &&
+          keywords &&
+          payload.length === 1 &&
+          payload[0][0] === "messages" &&
+          text === `No active results found for "${keywords}"`
+        )
+          emptyState = "active";
+        else throw new ProviderRequestError("unavailable");
+      }
+    }
+    if (REQUIRED_TYPES.has(module._type)) {
+      if (modules.has(module._type)) throw fail();
+      modules.set(module._type, module);
+    }
+  }
+  return {
+    push(chunk: string) {
+      bytes += Buffer.byteLength(chunk, "utf8");
+      if (bytes > 2 * 1024 * 1024) throw fail();
+      let base = buffer.length;
+      buffer += chunk;
+      // Scan only new characters; flatten the buffered string only at frame boundaries.
+      for (let index = 0; index < chunk.length; index++) {
+        const char = chunk[index];
+        if (!started && !/\s/.test(char)) {
+          started = true;
+          if (char === "<")
+            throw new ProviderRequestError("reconnect-required");
+        }
+        if (char === "\n") {
+          if (pendingNewline === null)
+            pendingNewline = base + index - (previousWasCR ? 1 : 0);
+          else {
+            consume(buffer.slice(0, pendingNewline));
+            buffer = chunk.slice(index + 1);
+            base = -index - 1;
+            pendingNewline = null;
+          }
+        } else if (char !== " " && char !== "\t" && char !== "\r")
+          pendingNewline = null;
+        previousWasCR = char === "\r";
+      }
+    },
+    finish() {
+      consume(buffer);
+      buffer = "";
+      const header = modules.get("ResultsHeaderModule");
+      const aggregate = modules.get("ResearchAggregateModule");
+      if (!header || !aggregate || !Array.isArray(header.tabs)) throw fail();
+      const selected = header.tabs.filter(
+        (tab) => tab && typeof tab === "object" && tab.active === true,
+      );
+      if (selected.length !== 1 || !["sold", "active"].includes(selected[0].id))
+        throw fail();
+      const state = selected[0].id as "sold" | "active";
+      const results = modules.get(
+        state === "sold" ? "SearchResultsModule" : "ActiveSearchResultsModule",
+      );
+      if (
+        !results ||
+        (emptyState === null && !Array.isArray(results.results)) ||
+        (Array.isArray(results.results) && results.results.length > 50) ||
+        modules.has(
+          state === "sold"
+            ? "ActiveSearchResultsModule"
+            : "SearchResultsModule",
+        )
+      )
+        throw fail();
+      if (emptyState !== null) {
+        if (
+          state !== emptyState ||
+          (results.results !== undefined &&
+            (!Array.isArray(results.results) ||
+              results.results.length !== 0)) ||
+          (emptyState === "sold" &&
+            aggregate.sections !== undefined &&
+            (!Array.isArray(aggregate.sections) ||
+              aggregate.sections.length !== 0))
+        )
+          throw fail();
+        if (emptyState === "active") {
+          const sections = aggregate.sections;
+          if (!Array.isArray(sections)) throw fail();
+          const totals = sections
+            .flatMap((section) =>
+              Array.isArray(section?.dataItems) ? section.dataItems : [],
+            )
+            .filter(
+              (item) => researchText(item.header) === "Total active listings",
+            );
+          if (totals.length !== 1 || researchText(totals[0].value) !== "0")
+            throw fail();
+        }
+        return {
+          state,
+          results: { ...results, results: [] },
+          aggregate: { ...aggregate, sections: aggregate.sections ?? [] },
+          header,
+          empty: true,
+        };
+      }
+      return { state, results, aggregate, header, empty: false };
+    },
+  };
+}

--- a/app/features/ebay-slab-pricing/evidence/fixtures/ebay-active.json
+++ b/app/features/ebay-slab-pricing/evidence/fixtures/ebay-active.json
@@ -1,0 +1,532 @@
+[
+  {
+    "_type": "PageErrorModule"
+  },
+  {
+    "_type": "ResultsHeaderModule",
+    "tabs": [
+      {
+        "id": "sold",
+        "active": false
+      },
+      {
+        "id": "active",
+        "active": true
+      }
+    ],
+    "autoSwitchTooltip": {
+      "_type": "TextualDisplay",
+      "textSpans": [
+        {
+          "_type": "TextSpan",
+          "text": "We couldn't find any Sold results in the date range you've selected, so we've switched to Active listings."
+        }
+      ]
+    }
+  },
+  {
+    "_type": "ResearchAggregateModule",
+    "sections": [
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Avg listing price"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "$308.96"
+                }
+              ]
+            }
+          },
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Listing price range"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "$9.50 - $1,490.73"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Avg shipping"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "$17.28"
+                }
+              ]
+            }
+          },
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Free shipping"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "21%"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Total active listings"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "24"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Promoted listings"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "21%"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "_type": "ActiveSearchResultsModule",
+    "results": [
+      {
+        "listing": {
+          "itemId": {
+            "_type": "TextualDisplayValue",
+            "value": "178447981501",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "178447981501"
+              }
+            ]
+          },
+          "title": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "PONYTA PSA 9 1999 POKEMON 1ST EDITION #60/102 BASE SET 5983"
+              }
+            ]
+          },
+          "formatList": [
+            {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Auction"
+                }
+              ]
+            }
+          ]
+        },
+        "listingPrice": {
+          "listingPrice": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "$9.50"
+              }
+            ]
+          },
+          "listingShipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "+$6.00 shipping"
+              }
+            ]
+          }
+        },
+        "bids": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "4"
+            }
+          ]
+        },
+        "watchers": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "15"
+            }
+          ]
+        },
+        "promoted": {
+          "_type": "IconAndText",
+          "text": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "-"
+              }
+            ]
+          }
+        },
+        "startDate": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "Sep 1, 2026"
+            }
+          ]
+        }
+      },
+      {
+        "listing": {
+          "itemId": {
+            "_type": "TextualDisplayValue",
+            "value": "397802495164",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "397802495164"
+              }
+            ]
+          },
+          "title": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "1999 Pokemon Base Set 1st Edition Shadowless Ponyta 60/102 PSA 9 Mint"
+              }
+            ]
+          },
+          "formatList": [
+            {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Fixed price"
+                }
+              ]
+            }
+          ]
+        },
+        "listingPrice": {
+          "listingPrice": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "$150.00"
+              }
+            ]
+          },
+          "listingShipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "+$5.17 shipping"
+              }
+            ]
+          }
+        },
+        "bids": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "-"
+            }
+          ]
+        },
+        "watchers": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "13"
+            }
+          ]
+        },
+        "promoted": {
+          "_type": "IconAndText",
+          "text": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "-"
+              }
+            ]
+          }
+        },
+        "startDate": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "Apr 4, 2026"
+            }
+          ]
+        }
+      },
+      {
+        "listing": {
+          "itemId": {
+            "_type": "TextualDisplayValue",
+            "value": "267752985103",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "267752985103"
+              }
+            ]
+          },
+          "title": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "PSA 9 MINT Ponyta 1st Edition 60/102 PokÃ©mon 1999 French Base Graded Card"
+              }
+            ]
+          },
+          "formatList": [
+            {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Fixed price"
+                }
+              ]
+            },
+            {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Best Offer accepted"
+                }
+              ]
+            }
+          ]
+        },
+        "listingPrice": {
+          "listingPrice": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "$99.99"
+              }
+            ]
+          },
+          "listingShipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "+$8.30 shipping"
+              }
+            ]
+          }
+        },
+        "bids": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "-"
+            }
+          ]
+        },
+        "watchers": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "0"
+            }
+          ]
+        },
+        "promoted": {
+          "_type": "IconAndText",
+          "text": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "-"
+              }
+            ]
+          }
+        },
+        "startDate": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "Aug 10, 2026"
+            }
+          ]
+        }
+      }
+    ],
+    "pagination": {
+      "summary": {
+        "_type": "TextualDisplay",
+        "textSpans": [
+          {
+            "_type": "TextSpan",
+            "text": "Results: 1 - 3"
+          }
+        ]
+      },
+      "first": {
+        "_type": "PaginationTextualDisplay",
+        "disabled": false,
+        "textSpans": [
+          {
+            "_type": "TextSpan"
+          }
+        ]
+      },
+      "prev": {
+        "_type": "PaginationTextualDisplay",
+        "disabled": true,
+        "textSpans": [
+          {
+            "_type": "TextSpan"
+          }
+        ]
+      },
+      "current": {
+        "_type": "TextualDisplay",
+        "textSpans": [
+          {
+            "_type": "TextSpan",
+            "text": "Page 1"
+          }
+        ]
+      },
+      "next": {
+        "_type": "PaginationTextualDisplay",
+        "disabled": true,
+        "textSpans": [
+          {
+            "_type": "TextSpan"
+          }
+        ]
+      },
+      "itemsPerPage": {
+        "options": [
+          {
+            "_type": "OptionValueSpan",
+            "value": "10",
+            "selected": false,
+            "text": "10"
+          },
+          {
+            "_type": "OptionValueSpan",
+            "value": "20",
+            "selected": false,
+            "text": "20"
+          },
+          {
+            "_type": "OptionValueSpan",
+            "value": "50",
+            "selected": true,
+            "text": "50"
+          }
+        ],
+        "label": "Results per page"
+      },
+      "currentPageNum": 1
+    }
+  }
+]

--- a/app/features/ebay-slab-pricing/evidence/fixtures/ebay-empty-active.json
+++ b/app/features/ebay-slab-pricing/evidence/fixtures/ebay-empty-active.json
@@ -1,0 +1,228 @@
+[
+  {
+    "_type": "PageErrorModule",
+    "messages": [
+      {
+        "_type": "TextualDisplay",
+        "textSpans": [
+          {
+            "_type": "TextSpan",
+            "text": "No active results found for \"Ponyta nonexistent-cert-0000000000\""
+          }
+        ]
+      }
+    ],
+    "severity": "ERROR"
+  },
+  {
+    "_type": "ResultsHeaderModule",
+    "tabs": [
+      {
+        "id": "sold",
+        "active": false
+      },
+      {
+        "id": "active",
+        "active": true
+      }
+    ]
+  },
+  {
+    "_type": "ResearchAggregateModule",
+    "sections": [
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Avg listing price"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "$0.00"
+                }
+              ]
+            },
+            "tooltip": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "The average price similar items are currently listed for. Shipping costs aren't included in the listing price."
+                }
+              ]
+            }
+          },
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Listing price range"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "- - -"
+                }
+              ]
+            },
+            "tooltip": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "The minimum and maximum price similar items are listed for. Shipping costs aren't included in the listing prices."
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Avg shipping"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "$0.00"
+                }
+              ]
+            },
+            "tooltip": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "The average shipping cost to be paid by the buyer. This average doesn't include listings with free shipping."
+                }
+              ]
+            }
+          },
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Free shipping"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "0%"
+                }
+              ]
+            },
+            "tooltip": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "The percentage of active listings that offer free shipping."
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Total active listings"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "0"
+                }
+              ]
+            },
+            "tooltip": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "The total number of active listings."
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Promoted listings"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "0%"
+                }
+              ]
+            },
+            "tooltip": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "The percentage of listings that are sponsored through Promoted Listings."
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "_type": "ActiveSearchResultsModule"
+  }
+]

--- a/app/features/ebay-slab-pricing/evidence/fixtures/ebay-empty.json
+++ b/app/features/ebay-slab-pricing/evidence/fixtures/ebay-empty.json
@@ -1,0 +1,53 @@
+[
+  {
+    "_type": "PageErrorModule",
+    "messages": [
+      {
+        "_type": "TextualDisplay",
+        "textSpans": [
+          {
+            "_type": "TextSpan",
+            "text": "No sold results found for \"Ponyta nonexistent-cert-0000000000\""
+          }
+        ]
+      }
+    ],
+    "severity": "WARNING"
+  },
+  {
+    "_type": "ResultsHeaderModule",
+    "tabs": [
+      {
+        "id": "sold",
+        "active": true
+      },
+      {
+        "id": "active",
+        "active": false
+      }
+    ],
+    "dateRange": {
+      "_type": "TextualDisplay",
+      "textSpans": [
+        {
+          "_type": "TextSpan",
+          "text": "Jun 7, 2026"
+        },
+        {
+          "_type": "TextSpan",
+          "text": "–"
+        },
+        {
+          "_type": "TextSpan",
+          "text": "Sep 5, 2026"
+        }
+      ]
+    }
+  },
+  {
+    "_type": "ResearchAggregateModule"
+  },
+  {
+    "_type": "SearchResultsModule"
+  }
+]

--- a/app/features/ebay-slab-pricing/evidence/fixtures/ebay-sold.json
+++ b/app/features/ebay-slab-pricing/evidence/fixtures/ebay-sold.json
@@ -1,0 +1,686 @@
+[
+  {
+    "_type": "PageErrorModule",
+    "severity": "ERROR"
+  },
+  {
+    "_type": "ResultsHeaderModule",
+    "tabs": [
+      {
+        "id": "sold",
+        "active": true
+      },
+      {
+        "id": "active",
+        "active": false
+      }
+    ],
+    "dateRange": {
+      "_type": "TextualDisplay",
+      "textSpans": [
+        {
+          "_type": "TextSpan",
+          "text": "Jun 7, 2026"
+        },
+        {
+          "_type": "TextSpan",
+          "text": "–"
+        },
+        {
+          "_type": "TextSpan",
+          "text": "Sep 5, 2026"
+        }
+      ]
+    },
+    "autoSwitchTooltip": {
+      "_type": "TextualDisplay",
+      "textSpans": [
+        {
+          "_type": "TextSpan",
+          "text": "We couldn't find any Sold results in the date range you've selected, so we've switched to Active listings."
+        }
+      ]
+    }
+  },
+  {
+    "_type": "ResearchAggregateModule",
+    "sections": [
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Avg sold price"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "$168.49"
+                }
+              ]
+            }
+          },
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Sold price range"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "$18.50 - $450.00"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Avg shipping"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "$10.80"
+                }
+              ]
+            }
+          },
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Free shipping"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "19%"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Total sold"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "21"
+                }
+              ]
+            }
+          },
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Sell-through"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "40.38%"
+                }
+              ]
+            }
+          },
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Total sellers"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "19"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      {
+        "dataItems": [
+          {
+            "header": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Total item sales"
+                }
+              ]
+            },
+            "value": {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "$3,538.29"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "_type": "SearchResultsModule",
+    "results": [
+      {
+        "listing": {
+          "itemId": {
+            "_type": "TextualDisplayValue",
+            "value": "117245257846",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "117245257846"
+              }
+            ]
+          },
+          "title": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "1999 POKEMON BASE SET 1ST EDITION #60 PONYTA PSA 9"
+              }
+            ]
+          },
+          "extendedTitle": {
+            "_type": "TextualDisplayValue",
+            "value": "1999 POKEMON BASE SET 1ST EDITION #60 PONYTA PSA 9 060/102 40 Base Set (Shadowless) Basic Common English Ken Sugimori Pokémon Pokémon TCG Professional Sports Authenticator (PSA) Regular The Pokémon Company United States Yes 4043367850",
+            "textSpans": [
+              {
+                "_type": "TextSpan"
+              }
+            ]
+          },
+          "formatList": [
+            {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Fixed price"
+                }
+              ]
+            }
+          ]
+        },
+        "avgsalesprice": {
+          "avgsalesprice": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "$124.99"
+              }
+            ]
+          },
+          "averageshipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "Free shipping"
+              }
+            ]
+          },
+          "format": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "Fixed price"
+              }
+            ]
+          }
+        },
+        "avgshipping": {
+          "avgshipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "$0.00"
+              }
+            ]
+          },
+          "freeshipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "100% Free shipping"
+              }
+            ]
+          }
+        },
+        "itemssold": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "1"
+            }
+          ]
+        },
+        "totalsales": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "$124.99"
+            }
+          ]
+        },
+        "bids": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "-"
+            }
+          ]
+        },
+        "datelastsold": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "Jun 21, 2026"
+            }
+          ]
+        }
+      },
+      {
+        "listing": {
+          "itemId": {
+            "_type": "TextualDisplayValue",
+            "value": "127936723252",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "127936723252"
+              }
+            ]
+          },
+          "title": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "1999 Pokemon Base Set PONYTA 1st Edition #60 PSA 9"
+              }
+            ]
+          },
+          "extendedTitle": {
+            "_type": "TextualDisplayValue",
+            "value": "1999 Pokemon Base Set PONYTA 1st Edition #60 PSA 9 060/102 40 60 Base Set (Shadowless) Basic Common English Ken Sugimori No Pokémon Pokémon TCG Professional Sports Authenticator (PSA) Regular The Pokémon Company United States Yes 4043367850",
+            "textSpans": [
+              {
+                "_type": "TextSpan"
+              }
+            ]
+          },
+          "formatList": [
+            {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Fixed price"
+                }
+              ]
+            }
+          ]
+        },
+        "avgsalesprice": {
+          "avgsalesprice": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "$130.00"
+              }
+            ]
+          },
+          "averageshipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "+$6.50 shipping"
+              }
+            ]
+          },
+          "format": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "Fixed price"
+              }
+            ]
+          }
+        },
+        "avgshipping": {
+          "avgshipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "$6.50"
+              }
+            ]
+          },
+          "freeshipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "0% Free shipping"
+              }
+            ]
+          }
+        },
+        "itemssold": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "1"
+            }
+          ]
+        },
+        "totalsales": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "$130.00"
+            }
+          ]
+        },
+        "bids": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "-"
+            }
+          ]
+        },
+        "datelastsold": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "Jun 22, 2026"
+            }
+          ]
+        }
+      },
+      {
+        "listing": {
+          "itemId": {
+            "_type": "TextualDisplayValue",
+            "value": "127943558744",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "127943558744"
+              }
+            ]
+          },
+          "title": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "1999 Pokemon - 1st Edition Shadowless Ponyta Base Set 60/102 - PSA 9 MINT! WOTC"
+              }
+            ]
+          },
+          "extendedTitle": {
+            "_type": "TextualDisplayValue",
+            "value": "1999 Pokemon - 1st Edition Shadowless Ponyta Base Set 60/102 - PSA 9 MINT! WOTC Wizards of the Coast Basic Pokémon 060/102 United States Yes Regular Standard Near Mint or Better Pokémon TCG Base Set (Shadowless) Common English Ken Sugimori Professional Sports Authenticator (PSA) 4+ Fire Card Stock 40 The Pokémon Company 4043367850",
+            "textSpans": [
+              {
+                "_type": "TextSpan"
+              }
+            ]
+          },
+          "formatList": [
+            {
+              "_type": "TextualDisplay",
+              "textSpans": [
+                {
+                  "_type": "TextSpan",
+                  "text": "Fixed price"
+                }
+              ]
+            }
+          ]
+        },
+        "avgsalesprice": {
+          "avgsalesprice": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "$160.00"
+              }
+            ]
+          },
+          "averageshipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "+$20.27 shipping"
+              }
+            ]
+          },
+          "format": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "Fixed price"
+              }
+            ]
+          }
+        },
+        "avgshipping": {
+          "avgshipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "$20.27"
+              }
+            ]
+          },
+          "freeshipping": {
+            "_type": "TextualDisplay",
+            "textSpans": [
+              {
+                "_type": "TextSpan",
+                "text": "0% Free shipping"
+              }
+            ]
+          }
+        },
+        "itemssold": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "1"
+            }
+          ]
+        },
+        "totalsales": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "$160.00"
+            }
+          ]
+        },
+        "bids": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "-"
+            }
+          ]
+        },
+        "datelastsold": {
+          "_type": "TextualDisplay",
+          "textSpans": [
+            {
+              "_type": "TextSpan",
+              "text": "Jul 20, 2026"
+            }
+          ]
+        }
+      }
+    ],
+    "pagination": {
+      "summary": {
+        "_type": "TextualDisplay",
+        "textSpans": [
+          {
+            "_type": "TextSpan",
+            "text": "Results: 1 - 3"
+          }
+        ]
+      },
+      "first": {
+        "_type": "PaginationTextualDisplay",
+        "disabled": false,
+        "textSpans": [
+          {
+            "_type": "TextSpan"
+          }
+        ]
+      },
+      "prev": {
+        "_type": "PaginationTextualDisplay",
+        "disabled": true,
+        "textSpans": [
+          {
+            "_type": "TextSpan"
+          }
+        ]
+      },
+      "current": {
+        "_type": "TextualDisplay",
+        "textSpans": [
+          {
+            "_type": "TextSpan",
+            "text": "Page 1"
+          }
+        ]
+      },
+      "next": {
+        "_type": "PaginationTextualDisplay",
+        "disabled": true,
+        "textSpans": [
+          {
+            "_type": "TextSpan"
+          }
+        ]
+      },
+      "itemsPerPage": {
+        "options": [
+          {
+            "_type": "OptionValueSpan",
+            "value": "10",
+            "selected": false,
+            "text": "10"
+          },
+          {
+            "_type": "OptionValueSpan",
+            "value": "20",
+            "selected": false,
+            "text": "20"
+          },
+          {
+            "_type": "OptionValueSpan",
+            "value": "50",
+            "selected": true,
+            "text": "50"
+          }
+        ],
+        "label": "Results per page"
+      },
+      "currentPageNum": 1
+    }
+  }
+]

--- a/app/features/ebay-slab-pricing/evidence/slabEvidence.server.ts
+++ b/app/features/ebay-slab-pricing/evidence/slabEvidence.server.ts
@@ -1,9 +1,17 @@
 import { createProviderRequest } from "../connections/providerRequest.server";
 import { providerRequestGate } from "../connections/providerConnections.server";
 import { createAltEvidenceProvider } from "./altEvidenceProvider.server";
+import { createEbayResearchProvider } from "./ebayResearchProvider.server";
 
 export function createAltEvidenceForRun(signal?: AbortSignal) {
   return createAltEvidenceProvider(createProviderRequest(providerRequestGate), {
     signal,
   });
+}
+
+export function createEbayResearchForRun(signal?: AbortSignal) {
+  return createEbayResearchProvider(
+    createProviderRequest(providerRequestGate),
+    { signal },
+  );
 }

--- a/app/features/ebay-slab-pricing/evidence/slabEvidence.ts
+++ b/app/features/ebay-slab-pricing/evidence/slabEvidence.ts
@@ -14,6 +14,7 @@ export type SaleEvidence = {
   date: string | null;
   format: string | null;
   title: string | null;
+  extendedTitle?: string | null;
   card: SlabIdentity["card"] | null;
   grading: SlabIdentity["grading"];
   certificateNumber: string | null;
@@ -40,6 +41,8 @@ export type SalesEvidenceResult = {
   };
 };
 export type SupplyEvidence = {
+  title?: string | null;
+  extendedTitle?: string | null;
   provider: "alt" | "ebayResearch";
   providerId: string;
   assetId: string | null;

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -72,3 +72,4 @@ import "../features/shipping-export/components/steps/PackStep.test";
 import "../features/ebay-slab-pricing/connections/providerConnections.test";
 import "../features/ebay-slab-pricing/identity/slabIdentity.test";
 import "../features/ebay-slab-pricing/evidence/altEvidenceProvider.test";
+import "../features/ebay-slab-pricing/evidence/ebayResearchProvider.test";

--- a/docs/ebay-slab-research-evidence.md
+++ b/docs/ebay-slab-research-evidence.md
@@ -1,0 +1,19 @@
+# eBay Research evidence
+
+`createEbayResearchForRun(signal)` exposes on-demand `getSalesPage(query)` and `getSupplyPage(query)`. Queries include explicit keywords, an inclusive date window, offset, page size (10/20/50) and timezone. The current adapter supports EBAY-US and English USD displays. It defaults to three page requests per run; the lower-level factory allows a maximum of ten. Every request also uses the existing shared provider lease, cooldown, byte limit and deadline. Callers reschedule busy work rather than poll.
+
+`buildResearchKeywords(identity)` includes known card, language, edition, finish/stamp and grade constraints. The optional `omit-set` broadening is explicit and retains the other constraints. Results remain unverified candidates: the queried identity is never copied into each result. Screening and identity decisions follow in #26/#28.
+
+The transport now offers a decoded-chunk callback without retaining the full response string. The Research parser scans only new characters, handles separators spanning chunks, and bounds the stream to two MiB, 16 modules and 50 rows. UTF-8 decoding stays in the transport. Duplicate/missing modules, malformed/truncated JSON, real module failures, mismatched date windows and inconsistent pagination fail the request instead of returning an empty collection.
+
+The selected `ResultsHeaderModule` tab determines source state. Its auto-switch tooltip is present even in successful sold results and is not evidence of a fallback. A sold request that returns active state produces `status: "active-fallback"` without a sales property. Active rows never enter sale evidence. Sold rows use `kind: "listing-average"`, retain total sold and last-sold date, and are not expanded into independent transactions. Original/extended titles remain available for screening. Prices exclude shipping; unknown fees, quantities or grade fields remain unknown. Auction supply is classified as bid data, including a displayed starting bid, rather than an executable asking price.
+
+Empty results require the observed exact message for the requested keywords, the matching selected tab and an empty result module. eBay uses a warning for no sold results and an error for no active results; active emptiness also requires a zero active-listing total. Other errors cannot replace cached evidence with an empty result. Consumers must distinguish an empty sold page from unavailable data and active fallback.
+
+Dates are converted at midnight in the requested timezone and at the next day's midnight for the inclusive end, accounting for daylight-saving changes. Returned sold date headers, page number, page size and row-range summary must agree with the request. Page metadata exposes the next offset and partial-page status. Exhausting a keyword search still does not prove complete market coverage.
+
+## Verification on September 5, 2026
+
+Live configured reads reproduced 21 sold Ponyta rows, ten rows on the second ten-row page, and 24 active listings. The first active auction displayed 9.50 USD with four bids. Exact empty sold and active searches were captured independently; neither is inferred from a missing module. Contract fixtures project three real rows per nonempty page and adjust pagination summaries to that sample, preserving the observed nested display structures. Empty fixtures retain the actual empty-response shape. Fixtures contain no cookies, account credentials or tracking actions.
+
+Tests cover one-character through full-frame chunks, split UTF-8 data, sold-to-active fallback, genuine empty responses, placeholder versus real errors, partial/malformed streams, monetary fields, grouped averages, auction bids, page/budget limits, mismatched ranges and DST boundaries. Populated results are candidates awaiting screening, and the supplied aggregate summaries are display context rather than pricing-model inputs.


### PR DESCRIPTION
eBay Research returns streamed UI modules, listing averages and active-search fallbacks. Add a bounded streaming adapter that requires confirmed sold state before returning sales, preserves aggregate quantity/last-sold dates and item/shipping prices, and keeps active asking prices separate from auction bids.

The existing fixed-origin transport now supports decoded chunks without collecting the full response string. The parser handles arbitrary byte/frame boundaries, exact empty-result messages, real versus placeholder errors, and module/row/byte limits. Queries use explicit identity constraints, timezone-aware inclusive dates, checked pagination, and a small per-run request budget. No dependencies or new services are added.

Validation: full tests, typecheck, build and diff checks passed. Live reads reproduced 21 sold Ponyta rows, ten rows on the second ten-row page, and 24 active rows. Empty sold and active response shapes were captured independently. Contract tests cover split UTF-8, one-character chunks, truncation, partial modules, fallback, grouped averages, bids/asks, request budgets, date/page mismatches and DST boundaries.

Adversarial review found and fixed several source-specific traps: the fallback tooltip exists on successful sold responses; empty sold and active messages use different severity levels; date boundaries must account for timezone/DST; valid-looking truncated pages must fail their row-range check; active Best Offer availability is still an ask; and tiny chunks must not repeatedly rescan the buffered response. The final pass found no remaining actionable issues across composition, simplicity, design, performance and footprint.

Scope is English EBAY-US Research. Every returned row still needs identity screening, and completing a keyword search does not establish complete market coverage. Operational details and fixture projections are documented in `docs/ebay-slab-research-evidence.md`.

Fixes #23.
