### PR TITLE
Calculate descriptive slab ranges and reviewed seller asks

### DIFF
--- a/app/features/ebay-slab-pricing/routes/api.slab-recommendations.server.ts
+++ b/app/features/ebay-slab-pricing/routes/api.slab-recommendations.server.ts
@@ -1,0 +1,52 @@
+import { data } from "react-router";
+import { readSlabJsonRequest } from "../readJsonRequest.server";
+import {
+  calculateSlabRecommendation,
+  getSlabRecommendation,
+  overrideSlabPrice,
+} from "../valuation/slabRecommendations.server";
+import { SlabValuationError } from "../valuation/slabValuation";
+const respond = (body: unknown, status = 200) =>
+  data(body, { status, headers: { "Cache-Control": "no-store" } });
+const failure = (error: unknown) =>
+  respond(
+    {
+      error:
+        error instanceof SlabValuationError
+          ? error.message
+          : "Unable to calculate a slab recommendation.",
+    },
+    error instanceof SlabValuationError ||
+      error instanceof SyntaxError ||
+      error instanceof TypeError
+      ? 400
+      : 500,
+  );
+export async function loader({ request }: { request: Request }) {
+  try {
+    const record = await getSlabRecommendation(
+      new URL(request.url).searchParams.get("id") ?? "",
+    );
+    return record
+      ? respond(record)
+      : respond({ error: "Recommendation not found." }, 404);
+  } catch (error) {
+    return failure(error);
+  }
+}
+export async function action({ request }: { request: Request }) {
+  if (request.method !== "POST")
+    return respond({ error: "Method not allowed." }, 405);
+  if (request.headers.get("Origin") !== new URL(request.url).origin)
+    return respond({ error: "Submit this request from the application." }, 403);
+  try {
+    const input = await readSlabJsonRequest(request, 16384);
+    if (input.intent === "calculate")
+      return respond(await calculateSlabRecommendation(input));
+    if (input.intent === "override")
+      return respond(await overrideSlabPrice(input));
+    throw new SlabValuationError("Choose calculate or override.");
+  } catch (error) {
+    return failure(error);
+  }
+}

--- a/app/features/ebay-slab-pricing/routes/api.slab-recommendations.ts
+++ b/app/features/ebay-slab-pricing/routes/api.slab-recommendations.ts
@@ -1,0 +1,1 @@
+export { loader, action } from "./api.slab-recommendations.server";

--- a/app/features/ebay-slab-pricing/valuation/directCompInputs.ts
+++ b/app/features/ebay-slab-pricing/valuation/directCompInputs.ts
@@ -1,0 +1,166 @@
+import type { StoredSlabIdentity } from "../identity/slabIdentity";
+import {
+  reconcileSaleEvents,
+  type SaleReference,
+} from "../screening/compEvents";
+import {
+  screenComparableSale,
+  type CompDecision,
+} from "../screening/screenComparables";
+import type {
+  DirectComp,
+  EvidenceQuality,
+  ValuationPolicy,
+} from "./slabValuation";
+
+export type CompDisposition = {
+  key: string;
+  status: "needs-review" | "rejected";
+  reasons: string[];
+  references: DirectComp["references"];
+};
+export function collectDirectComps(
+  references: SaleReference[],
+  target: StoredSlabIdentity,
+  decisions: CompDecision[],
+  policy: ValuationPolicy,
+) {
+  const decisionIndex = new Map(
+    decisions.map((decision) => [
+      JSON.stringify([
+        decision.revisionId,
+        decision.provider,
+        decision.providerId,
+        decision.date,
+      ]),
+      decision,
+    ]),
+  );
+  const comps: DirectComp[] = [],
+    dispositions: CompDisposition[] = [],
+    eventWarnings = new Set<string>();
+  const activeReferences = references.filter((reference) => {
+    const decision = decisionIndex.get(
+      JSON.stringify([
+        reference.revisionId,
+        reference.sale.provider,
+        reference.sale.providerId,
+        reference.sale.date,
+      ]),
+    );
+    if (
+      decision?.decision !== "exclude" ||
+      decision.valuationGroupKey !== target.valuationGroupKey ||
+      !decision.note.trim()
+    )
+      return true;
+    dispositions.push({
+      key: `excluded:${reference.revisionId}:${reference.sale.provider}:${reference.sale.providerId}:${reference.sale.date}`,
+      status: "rejected",
+      reasons: ["excluded-by-review"],
+      references: [
+        {
+          revisionId: reference.revisionId,
+          provider: reference.sale.provider,
+          providerId: reference.sale.providerId,
+          date: reference.sale.date,
+        },
+      ],
+    });
+    return false;
+  });
+  for (const event of reconcileSaleEvents(activeReferences)) {
+    const screened = event.references.map((reference) =>
+      screenComparableSale(reference, target, {
+        currency: policy.currency,
+        decision: decisionIndex.get(
+          JSON.stringify([
+            reference.revisionId,
+            reference.sale.provider,
+            reference.sale.providerId,
+            reference.sale.date,
+          ]),
+        ),
+      }),
+    );
+    const accepted = screened
+      .filter((row) => row.status === "accepted")
+      .sort(
+        (a, b) =>
+          Number(b.reference.sale.provider === "ebayResearch") -
+            Number(a.reference.sale.provider === "ebayResearch") ||
+          b.reference.fetchedAt.localeCompare(a.reference.fetchedAt),
+      );
+    const refIds = event.references.map((ref) => ({
+      revisionId: ref.revisionId,
+      provider: ref.sale.provider,
+      providerId: ref.sale.providerId,
+      date: ref.sale.date,
+    }));
+    const selected = accepted.find((row) =>
+      policy.basis === "item-only"
+        ? row.price.itemOnly
+        : row.price.itemAndShipping,
+    );
+    const blockedEvent = event.reasons.some((reason) =>
+      [
+        "possible-duplicate-event-requires-review",
+        "aggregate-may-overlap-individual-sales",
+        "source-price-disagreement",
+      ].includes(reason),
+    );
+    const contradictory = screened.some((row) => row.status === "rejected");
+    if (selected && !blockedEvent && !contradictory) {
+      const price =
+        policy.basis === "item-only"
+          ? selected.price.itemOnly!
+          : selected.price.itemAndShipping!;
+      // Keep the price reference first, with all corroborating sources after it.
+      const primary = refIds.find(
+        (ref) =>
+          ref.revisionId === selected.reference.revisionId &&
+          ref.provider === selected.reference.sale.provider &&
+          ref.providerId === selected.reference.sale.providerId,
+      )!;
+      comps.push({
+        key: event.key,
+        date: selected.reference.sale.date!,
+        amount: price.amount,
+        currency: price.currency!,
+        kind: event.kind,
+        references: [primary, ...refIds.filter((ref) => ref !== primary)],
+      });
+      event.reasons.forEach((reason) => eventWarnings.add(reason));
+    } else {
+      const reasons = new Set([
+        ...event.reasons,
+        ...screened.flatMap((row) => row.reasons.map((reason) => reason.code)),
+      ]);
+      if (accepted.length && !selected)
+        reasons.add("requested-price-basis-unresolved");
+      dispositions.push({
+        key: event.key,
+        status:
+          contradictory && screened.every((row) => row.status === "rejected")
+            ? "rejected"
+            : "needs-review",
+        reasons: [...reasons].sort(),
+        references: refIds,
+      });
+    }
+  }
+  return {
+    comps,
+    dispositions,
+    decisions,
+    quality: {
+      uncertain: dispositions.filter((row) => row.status === "needs-review")
+        .length,
+      rejected: dispositions.filter((row) => row.status === "rejected").length,
+      eventWarnings: [...eventWarnings].sort(),
+    } satisfies Pick<
+      EvidenceQuality,
+      "uncertain" | "rejected" | "eventWarnings"
+    >,
+  };
+}

--- a/app/features/ebay-slab-pricing/valuation/slabRecommendations.integration.test.ts
+++ b/app/features/ebay-slab-pricing/valuation/slabRecommendations.integration.test.ts
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import pg from "pg";
+import dotenv from "dotenv";
+import { getPool } from "~/core/db/database.server";
+import { slabIdentityStore } from "../identity/slabIdentities.server";
+import { valuationGroupKey } from "../identity/slabIdentityService.server";
+import {
+  requestEvidence,
+  claimEvidenceJob,
+  completeEvidenceJob,
+  cleanEvidenceCache,
+} from "../evidence/evidenceRefreshStore.server";
+import { saveCompDecision } from "../screening/compDecisions.server";
+import { compTarget, compSale } from "../screening/screenComparables.test";
+import { DEFAULT_SLAB_POLICY } from "./slabValuation";
+import { sellerContext } from "./slabValuation.test";
+import {
+  calculateSlabRecommendation,
+  getSlabRecommendation,
+  overrideSlabPrice,
+} from "./slabRecommendations.server";
+
+dotenv.config({
+  path: [".env.development.local", ".env.local", ".env.development", ".env"],
+  quiet: true,
+});
+const url = new URL(
+  process.env.DATABASE_URL ??
+    "postgresql://postgres:postgres@localhost:5433/tcgplayer_automation",
+);
+assert.ok(
+  ["localhost", "127.0.0.1"].includes(url.hostname) &&
+    url.port === "5433" &&
+    url.pathname === "/tcgplayer_automation",
+);
+const admin = new pg.Client({ connectionString: url.toString() }),
+  schema = `slab_valuation_test_${randomUUID().replaceAll("-", "")}`;
+await admin.connect();
+await admin.query(`CREATE SCHEMA "${schema}"`);
+url.searchParams.set("options", `-c search_path=${schema}`);
+process.env.DATABASE_URL = url.toString();
+const db = getPool();
+const originalFetch = globalThis.fetch;
+try {
+  for (const name of [
+    "025_add_slab_identities.sql",
+    "027_add_slab_evidence_refreshes.sql",
+    "028_add_slab_comp_decisions.sql",
+    "029_add_slab_recommendations.sql",
+  ])
+    await db.query(await readFile(`db/migrations/${name}`, "utf8"));
+  const cert = {
+    grader: compTarget.grader,
+    certificateNumber: compTarget.certificateNumber,
+  };
+  const created = await slabIdentityStore.saveCandidate(cert, null, []);
+  const target = (await slabIdentityStore.confirm(
+    cert,
+    created.revision,
+    compTarget.identity!,
+    valuationGroupKey(compTarget.identity!),
+    "Fixture identity",
+  ))!;
+  const revisionIds: string[] = [],
+    sales = [];
+  for (let index = 0; index < 3; index++) {
+    const sale = {
+      ...compSale,
+      providerId: `sale-${index}`,
+      sourceItemId: `12345678901${index}`,
+      date: new Date(Date.now() - index * 86400000).toISOString().slice(0, 10),
+      price: { amount: 99 + index, currency: "USD" },
+    };
+    const spec = {
+      kind: "alt-sale-detail" as const,
+      transactionId: sale.providerId,
+    };
+    await requestEvidence([spec]);
+    const job = (await claimEvidenceJob())!;
+    await completeEvidenceJob(job, { kind: "alt-sale-detail", data: sale }, 1);
+    revisionIds.push(job.runId);
+    sales.push(sale);
+  }
+  globalThis.fetch = async () => {
+    throw Error("Valuation must never fetch upstream");
+  };
+  const input = {
+    slabId: target.id,
+    identityRevision: target.revision,
+    revisionIds,
+    policy: DEFAULT_SLAB_POLICY,
+    seller: sellerContext,
+  };
+  const asOf = new Date(Date.now() + 10).toISOString();
+  const result = await calculateSlabRecommendation(input, asOf);
+  assert.equal(result.calculation.market.status, "direct-evidence");
+  assert.equal(result.calculation.ask.proposedItemAsk, 100);
+  assert.equal(
+    (await calculateSlabRecommendation(input, asOf)).id,
+    result.id,
+    "identical calculations are idempotent",
+  );
+  assert.equal((await getSlabRecommendation(result.id))?.current, true);
+  await overrideSlabPrice({
+    recommendationId: result.id,
+    itemPrice: 105,
+    currency: "USD",
+    note: "Reviewed seller adjustment",
+  });
+  const overridden = await getSlabRecommendation(result.id);
+  assert.equal(overridden?.calculation.ask.proposedItemAsk, 100);
+  assert.equal(
+    overridden?.override?.itemPrice,
+    105,
+    "override is separate from model calculation",
+  );
+  await saveCompDecision({
+    slabId: target.id,
+    identityRevision: target.revision,
+    revisionId: revisionIds[0],
+    provider: "alt",
+    providerId: sales[0].providerId,
+    date: sales[0].date,
+    decision: "exclude",
+    note: "Reviewed source mismatch",
+  });
+  assert.equal(
+    (await getSlabRecommendation(result.id))?.current,
+    false,
+    "changed comp decisions invalidate a recommendation",
+  );
+  const recalculated = await calculateSlabRecommendation(
+    input,
+    new Date(Date.now() + 10).toISOString(),
+  );
+  assert.equal(recalculated.calculation.market.count, 2);
+  assert.equal(recalculated.calculation.ask.proposedItemAsk, null);
+  await db.query(
+    "UPDATE slab_evidence_revisions SET created_at=clock_timestamp()-interval '100 days'",
+  );
+  await db.query(
+    "UPDATE slab_evidence_refreshes SET updated_at=clock_timestamp()-interval '100 days'",
+  );
+  await cleanEvidenceCache();
+  assert.equal(
+    (
+      await db.query(
+        "SELECT 1 FROM slab_recommendation_evidence WHERE recommendation_id=$1",
+        [result.id],
+      )
+    ).rowCount,
+    3,
+  );
+  await db.query(
+    "UPDATE slab_evidence_refreshes SET expires_at=clock_timestamp()-interval '1 second'",
+  );
+  assert.equal(
+    (await getSlabRecommendation(recalculated.id))?.current,
+    false,
+    "expired evidence makes currency explicit",
+  );
+  const changed = {
+    ...target.identity!,
+    card: { ...target.identity!.card, language: "Spanish" },
+  };
+  await slabIdentityStore.confirm(
+    cert,
+    target.revision,
+    changed,
+    valuationGroupKey(changed),
+    "Corrected identity",
+  );
+  await assert.rejects(
+    overrideSlabPrice({
+      recommendationId: result.id,
+      itemPrice: 110,
+      currency: "USD",
+      note: "Stale target",
+    }),
+    /changed/,
+  );
+  await assert.rejects(calculateSlabRecommendation(input), /identity changed/);
+  console.log(
+    "PASS offline recommendation persistence, idempotence, separate overrides, review/identity/evidence invalidation and retained sources",
+  );
+} finally {
+  globalThis.fetch = originalFetch;
+  await db.end();
+  await admin.query(`DROP SCHEMA "${schema}" CASCADE`);
+  await admin.end();
+}

--- a/app/features/ebay-slab-pricing/valuation/slabRecommendations.server.ts
+++ b/app/features/ebay-slab-pricing/valuation/slabRecommendations.server.ts
@@ -1,0 +1,309 @@
+import { createHash, randomUUID } from "node:crypto";
+import { queryOne, withTransaction } from "~/core/db/database.server";
+import type { StoredSlabIdentity } from "../identity/slabIdentity";
+import type { EvidencePayload } from "../evidence/evidenceRefreshProvider.server";
+import type { EvidenceSpec } from "../evidence/evidenceRefresh";
+import { retainEvidenceRevisions } from "../evidence/evidenceRefreshStore.server";
+import type { SaleReference } from "../screening/compEvents";
+import type { CompDecision } from "../screening/screenComparables";
+import { collectDirectComps } from "./directCompInputs";
+import {
+  estimateSlabMarket,
+  proposeSlabAsk,
+  validateValuationPolicy,
+  validateSellerPriceContext,
+  SlabValuationError,
+  type SellerPriceContext,
+  type ValuationPolicy,
+} from "./slabValuation";
+
+const uuid = (id: unknown): id is string =>
+  typeof id === "string" &&
+  /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/.test(id);
+export type RecommendationInput = {
+  slabId: string;
+  identityRevision: number;
+  revisionIds: string[];
+  policy: ValuationPolicy;
+  seller: SellerPriceContext;
+};
+type EvidenceRow = {
+  id: string;
+  payload: EvidencePayload;
+  spec: EvidenceSpec;
+  fetchedAt: Date;
+  expiresAt: Date | null;
+  latestRevision: string | null;
+  state: string;
+  bytes: number;
+};
+export async function calculateSlabRecommendation(
+  input: RecommendationInput,
+  asOf = new Date().toISOString(),
+) {
+  if (
+    !input ||
+    !uuid(input.slabId) ||
+    !Number.isSafeInteger(input.identityRevision) ||
+    input.identityRevision < 1 ||
+    !Array.isArray(input.revisionIds) ||
+    input.revisionIds.length > 20 ||
+    input.revisionIds.some((id) => !uuid(id)) ||
+    !Number.isFinite(Date.parse(asOf))
+  )
+    throw new SlabValuationError(
+      "Choose a current slab identity and at most twenty evidence revisions.",
+    );
+  input = {
+    ...input,
+    policy: validateValuationPolicy(input.policy),
+    seller: validateSellerPriceContext(input.seller, input.policy.currency),
+  };
+  const revisionIds = [...new Set(input.revisionIds)].sort();
+  return withTransaction(async (db) => {
+    await db.query("SET LOCAL statement_timeout = '15s'");
+    const target = (
+      await db.query<StoredSlabIdentity>(
+        `SELECT id, grader, certificate_number AS "certificateNumber", identity, status, revision, valuation_group_key AS "valuationGroupKey" FROM slab_identities
+      WHERE id = $1 AND revision = $2 AND status = 'confirmed' FOR SHARE`,
+        [input.slabId, input.identityRevision],
+      )
+    ).rows[0];
+    if (!target?.identity || !target.valuationGroupKey)
+      throw new SlabValuationError(
+        "The slab identity changed or is unconfirmed. Reload before calculating.",
+      );
+    const size = (
+      await db.query<{ count: number; bytes: number }>(
+        "SELECT count(*)::int AS count, COALESCE(sum(byte_count),0)::int AS bytes FROM slab_evidence_revisions WHERE id=ANY($1::uuid[])",
+        [revisionIds],
+      )
+    ).rows[0];
+    if (size.count !== revisionIds.length || size.bytes > 5 * 1024 * 1024)
+      throw new SlabValuationError(
+        "Evidence expired or the selection exceeds the calculation limit.",
+      );
+    const evidence = (
+      await db.query<EvidenceRow>(
+        `SELECT r.id, r.payload, r.fetched_at AS "fetchedAt", r.byte_count AS bytes,
+      j.spec, j.expires_at AS "expiresAt", j.latest_revision AS "latestRevision", j.state
+      FROM slab_evidence_revisions r JOIN slab_evidence_refreshes j ON j.key = r.key WHERE r.id = ANY($1::uuid[]) ORDER BY r.id FOR SHARE OF r`,
+        [revisionIds],
+      )
+    ).rows;
+    if (
+      evidence.length !== revisionIds.length ||
+      evidence.reduce((sum, row) => sum + row.bytes, 0) > 5 * 1024 * 1024
+    )
+      throw new SlabValuationError(
+        "Evidence expired or the selection exceeds the calculation limit.",
+      );
+    const references: SaleReference[] = [];
+    let capped = false,
+      partial = false,
+      stale = false;
+    for (const row of evidence) {
+      if (row.fetchedAt.getTime() > Date.parse(asOf))
+        throw new SlabValuationError(
+          "Evidence was captured after this calculation time.",
+        );
+      if (
+        (row.spec.kind === "ebay-sales" || row.spec.kind === "ebay-supply") &&
+        row.spec.groupKey !== target.valuationGroupKey
+      )
+        throw new SlabValuationError(
+          "The eBay evidence belongs to another valuation identity.",
+        );
+      if (
+        (row.spec.kind === "alt-sales" || row.spec.kind === "alt-supply") &&
+        row.spec.assetId !== target.identity.providerAsset?.id
+      )
+        throw new SlabValuationError(
+          "The Alt evidence belongs to another card asset.",
+        );
+      stale ||=
+        !row.expiresAt ||
+        row.expiresAt.getTime() <= Date.parse(asOf) ||
+        row.latestRevision !== row.id ||
+        row.state === "failed";
+      const payload = row.payload;
+      if (payload.kind === "alt-supply" || payload.kind === "ebay-supply")
+        throw new SlabValuationError(
+          "Supply observations cannot be used as sold comps.",
+        );
+      if (payload.kind === "alt-sale-detail") {
+        if (payload.data) {
+          if (
+            payload.data.assetId &&
+            target.identity.providerAsset?.id &&
+            payload.data.assetId !== target.identity.providerAsset.id
+          )
+            throw new SlabValuationError(
+              "The sale detail belongs to another card asset.",
+            );
+          references.push({
+            revisionId: row.id,
+            fetchedAt: row.fetchedAt.toISOString(),
+            window: {
+              from: new Date(
+                Date.parse(asOf) - input.policy.maximumAgeDays * 86400000,
+              )
+                .toISOString()
+                .slice(0, 10),
+              to: asOf.slice(0, 10),
+            },
+            sale: payload.data,
+          });
+        }
+      } else if (
+        payload.kind === "alt-sales" ||
+        payload.data.status === "sold"
+      ) {
+        capped ||= payload.data.coverage!.reason === "capped-per-grade";
+        partial ||= !payload.data.coverage!.complete;
+        for (const sale of payload.data.sales!)
+          references.push({
+            revisionId: row.id,
+            fetchedAt: row.fetchedAt.toISOString(),
+            window: payload.data.coverage!.requestedWindow,
+            sale,
+          });
+      }
+    }
+    if (references.length > 2000)
+      throw new SlabValuationError(
+        "Narrow the evidence selection to at most 2,000 observations.",
+      );
+    const decisions = (
+      await db.query<{ decision: CompDecision }>(
+        "SELECT decision FROM slab_comp_decisions WHERE valuation_group_key = $1 AND revision_id = ANY($2::uuid[]) ORDER BY revision_id,event_key",
+        [target.valuationGroupKey, revisionIds],
+      )
+    ).rows.map((row) => row.decision);
+    const direct = collectDirectComps(
+      references,
+      target,
+      decisions,
+      input.policy,
+    );
+    const market = estimateSlabMarket({
+      comps: direct.comps,
+      quality: { ...direct.quality, stale, capped, partial },
+      asOf,
+      policy: input.policy,
+    });
+    const ask = proposeSlabAsk(market, input.seller, input.policy);
+    const calculation = {
+      identity: {
+        slabId: target.id,
+        revision: target.revision,
+        valuationGroupKey: target.valuationGroupKey,
+      },
+      policyVersion: "slab-policy-v1",
+      policy: input.policy,
+      seller: input.seller,
+      market,
+      ask,
+      dispositions: direct.dispositions,
+      decisions,
+      evidence: evidence.map((row) => ({
+        revisionId: row.id,
+        fetchedAt: row.fetchedAt.toISOString(),
+        expiresAt: row.expiresAt?.toISOString() ?? null,
+        spec: row.spec,
+      })),
+    };
+    const json = JSON.stringify(calculation);
+    if (Buffer.byteLength(json) > 512 * 1024)
+      throw new SlabValuationError(
+        "The calculation exceeds its storage limit. Narrow the evidence selection.",
+      );
+    const inputKey = createHash("sha256").update(json).digest("hex");
+    const id = randomUUID();
+    const saved = (
+      await db.query<{ id: string }>(
+        `INSERT INTO slab_recommendations(id,input_key,slab_id,identity_revision,valuation_group_key,calculation) VALUES($1,$2,$3,$4,$5,$6)
+      ON CONFLICT(input_key) DO UPDATE SET input_key = EXCLUDED.input_key RETURNING id`,
+        [
+          id,
+          inputKey,
+          target.id,
+          target.revision,
+          target.valuationGroupKey,
+          json,
+        ],
+      )
+    ).rows[0];
+    await db.query(
+      "INSERT INTO slab_recommendation_evidence(recommendation_id,revision_id) SELECT $1, unnest($2::uuid[]) ON CONFLICT DO NOTHING",
+      [saved.id, revisionIds],
+    );
+    await retainEvidenceRevisions(revisionIds, db);
+    return { id: saved.id, calculation };
+  });
+}
+export type SlabCalculation = Awaited<
+  ReturnType<typeof calculateSlabRecommendation>
+>["calculation"];
+export type StoredSlabRecommendation = {
+  id: string;
+  calculation: SlabCalculation;
+  current: boolean;
+  override: {
+    itemPrice: number;
+    currency: string;
+    note: string;
+    reviewedAt: string;
+  } | null;
+};
+export async function getSlabRecommendation(id: string) {
+  if (!uuid(id)) throw new SlabValuationError("Choose a recommendation.");
+  return queryOne<StoredSlabRecommendation>(
+    `SELECT r.id, r.calculation, (i.revision = r.identity_revision AND i.valuation_group_key = r.valuation_group_key AND i.status = 'confirmed'
+    AND r.calculation->'decisions' = COALESCE((SELECT jsonb_agg(d.decision ORDER BY d.revision_id,d.event_key) FROM slab_comp_decisions d
+      WHERE d.valuation_group_key=r.valuation_group_key AND d.revision_id IN (SELECT revision_id FROM slab_recommendation_evidence WHERE recommendation_id=r.id)), '[]'::jsonb)
+    AND NOT EXISTS (SELECT 1 FROM slab_recommendation_evidence e JOIN slab_evidence_revisions v ON v.id=e.revision_id
+      JOIN slab_evidence_refreshes j ON j.key=v.key WHERE e.recommendation_id=r.id AND (j.latest_revision IS DISTINCT FROM v.id OR j.expires_at <= clock_timestamp() OR j.expires_at IS NULL OR j.state='failed'))) AS current,
+    CASE WHEN o.recommendation_id IS NULL THEN NULL ELSE jsonb_build_object('itemPrice',o.item_price,'currency',o.currency,'note',o.note,'reviewedAt',o.reviewed_at) END AS override
+    FROM slab_recommendations r JOIN slab_identities i ON i.id=r.slab_id LEFT JOIN slab_price_overrides o ON o.recommendation_id=r.id WHERE r.id=$1`,
+    [id],
+  );
+}
+export async function overrideSlabPrice(input: {
+  recommendationId: string;
+  itemPrice: number;
+  currency: string;
+  note: string;
+}) {
+  if (
+    !input ||
+    !uuid(input.recommendationId) ||
+    !Number.isFinite(input.itemPrice) ||
+    input.itemPrice <= 0 ||
+    input.itemPrice >= 1e9 ||
+    !/^[A-Z]{3}$/.test(input.currency) ||
+    typeof input.note !== "string" ||
+    !input.note.trim() ||
+    input.note.length > 1000
+  )
+    throw new SlabValuationError(
+      "Provide an explicit item price, currency and review reason.",
+    );
+  const saved = await queryOne(
+    `INSERT INTO slab_price_overrides(recommendation_id,item_price,currency,note)
+    SELECT r.id,$2,$3,$4 FROM slab_recommendations r JOIN slab_identities i ON i.id=r.slab_id
+    WHERE r.id=$1 AND i.revision=r.identity_revision AND i.status='confirmed' AND i.valuation_group_key=r.valuation_group_key AND r.calculation->'policy'->>'currency'=$3
+    ON CONFLICT(recommendation_id) DO UPDATE SET item_price=EXCLUDED.item_price,currency=EXCLUDED.currency,note=EXCLUDED.note,reviewed_at=clock_timestamp() RETURNING recommendation_id`,
+    [
+      input.recommendationId,
+      input.itemPrice,
+      input.currency,
+      input.note.trim(),
+    ],
+  );
+  if (!saved)
+    throw new SlabValuationError(
+      "The recommendation changed or uses another currency. Recalculate before overriding.",
+    );
+  return getSlabRecommendation(input.recommendationId);
+}

--- a/app/features/ebay-slab-pricing/valuation/slabValuation.test.ts
+++ b/app/features/ebay-slab-pricing/valuation/slabValuation.test.ts
@@ -1,0 +1,297 @@
+import assert from "node:assert/strict";
+import {
+  DEFAULT_SLAB_POLICY,
+  estimateSlabMarket,
+  proposeSlabAsk,
+  type DirectComp,
+  type EvidenceQuality,
+  type SellerPriceContext,
+} from "./slabValuation";
+import { collectDirectComps } from "./directCompInputs";
+import {
+  compReference,
+  compSale,
+  compTarget,
+} from "../screening/screenComparables.test";
+
+export const sellerContext: SellerPriceContext = {
+  currency: "USD",
+  currentAsk: 100,
+  shippingCharged: 0,
+  shippingCost: null,
+  acquisitionCost: null,
+  fees: null,
+  minimumAsk: null,
+  minimumProfit: null,
+};
+const quality: EvidenceQuality = {
+  stale: false,
+  capped: false,
+  partial: false,
+  uncertain: 0,
+  rejected: 0,
+  eventWarnings: [],
+};
+const asOf = "2026-09-05T12:00:00Z";
+const comp = (
+  amount: number,
+  index: number,
+  date = "2026-09-04",
+): DirectComp => ({
+  key: `event-${index}`,
+  amount,
+  currency: "USD",
+  date,
+  kind: "single-sale",
+  references: [
+    {
+      revisionId: `revision-${index}`,
+      provider: "alt",
+      providerId: `sale-${index}`,
+      date,
+    },
+  ],
+});
+const estimate = (
+  comps: DirectComp[],
+  changed: Partial<EvidenceQuality> = {},
+) =>
+  estimateSlabMarket({
+    comps,
+    quality: { ...quality, ...changed },
+    asOf,
+    policy: DEFAULT_SLAB_POLICY,
+  });
+assert.equal(estimate([]).status, "insufficient-evidence");
+assert.equal(estimate([]).range, null);
+assert.equal(estimate([], { uncertain: 5 }).status, "needs-review");
+assert.equal(estimate([comp(100, 1)]).range, null);
+const prices = [90, 100, 110].map((amount, index) => comp(amount, index));
+const market = estimate(prices);
+assert.equal(market.status, "direct-evidence");
+assert.equal(market.range?.midpoint, 100);
+assert.equal(market.range?.calibrated, false);
+assert.deepEqual(
+  estimate(prices),
+  market,
+  "same inputs produce the same calculation",
+);
+const ask = proposeSlabAsk(market, sellerContext, DEFAULT_SLAB_POLICY);
+assert.equal(ask.proposedItemAsk, 100);
+assert.equal(ask.estimatedProfit, null);
+assert.equal(ask.estimatedProceeds, null);
+assert.equal(
+  proposeSlabAsk(
+    market,
+    { ...sellerContext, shippingCharged: 5 },
+    DEFAULT_SLAB_POLICY,
+  ).proposedItemAsk,
+  95,
+);
+assert.equal(
+  proposeSlabAsk(
+    market,
+    { ...sellerContext, shippingCharged: null },
+    DEFAULT_SLAB_POLICY,
+  ).proposedItemAsk,
+  null,
+);
+assert.equal(
+  estimate(prices, { capped: true, partial: true }).range?.midpoint,
+  100,
+);
+assert.ok(
+  estimate(prices, { capped: true }).flags.some(
+    (flag) => flag.code === "capped-source-history",
+  ),
+);
+assert.equal(estimate(prices, { stale: true }).status, "needs-review");
+assert.equal(
+  estimate(prices.map((row) => ({ ...row, date: "2020-01-01" }))).range,
+  null,
+);
+assert.equal(
+  estimate(prices.map((row) => ({ ...row, date: "2026-01-01" }))).range,
+  null,
+  "recency lowers effective evidence count even for equal-age sales",
+);
+assert.equal(
+  estimate(prices.map((row) => ({ ...row, currency: "EUR" }))).range,
+  null,
+);
+const mean = estimate(
+  prices.map((row) => ({ ...row, kind: "listing-average" as const })),
+);
+assert.equal(mean.count, 3);
+assert.equal(mean.status, "needs-review");
+const extreme = estimate([...prices, comp(10000, 10)]);
+assert.equal(extreme.count, 4);
+assert.equal(extreme.status, "needs-review");
+assert.equal(extreme.observedSpan?.high, 10000);
+assert.ok(
+  extreme.comps.some((row) => row.amount === 10000),
+  "legitimate premium remains in the evidence",
+);
+const floor = proposeSlabAsk(
+  market,
+  {
+    ...sellerContext,
+    acquisitionCost: 120,
+    shippingCost: 5,
+    shippingCharged: 5,
+    fees: { rate: 0.1, fixed: 0.3, basis: "item-plus-shipping" },
+    minimumProfit: 10,
+  },
+  DEFAULT_SLAB_POLICY,
+);
+assert.equal(floor.proposedItemAsk, 145.34);
+assert.ok(floor.estimatedProfit! >= 10);
+assert.ok(
+  floor.flags.some((flag) => flag.code === "seller-floor-raised-proposed-ask"),
+);
+assert.equal(
+  proposeSlabAsk(
+    market,
+    { ...sellerContext, minimumProfit: 0 },
+    DEFAULT_SLAB_POLICY,
+  ).proposedItemAsk,
+  null,
+);
+assert.equal(
+  proposeSlabAsk(
+    market,
+    { ...sellerContext, minimumAsk: 100.001 },
+    DEFAULT_SLAB_POLICY,
+  ).proposedItemAsk,
+  100.01,
+);
+assert.equal(
+  proposeSlabAsk(
+    market,
+    { ...sellerContext, currentAsk: 200 },
+    DEFAULT_SLAB_POLICY,
+  ).requiresReview,
+  true,
+);
+assert.throws(() =>
+  proposeSlabAsk(
+    market,
+    { ...sellerContext, fees: { rate: 1, fixed: 0, basis: "item-only" } },
+    DEFAULT_SLAB_POLICY,
+  ),
+);
+assert.throws(() =>
+  proposeSlabAsk(
+    market,
+    {
+      ...sellerContext,
+      fees: { rate: 0.1, fixed: null as unknown as number, basis: "item-only" },
+    },
+    DEFAULT_SLAB_POLICY,
+  ),
+);
+assert.throws(() =>
+  estimateSlabMarket({
+    comps: prices,
+    quality,
+    asOf,
+    policy: { ...DEFAULT_SLAB_POLICY, roundingIncrement: 0 },
+  }),
+);
+assert.throws(() => estimate([prices[0], prices[0]]));
+// Exact item+shipping amounts and dates from the captured store evaluation, even assuming identity review succeeds.
+for (const sample of [
+  {
+    name: "Slaking PSA 9",
+    ask: 100,
+    sales: [comp(16, 1, "2026-07-08"), comp(20.72, 2, "2026-07-26")],
+  },
+  {
+    name: "Buneary Master Ball PSA 10",
+    ask: 215,
+    sales: [comp(104.99, 1, "2026-07-24"), comp(116.98, 2, "2026-06-08")],
+  },
+]) {
+  const sparse = estimate(sample.sales),
+    proposal = proposeSlabAsk(
+      sparse,
+      { ...sellerContext, currentAsk: sample.ask },
+      DEFAULT_SLAB_POLICY,
+    );
+  assert.equal(sparse.range, null, sample.name);
+  assert.equal(proposal.proposedItemAsk, null, sample.name);
+  assert.ok(
+    proposal.flags.some(
+      (flag) => flag.code === "current-ask-above-sparse-observed-sales",
+    ),
+    sample.name,
+  );
+}
+const direct = collectDirectComps(
+  [compReference],
+  compTarget,
+  [],
+  DEFAULT_SLAB_POLICY,
+);
+const copy = {
+  ...compReference,
+  revisionId: "ebay-copy",
+  sale: {
+    ...compSale,
+    provider: "ebayResearch" as const,
+    providerId: compSale.sourceItemId!,
+    kind: "listing-average" as const,
+  },
+};
+const wrongSource = {
+  ...compReference,
+  sale: { ...compSale, price: { amount: 200, currency: "USD" } },
+};
+assert.equal(
+  collectDirectComps([wrongSource, copy], compTarget, [], DEFAULT_SLAB_POLICY)
+    .comps.length,
+  0,
+);
+const reviewedExclusion = collectDirectComps(
+  [wrongSource, copy],
+  compTarget,
+  [
+    {
+      revisionId: compReference.revisionId,
+      provider: compSale.provider,
+      providerId: compSale.providerId,
+      date: compSale.date,
+      valuationGroupKey: compTarget.valuationGroupKey!,
+      decision: "exclude",
+      note: "This source reported an incorrect amount",
+      itemPrice: null,
+    },
+  ],
+  DEFAULT_SLAB_POLICY,
+);
+assert.equal(reviewedExclusion.comps.length, 1);
+assert.equal(reviewedExclusion.comps[0].amount, 100);
+assert.equal(direct.comps.length, 1);
+assert.equal(direct.comps[0].amount, 100);
+const missingShipping = collectDirectComps(
+  [{ ...compReference, sale: { ...compSale, shipping: null } }],
+  compTarget,
+  [
+    {
+      revisionId: compReference.revisionId,
+      provider: compSale.provider,
+      providerId: compSale.providerId,
+      date: compSale.date,
+      valuationGroupKey: compTarget.valuationGroupKey!,
+      decision: "accept",
+      note: "Verified item quote",
+      itemPrice: { amount: 100, currency: "USD" },
+    },
+  ],
+  DEFAULT_SLAB_POLICY,
+);
+assert.equal(missingShipping.comps.length, 0);
+assert.equal(missingShipping.dispositions[0].status, "needs-review");
+console.log(
+  "PASS direct weighted ranges, sparse examples, coverage, grouped means, premiums, money uncertainty, seller floors and rounding",
+);

--- a/app/features/ebay-slab-pricing/valuation/slabValuation.ts
+++ b/app/features/ebay-slab-pricing/valuation/slabValuation.ts
@@ -1,0 +1,441 @@
+export type ValuationPolicy = {
+  currency: string;
+  basis: "item-only" | "item-plus-shipping";
+  minimumComps: number;
+  minimumEffectiveCount: number;
+  halfLifeDays: number;
+  maximumAgeDays: number;
+  roundingIncrement: number;
+  reviewChangeFraction: number;
+  reviewSpreadRatio: number;
+};
+export const DEFAULT_SLAB_POLICY: ValuationPolicy = {
+  currency: "USD",
+  basis: "item-plus-shipping",
+  minimumComps: 3,
+  minimumEffectiveCount: 2.5,
+  halfLifeDays: 90,
+  maximumAgeDays: 365,
+  roundingIncrement: 0.01,
+  reviewChangeFraction: 0.25,
+  reviewSpreadRatio: 4,
+};
+export type DirectComp = {
+  key: string;
+  date: string;
+  amount: number;
+  currency: string;
+  kind: "single-sale" | "listing-average";
+  references: Array<{
+    revisionId: string;
+    provider: string;
+    providerId: string;
+    date: string | null;
+  }>;
+};
+export type EvidenceQuality = {
+  stale: boolean;
+  capped: boolean;
+  partial: boolean;
+  uncertain: number;
+  rejected: number;
+  eventWarnings: string[];
+};
+export type ValuationFlag = { code: string; review: boolean };
+export type MarketEstimate = {
+  status: "direct-evidence" | "insufficient-evidence" | "needs-review";
+  modelVersion: "direct-sales-v1";
+  asOf: string;
+  currency: string;
+  basis: ValuationPolicy["basis"];
+  range: {
+    low: number;
+    midpoint: number;
+    high: number;
+    meaning: "descriptive-middle-half";
+    calibrated: false;
+  } | null;
+  observedSpan: { low: number; high: number } | null;
+  count: number;
+  effectiveCount: number;
+  comps: Array<DirectComp & { ageDays: number; weight: number }>;
+  excluded: Array<{ key: string; reason: string }>;
+  quality: EvidenceQuality;
+  flags: ValuationFlag[];
+};
+export class SlabValuationError extends Error {}
+const money = (value: number | null) =>
+  value === null || (Number.isFinite(value) && value >= 0 && value < 1e9);
+const tidy = (value: number) => Math.round(value * 1e8) / 1e8;
+export function validateValuationPolicy(policy: ValuationPolicy) {
+  if (
+    !policy ||
+    !/^[A-Z]{3}$/.test(policy.currency) ||
+    !["item-only", "item-plus-shipping"].includes(policy.basis) ||
+    !Number.isInteger(policy.minimumComps) ||
+    policy.minimumComps < 3 ||
+    policy.minimumComps > 100 ||
+    !Number.isFinite(policy.minimumEffectiveCount) ||
+    policy.minimumEffectiveCount < 1 ||
+    policy.minimumEffectiveCount > policy.minimumComps ||
+    !Number.isFinite(policy.halfLifeDays) ||
+    policy.halfLifeDays < 1 ||
+    policy.halfLifeDays > 1095 ||
+    !Number.isFinite(policy.maximumAgeDays) ||
+    policy.maximumAgeDays < 1 ||
+    policy.maximumAgeDays > 3660 ||
+    ![0.01, 0.05, 0.1, 0.25, 0.5, 1].includes(policy.roundingIncrement) ||
+    !Number.isFinite(policy.reviewChangeFraction) ||
+    policy.reviewChangeFraction <= 0 ||
+    policy.reviewChangeFraction > 1 ||
+    !Number.isFinite(policy.reviewSpreadRatio) ||
+    policy.reviewSpreadRatio < 2 ||
+    policy.reviewSpreadRatio > 100
+  )
+    throw new SlabValuationError(
+      "Provide a valid, bounded slab pricing policy.",
+    );
+  return {
+    currency: policy.currency,
+    basis: policy.basis,
+    minimumComps: policy.minimumComps,
+    minimumEffectiveCount: policy.minimumEffectiveCount,
+    halfLifeDays: policy.halfLifeDays,
+    maximumAgeDays: policy.maximumAgeDays,
+    roundingIncrement: policy.roundingIncrement,
+    reviewChangeFraction: policy.reviewChangeFraction,
+    reviewSpreadRatio: policy.reviewSpreadRatio,
+  };
+}
+export function estimateSlabMarket(input: {
+  comps: DirectComp[];
+  quality: EvidenceQuality;
+  asOf: string;
+  policy: ValuationPolicy;
+}): MarketEstimate {
+  const { quality, asOf } = input,
+    policy = validateValuationPolicy(input.policy);
+  const now = Date.parse(asOf);
+  if (
+    !Number.isFinite(now) ||
+    !Array.isArray(input.comps) ||
+    input.comps.length > 2000
+  )
+    throw new SlabValuationError(
+      "Provide a calculation time and at most 2,000 comparable events.",
+    );
+  const excluded: MarketEstimate["excluded"] = [],
+    comps: MarketEstimate["comps"] = [];
+  const seen = new Set<string>();
+  for (const comp of input.comps) {
+    if (seen.has(comp.key))
+      throw new SlabValuationError(
+        "Deduplicate source events before calculating a range.",
+      );
+    seen.add(comp.key);
+    const date =
+      /^\d{4}-\d{2}-\d{2}$/.test(comp.date) &&
+      Number.isFinite(Date.parse(comp.date)) &&
+      new Date(comp.date).toISOString().slice(0, 10) === comp.date
+        ? Date.parse(comp.date)
+        : NaN;
+    const ageDays = (now - date) / 86400000;
+    const reason =
+      !Number.isFinite(ageDays) || ageDays < 0
+        ? "sale-date-unresolved"
+        : ageDays > policy.maximumAgeDays
+          ? "sale-outside-age-policy"
+          : comp.currency !== policy.currency
+            ? "currency-mismatch"
+            : !money(comp.amount) || comp.amount <= 0
+              ? "invalid-comp-price"
+              : null;
+    if (reason) {
+      excluded.push({ key: comp.key, reason });
+      continue;
+    }
+    comps.push({
+      ...comp,
+      ageDays,
+      weight: Math.pow(2, -ageDays / policy.halfLifeDays),
+    });
+  }
+  comps.sort((a, b) => a.amount - b.amount || a.key.localeCompare(b.key));
+  const effectiveCount = comps.reduce((sum, comp) => sum + comp.weight, 0);
+  const flags: ValuationFlag[] = [];
+  if (quality.stale) flags.push({ code: "stale-evidence", review: true });
+  if (quality.capped)
+    flags.push({ code: "capped-source-history", review: false });
+  if (quality.partial)
+    flags.push({ code: "partial-market-coverage", review: false });
+  if (comps.some((comp) => comp.kind === "listing-average"))
+    flags.push({ code: "range-includes-grouped-means", review: true });
+  quality.eventWarnings.forEach((code) => flags.push({ code, review: true }));
+  const observedSpan = comps.length
+    ? { low: comps[0].amount, high: comps[comps.length - 1].amount }
+    : null;
+  if (
+    observedSpan &&
+    observedSpan.high / observedSpan.low > policy.reviewSpreadRatio
+  )
+    flags.push({ code: "wide-observed-price-spread", review: true });
+  const enough =
+    comps.length >= policy.minimumComps &&
+    effectiveCount >= policy.minimumEffectiveCount;
+  if (!enough)
+    flags.push({
+      code:
+        comps.length < policy.minimumComps
+          ? "too-few-direct-comps"
+          : "too-little-recent-evidence",
+      review: true,
+    });
+  const quantile = (fraction: number) => {
+    const threshold = fraction * effectiveCount;
+    let cumulative = 0;
+    for (const comp of comps) {
+      cumulative += comp.weight;
+      if (cumulative >= threshold) return comp.amount;
+    }
+    return comps[comps.length - 1].amount;
+  };
+  const range: MarketEstimate["range"] = enough
+    ? {
+        low: quantile(0.25),
+        midpoint: quantile(0.5),
+        high: quantile(0.75),
+        meaning: "descriptive-middle-half",
+        calibrated: false,
+      }
+    : null;
+  const needsReview =
+    flags.some((flag) => flag.review) ||
+    (!comps.length && quality.uncertain > 0);
+  return {
+    status:
+      !enough &&
+      !quality.uncertain &&
+      !quality.stale &&
+      !quality.eventWarnings.length
+        ? "insufficient-evidence"
+        : needsReview
+          ? "needs-review"
+          : "direct-evidence",
+    modelVersion: "direct-sales-v1",
+    asOf,
+    currency: policy.currency,
+    basis: policy.basis,
+    range,
+    observedSpan,
+    count: comps.length,
+    effectiveCount: tidy(effectiveCount),
+    comps,
+    excluded,
+    quality,
+    flags,
+  };
+}
+
+export type SellerPriceContext = {
+  currency: string;
+  currentAsk: number | null;
+  shippingCharged: number | null;
+  shippingCost: number | null;
+  acquisitionCost: number | null;
+  fees: {
+    rate: number;
+    fixed: number;
+    basis: "item-only" | "item-plus-shipping";
+  } | null;
+  minimumAsk: number | null;
+  minimumProfit: number | null;
+};
+export type SellerAsk = {
+  proposedItemAsk: number | null;
+  estimatedProceeds: number | null;
+  estimatedProfit: number | null;
+  appliedFloor: number | null;
+  flags: ValuationFlag[];
+  requiresReview: boolean;
+};
+export function validateSellerPriceContext(
+  context: SellerPriceContext,
+  currency: string,
+): SellerPriceContext {
+  if (
+    !context ||
+    context.currency !== currency ||
+    [
+      context.currentAsk,
+      context.shippingCharged,
+      context.shippingCost,
+      context.acquisitionCost,
+      context.minimumAsk,
+      context.minimumProfit,
+    ].some((value) => !money(value)) ||
+    (context.fees &&
+      (!Number.isFinite(context.fees.rate) ||
+        context.fees.rate < 0 ||
+        context.fees.rate >= 1 ||
+        !Number.isFinite(context.fees.fixed) ||
+        !money(context.fees.fixed) ||
+        !["item-only", "item-plus-shipping"].includes(context.fees.basis)))
+  )
+    throw new SlabValuationError(
+      "Provide seller costs and fees in the pricing currency; unknown values must be explicit nulls.",
+    );
+  return {
+    currency: context.currency,
+    currentAsk: context.currentAsk,
+    shippingCharged: context.shippingCharged,
+    shippingCost: context.shippingCost,
+    acquisitionCost: context.acquisitionCost,
+    fees: context.fees
+      ? {
+          rate: context.fees.rate,
+          fixed: context.fees.fixed,
+          basis: context.fees.basis,
+        }
+      : null,
+    minimumAsk: context.minimumAsk,
+    minimumProfit: context.minimumProfit,
+  };
+}
+export function proposeSlabAsk(
+  market: MarketEstimate,
+  context: SellerPriceContext,
+  policy: ValuationPolicy,
+): SellerAsk {
+  validateValuationPolicy(policy);
+  context = validateSellerPriceContext(context, policy.currency);
+  if (market.currency !== policy.currency || market.basis !== policy.basis)
+    throw new SlabValuationError(
+      "Use the market estimate's currency and price basis.",
+    );
+  const flags: ValuationFlag[] = [...market.flags];
+  const result: SellerAsk = {
+    proposedItemAsk: null,
+    estimatedProceeds: null,
+    estimatedProfit: null,
+    appliedFloor: null,
+    flags,
+    requiresReview: market.status !== "direct-evidence",
+  };
+  const currentComparable =
+    context.currentAsk !== null &&
+    (market.basis === "item-only" || context.shippingCharged !== null)
+      ? context.currentAsk +
+        (market.basis === "item-plus-shipping" ? context.shippingCharged! : 0)
+      : null;
+  if (!market.range) {
+    if (
+      currentComparable !== null &&
+      market.observedSpan &&
+      currentComparable >
+        market.observedSpan.high * (1 + policy.reviewChangeFraction)
+    )
+      flags.push({
+        code: "current-ask-above-sparse-observed-sales",
+        review: true,
+      });
+    return result;
+  }
+  if (
+    market.basis === "item-plus-shipping" &&
+    context.shippingCharged === null
+  ) {
+    flags.push({ code: "seller-shipping-charge-unresolved", review: true });
+    result.requiresReview = true;
+    return result;
+  }
+  let ask =
+    market.range.midpoint -
+    (market.basis === "item-plus-shipping" ? context.shippingCharged! : 0);
+  let floor = context.minimumAsk ?? 0;
+  if (context.minimumProfit !== null) {
+    if (
+      context.acquisitionCost === null ||
+      context.shippingCost === null ||
+      context.shippingCharged === null ||
+      !context.fees
+    ) {
+      flags.push({ code: "profit-floor-cannot-be-verified", review: true });
+      result.requiresReview = true;
+      return result;
+    }
+    const feeShipping =
+      context.fees.basis === "item-plus-shipping"
+        ? context.shippingCharged * context.fees.rate
+        : 0;
+    floor = Math.max(
+      floor,
+      (context.acquisitionCost +
+        context.shippingCost +
+        context.minimumProfit +
+        context.fees.fixed -
+        context.shippingCharged +
+        feeShipping) /
+        (1 - context.fees.rate),
+    );
+  }
+  if (floor > ask) {
+    flags.push({ code: "seller-floor-raised-proposed-ask", review: false });
+    result.appliedFloor = floor;
+    ask = floor;
+  }
+  if (ask <= 0 || !money(ask)) {
+    flags.push({
+      code:
+        ask <= 0
+          ? "seller-shipping-exceeds-market-value"
+          : "proposed-ask-out-of-range",
+      review: true,
+    });
+    result.requiresReview = true;
+    return result;
+  }
+  ask = tidy(
+    Math.ceil(ask / policy.roundingIncrement - 1e-9) * policy.roundingIncrement,
+  );
+  result.proposedItemAsk = ask;
+  if (
+    context.currentAsk !== null &&
+    (context.currentAsk === 0 ||
+      Math.abs(ask - context.currentAsk) / context.currentAsk >
+        policy.reviewChangeFraction)
+  )
+    flags.push({ code: "large-change-from-current-ask", review: true });
+  if (
+    context.shippingCharged !== null &&
+    context.shippingCost !== null &&
+    context.fees
+  ) {
+    const feeBase =
+      ask +
+      (context.fees.basis === "item-plus-shipping"
+        ? context.shippingCharged
+        : 0);
+    result.estimatedProceeds = tidy(
+      ask +
+        context.shippingCharged -
+        feeBase * context.fees.rate -
+        context.fees.fixed -
+        context.shippingCost,
+    );
+    result.estimatedProfit =
+      context.acquisitionCost === null
+        ? null
+        : tidy(result.estimatedProceeds - context.acquisitionCost);
+  } else
+    flags.push({
+      code: "proceeds-unknown-without-shipping-and-fees",
+      review: false,
+    });
+  if (context.acquisitionCost === null)
+    flags.push({
+      code: "profit-unknown-without-acquisition-cost",
+      review: false,
+    });
+  result.requiresReview ||= flags.some((flag) => flag.review);
+  return result;
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -2,6 +2,10 @@ import { type RouteConfig, index } from "@react-router/dev/routes";
 
 export default [
   {
+    path: "/api/slab-recommendations",
+    file: "features/ebay-slab-pricing/routes/api.slab-recommendations.ts",
+  },
+  {
     path: "/api/slab-comp-decisions",
     file: "features/ebay-slab-pricing/routes/api.slab-comp-decisions.ts",
   },

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -75,3 +75,4 @@ import "../features/ebay-slab-pricing/evidence/altEvidenceProvider.test";
 import "../features/ebay-slab-pricing/evidence/ebayResearchProvider.test";
 import "../features/ebay-slab-pricing/evidence/evidenceRefresh.test";
 import "../features/ebay-slab-pricing/screening/screenComparables.test";
+import "../features/ebay-slab-pricing/valuation/slabValuation.test";

--- a/db/migrations/029_add_slab_recommendations.sql
+++ b/db/migrations/029_add_slab_recommendations.sql
@@ -1,0 +1,22 @@
+CREATE TABLE slab_recommendations (
+  id UUID PRIMARY KEY,
+  input_key TEXT NOT NULL UNIQUE,
+  slab_id UUID NOT NULL REFERENCES slab_identities(id),
+  identity_revision INTEGER NOT NULL,
+  valuation_group_key TEXT NOT NULL,
+  calculation JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+);
+CREATE INDEX slab_recommendation_identity_idx ON slab_recommendations(slab_id, created_at DESC);
+CREATE TABLE slab_recommendation_evidence (
+  recommendation_id UUID NOT NULL REFERENCES slab_recommendations(id) ON DELETE CASCADE,
+  revision_id UUID NOT NULL REFERENCES slab_evidence_revisions(id),
+  PRIMARY KEY (recommendation_id, revision_id)
+);
+CREATE TABLE slab_price_overrides (
+  recommendation_id UUID PRIMARY KEY REFERENCES slab_recommendations(id),
+  item_price NUMERIC NOT NULL CHECK (item_price > 0),
+  currency TEXT NOT NULL,
+  note TEXT NOT NULL,
+  reviewed_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp()
+);

--- a/docs/ebay-slab-direct-valuation.md
+++ b/docs/ebay-slab-direct-valuation.md
@@ -1,0 +1,31 @@
+# Direct slab valuation
+
+`estimateSlabMarket` is a pure function of accepted event prices, an explicit calculation time, evidence quality and a small policy. `proposeSlabAsk` separately applies seller shipping and cost/fee constraints. Neither function performs I/O. The server composition reads only cached immutable evidence and reviewed comp decisions; it never calls a provider during calculation.
+
+The default baseline needs three comps and a recency-weighted count of at least 2.5. Each event receives weight `2^(-ageDays / 90)` and sales older than 365 days are excluded. The effective count is the sum of these weights, so equally old sales do not regain full strength merely because their relative weights are equal. These are initial policy choices, not calibrated predictive guarantees; later evaluation in #29 determines where borrowing grade relationships is justified.
+
+With enough evidence, the market range is the weighted 25th/50th/75th percentile: a **descriptive middle-half range**, never a statistical confidence interval. The full observed price span, event count, weights, excluded IDs, source references and coverage flags remain available. A very wide observed span triggers review without silently deleting premium sales. Grouped means count once and trigger review. Source caps and partial coverage are explicit; stale evidence and unresolved source disagreements require review. Missing or sparse evidence returns no estimated range or proposed ask.
+
+The default price basis is item plus reported shipping. It never mixes item-only observations with delivered observations in the same estimate. If that basis is unknown, the comp is left for review; an explicit item-only policy can instead use known item amounts. Reviewed source exclusions remove only that source reference, permitting an independently verified counterpart to remain usable. The first reference in each accepted `DirectComp` supplies the price; remaining references preserve corroborating provenance.
+
+## Seller constraints and overrides
+
+For an item-plus-shipping estimate, subtract the seller's known shipping charge to produce an item ask. Unknown seller shipping prevents that conversion. The seller may supply an explicit minimum item ask, or acquisition cost, shipping cost, shipping charge, minimum profit and fee assumptions. Fee inputs contain a rate, a fixed amount and whether the rate applies to item price alone or item plus shipping. No eBay fee percentage is hardcoded. Unknown inputs do not become zero and do not imply guaranteed profit.
+
+When enough cost/fee inputs exist, the profit floor is solved algebraically under those assumptions. The final proposed ask rounds upward to the policy increment so rounding does not undercut the floor. Constraint effects remain separate from the estimated market range. A change larger than 25% from the current item ask requires review by default. Proceeds and profit are estimates under supplied assumptions; missing costs or fees yield null estimates. An unverifiable requested profit floor prevents a proposed ask.
+
+A user price override is a separate reviewed decision with an amount, currency and reason. It does not rewrite the market range or the model's original ask/proceeds calculation. The original recommendation and override are returned separately. Publication remains #31 and must validate the current listing and applicable constraints before any write.
+
+## Persistence and API
+
+Migration `029_add_slab_recommendations.sql` adds immutable calculation records, evidence references and separate price overrides. Each calculation saves its model/policy versions, calculation time, confirmed identity revision, policy, seller assumptions, accepted event IDs and weights, rejected/uncertain dispositions, exact comp-review decisions and evidence retrieval metadata. Source evidence is retained in the same transaction. Equivalent normalized input at the same as-of time reuses the existing calculation.
+
+GET `/api/slab-recommendations?id=...` returns a recommendation and a `current` flag. Identity corrections, changed comp reviews, expired evidence or replacement evidence revisions invalidate the prior calculation. Historical records and sources remain inspectable. POST accepts `intent: calculate` with the current slab ID/revision, up to twenty evidence revision IDs, pricing policy and seller context; or `intent: override` with recommendation ID, item price, currency and a review reason. Same-origin JSON bodies are limited to 16 KiB. Calculations preflight source storage size before reading at most 5 MiB/2,000 observations; persisted calculation JSON is limited to 512 KiB.
+
+## Validation
+
+Tests cover no/one comp, recency, stale/capped/partial history, grouped means, extreme legitimate sales, unknown shipping and currencies, seller floors, fee-rate boundaries, rounding and source-specific exclusions. Isolated PostgreSQL integration replaces global `fetch` with a throwing function to prove cached calculations do not perform network I/O. It checks idempotence, separate overrides, review/identity/evidence invalidation and retained sources.
+
+The captured Slaking PSA 9 sample had two delivered candidate amounts, $16 and $20.72, against a $100 item ask. Buneary Master Ball PSA 10 had two, $104.99 and $116.98, against a $215 ask. Even assuming their identity review succeeds, both tests return no market range/proposed ask and flag the current ask above the sparse observed sales. The system does not blindly replace either listing with its two-point median.
+
+Run `npm test`, `npm run typecheck`, `npm run build`, and `node node_modules/tsx/dist/cli.mjs app/features/ebay-slab-pricing/valuation/slabRecommendations.integration.test.ts`. The integration test creates a disposable schema on localhost:5433. No production listing or price is changed.


### PR DESCRIPTION
Add a pure direct-sales estimator and a separate seller-ask calculation. The baseline uses explicitly screened event prices, recency weights and documented minimum evidence rules; its weighted quartile range is descriptive, not a calibrated confidence interval. Sparse or unknown evidence produces no fabricated range or ask.

Seller shipping, supplied fee assumptions, acquisition costs and floors affect the proposed listing price without changing the estimated market range. Unknown costs/fees remain unknown, rounding cannot undercut a calculated floor, and large changes from the current ask require review. Explicit price overrides are stored separately from the original model calculation.

The server composition uses cached immutable evidence only, saves policy/model versions and calculation inputs, retains source revisions transactionally, and reuses identical normalized calculations at the same time. Identity corrections, changed comp reviews, new evidence revisions and expiration invalidate older calculations. The bounded same-origin API does not expose publication.

Validation: full tests, typecheck, build and isolated PostgreSQL integration pass. Integration replaces fetch with a throwing function, proving valuation/recalculation does not contact providers. Coverage includes no/one comp, stale/capped evidence, grouped means, legitimate premiums, unknown money components, seller floors, rounding, reviewed source exclusions, retained audit sources and invalidation. The real Slaking/Buneary two-sale examples produce sparse-evidence/current-ask review flags and no proposed replacement prices.

Adversarial review addressed recency-weighted count, unverifiable profit floors, null fee values, normalized calculation identity, source-size preflight, review changes after calculation, and excluding an incorrect source without discarding its independently verified counterpart. The final pass found no remaining actionable issues across composition, simplicity, performance, design and footprint. No dependency, service or deployment is added; existing MUI build warnings remain.

Fixes #27.
