### PR TITLE
Save immutable slab price-change previews

### DIFF
--- a/app/features/ebay-slab-pricing/components/SlabPublicationPreview.tsx
+++ b/app/features/ebay-slab-pricing/components/SlabPublicationPreview.tsx
@@ -1,0 +1,197 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  Alert,
+  Button,
+  Link,
+  MenuItem,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import type { InventoryRow } from "../inventory/slabInventory.server";
+import type { StoredSlabRecommendation } from "../valuation/slabRecommendations.server";
+import type { SlabPublicationPreview } from "../publication/slabPublicationPreviews.server";
+import {
+  amount,
+  slabRequest,
+  useSlabAction,
+  words,
+  type Json,
+} from "./slabClient";
+export default function SlabPublicationPreviewPanel({
+  listing,
+  recommendation,
+  stale,
+}: {
+  listing: Json<InventoryRow>;
+  recommendation: Json<StoredSlabRecommendation>;
+  stale: boolean;
+}) {
+  const [selection, setSelection] = useState<"calculated" | "reviewed">(
+    recommendation.override ? "reviewed" : "calculated",
+  );
+  const [saved, setSaved] = useState<Json<SlabPublicationPreview> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [reload, setReload] = useState(0);
+  const pendingIntent = useRef<string | null>(null);
+  const action = useSlabAction();
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setLoadError(null);
+    void slabRequest<SlabPublicationPreview | null>(
+      `/api/slab-publication-previews?inventoryId=${listing.id}`,
+      undefined,
+      controller.signal,
+    )
+      .then((value) => {
+        if (!controller.signal.aborted) setSaved(value);
+      })
+      .catch((error) => {
+        if (!controller.signal.aborted)
+          setLoadError(
+            error instanceof Error
+              ? error.message
+              : "Unable to load the saved preview.",
+          );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+    return () => controller.abort();
+  }, [listing.id, reload]);
+  const plan = saved?.plan;
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Stack spacing={2}>
+        <Typography variant="h6">Review a listing price change</Typography>
+        <Typography variant="body2">
+          Save the selected ask with this listing and its evidence. A preview
+          uses imported inventory; a live seller read is still required before
+          approval.
+        </Typography>
+        <Stack direction="row" gap={2} useFlexGap flexWrap="wrap">
+          <TextField
+            select
+            size="small"
+            label="Price to review"
+            value={selection}
+            disabled={action.busy || loading}
+            onChange={(e) => {
+              setSelection(e.target.value as typeof selection);
+              pendingIntent.current = null;
+            }}
+          >
+            <MenuItem value="calculated">
+              Calculated ask ·{" "}
+              {amount(recommendation.calculation.ask.proposedItemAsk)}
+            </MenuItem>
+            {recommendation.override && (
+              <MenuItem value="reviewed">
+                Reviewed ask · {amount(recommendation.override.itemPrice)}
+              </MenuItem>
+            )}
+          </TextField>
+          <Button
+            disabled={action.busy || loading || stale}
+            onClick={() =>
+              void action.run(async () => {
+                pendingIntent.current ??= crypto.randomUUID();
+                const value = await slabRequest<SlabPublicationPreview>(
+                  "/api/slab-publication-previews",
+                  {
+                    intent: "prepare",
+                    intentId: pendingIntent.current,
+                    inventoryId: listing.id,
+                    inventoryRevision: listing.revision,
+                    recommendationId: recommendation.id,
+                    selection,
+                    overrideReviewedAt:
+                      selection === "reviewed"
+                        ? recommendation.override?.reviewedAt
+                        : null,
+                  },
+                );
+                setSaved(value);
+                pendingIntent.current = null;
+              })
+            }
+          >
+            Save price-change preview
+          </Button>
+          <Button
+            disabled={action.busy || loading}
+            onClick={() => setReload((v) => v + 1)}
+          >
+            Reload preview
+          </Button>
+        </Stack>
+        {loading && (
+          <Typography role="status">Loading saved preview…</Typography>
+        )}
+        {(action.error || loadError) && (
+          <Alert severity="error">{action.error ?? loadError}</Alert>
+        )}
+        {stale && (
+          <Alert severity="warning">
+            Recalculate using the current listing and evidence before preparing
+            another price change.
+          </Alert>
+        )}
+        {saved && plan && (
+          <>
+            <Typography>
+              <Link
+                href={`https://www.ebay.com/itm/${plan.inventory.itemId}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {plan.inventory.snapshot.title}
+              </Link>{" "}
+              · {plan.inventory.seller}
+            </Typography>
+            <Typography>
+              {amount(plan.oldPrice.amount)} → {amount(plan.newPrice.amount)} (
+              {plan.changePercent > 0 ? "+" : ""}
+              {plan.changePercent.toFixed(1)}%) · {words(plan.selection)} ask
+            </Typography>
+            <Typography variant="body2">
+              Quantity {plan.inventory.snapshot.quantity} ·{" "}
+              {words(plan.inventory.snapshot.format)} · Inventory revision{" "}
+              {plan.inventory.revision} · Identity revision{" "}
+              {plan.identity.revision}
+            </Typography>
+            <Typography variant="body2">
+              Saved {new Date(plan.createdAt).toLocaleString()} · Review expires{" "}
+              {new Date(plan.expiresAt).toLocaleString()} ·{" "}
+              {plan.evidence.length} evidence revisions
+            </Typography>
+            {plan.override && (
+              <Typography variant="body2">
+                Review reason: {plan.override.note}
+              </Typography>
+            )}
+            {plan.flags.length > 0 && (
+              <Alert severity="info">{plan.flags.map(words).join("; ")}</Alert>
+            )}
+            {saved.conflicts.length > 0 && (
+              <Alert severity="warning">
+                Preview needs replacement:{" "}
+                {saved.conflicts.map(words).join("; ")}.
+              </Alert>
+            )}
+            <Typography variant="caption">
+              Preview {saved.id} · {plan.policyVersion} · {plan.version}
+            </Typography>
+          </>
+        )}
+        <Alert severity="info">
+          Seller OAuth and live listing readback are not connected. Publishing
+          is unavailable; saved previews cannot write to eBay.
+        </Alert>
+      </Stack>
+    </Paper>
+  );
+}

--- a/app/features/ebay-slab-pricing/components/SlabRecommendationPanel.tsx
+++ b/app/features/ebay-slab-pricing/components/SlabRecommendationPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import {
   Alert,
   Button,
@@ -26,6 +26,7 @@ import {
   words,
   type Json,
 } from "./slabClient";
+const PublicationPreview = lazy(() => import("./SlabPublicationPreview"));
 
 const costFields = [
   "currentAsk",
@@ -108,6 +109,7 @@ export function SlabRecommendationPanel({
     useState(reviewVersion);
   const [override, setOverride] = useState("");
   const [note, setNote] = useState("");
+  const [showPublication, setShowPublication] = useState(false);
   const action = useSlabAction();
   const calculation = recommendation?.calculation;
   const stale =
@@ -405,6 +407,32 @@ export function SlabRecommendationPanel({
                 Save reviewed ask
               </Button>
             </Stack>
+            {listing && recommendation && (
+              <>
+                <Button
+                  sx={{ alignSelf: "start" }}
+                  onClick={() => setShowPublication((v) => !v)}
+                >
+                  {showPublication
+                    ? "Hide price-change review"
+                    : "Review listing price change"}
+                </Button>
+                {showPublication && (
+                  <Suspense
+                    fallback={
+                      <Typography>Loading price-change review…</Typography>
+                    }
+                  >
+                    <PublicationPreview
+                      key={`${listing.id}:${listing.revision}:${recommendation.id}:${recommendation.override?.reviewedAt ?? ""}`}
+                      listing={listing}
+                      recommendation={recommendation}
+                      stale={!!stale || !canCalculate}
+                    />
+                  </Suspense>
+                )}
+              </>
+            )}
           </>
         )}
       </Stack>

--- a/app/features/ebay-slab-pricing/publication/slabPublicationPreview.test.ts
+++ b/app/features/ebay-slab-pricing/publication/slabPublicationPreview.test.ts
@@ -1,0 +1,345 @@
+import assert from "node:assert/strict";
+import type { InventoryRow } from "../inventory/slabInventory.server";
+import type { StoredSlabRecommendation } from "../valuation/slabRecommendations.server";
+import {
+  DEFAULT_SLAB_POLICY,
+  estimateSlabMarket,
+  proposeSlabAsk,
+  type SellerPriceContext,
+} from "../valuation/slabValuation";
+import {
+  buildPublicationPreview,
+  previewConflicts,
+  type PreviewRequest,
+} from "./slabPublicationPreview";
+const id = (n: number) =>
+  `00000000-0000-0000-0000-${String(n).padStart(12, "0")}`;
+const now = "2026-09-06T00:00:00.000Z";
+const seller: SellerPriceContext = {
+  currency: "USD",
+  currentAsk: 100,
+  shippingCharged: 0,
+  shippingCost: null,
+  acquisitionCost: null,
+  fees: null,
+  minimumAsk: null,
+  minimumProfit: null,
+};
+const market = estimateSlabMarket({
+  policy: DEFAULT_SLAB_POLICY,
+  asOf: now,
+  quality: {
+    stale: false,
+    capped: false,
+    partial: true,
+    uncertain: 0,
+    rejected: 0,
+    eventWarnings: [],
+  },
+  comps: [100, 110, 120, 130].map((amount, i) => ({
+    key: String(i),
+    amount,
+    currency: "USD",
+    date: "2026-09-05",
+    kind: "single-sale",
+    references: [
+      {
+        revisionId: id(4),
+        provider: "fixture",
+        providerId: String(i),
+        date: "2026-09-05",
+      },
+    ],
+  })),
+});
+const recommendation: StoredSlabRecommendation = {
+  id: id(3),
+  current: true,
+  override: {
+    itemPrice: 125,
+    currency: "USD",
+    note: "Reviewed fixture",
+    reviewedAt: now,
+  },
+  calculation: {
+    identity: { slabId: id(2), revision: 1, valuationGroupKey: "a".repeat(64) },
+    policyVersion: "slab-policy-v1",
+    policy: DEFAULT_SLAB_POLICY,
+    seller,
+    market,
+    ask: proposeSlabAsk(market, seller, DEFAULT_SLAB_POLICY),
+    dispositions: [],
+    decisions: [],
+    evidence: [
+      {
+        revisionId: id(4),
+        fetchedAt: now,
+        expiresAt: "2026-09-06T06:00:00.000Z",
+        spec: {
+          kind: "alt-sales",
+          assetId: "fixture",
+          window: { from: "2026-09-01", to: "2026-09-05" },
+          limitPerGrade: 16,
+        },
+      },
+    ],
+  },
+};
+const inventory: InventoryRow = {
+  id: id(1),
+  seller: "fixture",
+  itemId: "123456789012",
+  variationKey: "",
+  source: "csv",
+  state: "active",
+  revision: 1,
+  identityId: id(2),
+  identitySource: "manual",
+  identityNote: "Fixture",
+  observedAt: new Date(now),
+  snapshot: {
+    itemId: "123456789012",
+    variationKey: "",
+    sku: null,
+    title: "Fixture PSA 1 slab",
+    price: { amount: 100, currency: "USD" },
+    shipping: { amount: 0, currency: "USD", policyId: null },
+    quantity: 1,
+    state: "active",
+    format: "fixed-price",
+    certificate: null,
+    expected: {},
+    specifics: {},
+    reviewReasons: ["certificate-required"],
+  },
+};
+const request: PreviewRequest = {
+  intentId: id(5),
+  inventoryId: inventory.id,
+  inventoryRevision: 1,
+  recommendationId: recommendation.id,
+  selection: "reviewed",
+  overrideReviewedAt: now,
+};
+const build = (row = inventory, rec = recommendation, input = request) =>
+  buildPublicationPreview(input, row, rec, now);
+const plan = build();
+assert.equal(plan.mode, "preview");
+assert.equal(plan.oldPrice.amount, 100);
+assert.equal(plan.newPrice.amount, 125);
+assert.equal(plan.expiresAt, "2026-09-06T00:15:00.000Z");
+assert.deepEqual(previewConflicts(plan, inventory, recommendation, now), []);
+assert.ok(
+  build(inventory, {
+    ...recommendation,
+    override: { ...recommendation.override!, itemPrice: 126 },
+  }).flags.includes("large-change-from-current-ask"),
+);
+const profitable = {
+  ...recommendation,
+  calculation: {
+    ...recommendation.calculation,
+    seller: {
+      ...seller,
+      acquisitionCost: 80,
+      shippingCost: 5,
+      fees: { rate: 0.1, fixed: 0.3, basis: "item-plus-shipping" as const },
+      minimumProfit: 20,
+    },
+  },
+};
+assert.equal(build(inventory, profitable).newPrice.amount, 125);
+assert.throws(
+  () =>
+    build(inventory, {
+      ...profitable,
+      override: { ...recommendation.override!, itemPrice: 116.99 },
+    }),
+  /constraints/,
+);
+assert.equal(
+  build(inventory, recommendation, {
+    ...request,
+    selection: "calculated",
+    overrideReviewedAt: null,
+  }).newPrice.amount,
+  market.range!.midpoint,
+);
+assert.throws(() => build({ ...inventory, state: "sold" }), /active/);
+assert.throws(() => build({ ...inventory, state: "ended" }), /active/);
+assert.throws(
+  () =>
+    build({ ...inventory, snapshot: { ...inventory.snapshot, quantity: 0 } }),
+  /active/,
+);
+assert.throws(
+  () =>
+    build({ ...inventory, snapshot: { ...inventory.snapshot, quantity: 2 } }),
+  /single-quantity/,
+);
+assert.throws(
+  () =>
+    build({
+      ...inventory,
+      snapshot: { ...inventory.snapshot, format: "auction" },
+    }),
+  /fixed-price/,
+);
+assert.throws(
+  () => build({ ...inventory, variationKey: "sku:variation" }),
+  /Variation/,
+);
+assert.throws(() => build({ ...inventory, revision: 2 }), /changed/);
+assert.throws(() => build({ ...inventory, identityId: id(6) }), /identity/);
+assert.throws(
+  () => build(inventory, { ...recommendation, current: false }),
+  /changed/,
+);
+assert.throws(
+  () =>
+    build({
+      ...inventory,
+      snapshot: {
+        ...inventory.snapshot,
+        price: { amount: 101, currency: "USD" },
+      },
+    }),
+  /Recalculate/,
+);
+assert.throws(
+  () =>
+    build({
+      ...inventory,
+      snapshot: {
+        ...inventory.snapshot,
+        price: { amount: 100, currency: "CAD" },
+      },
+    }),
+  /USD/,
+);
+assert.throws(
+  () =>
+    build({
+      ...inventory,
+      snapshot: {
+        ...inventory.snapshot,
+        shipping: { amount: 5, currency: "USD", policyId: null },
+      },
+    }),
+  /shipping/,
+);
+assert.throws(
+  () =>
+    build(inventory, {
+      ...recommendation,
+      override: {
+        ...recommendation.override!,
+        reviewedAt: "2026-09-06T00:01:00.000Z",
+      },
+    }),
+  /reviewed ask changed/,
+);
+assert.throws(
+  () =>
+    build(inventory, {
+      ...recommendation,
+      override: { ...recommendation.override!, itemPrice: 100 },
+    }),
+  /already matches/,
+);
+assert.throws(
+  () =>
+    build(inventory, {
+      ...recommendation,
+      override: { ...recommendation.override!, itemPrice: 125.001 },
+    }),
+  /whole cents/,
+);
+assert.throws(
+  () =>
+    build(inventory, {
+      ...recommendation,
+      calculation: {
+        ...recommendation.calculation,
+        seller: { ...seller, minimumAsk: 130 },
+      },
+    }),
+  /constraints/,
+);
+assert.throws(
+  () =>
+    build(inventory, {
+      ...recommendation,
+      calculation: {
+        ...recommendation.calculation,
+        seller: { ...seller, minimumProfit: 20 },
+      },
+    }),
+  /constraints/,
+);
+assert.throws(
+  () =>
+    build(inventory, {
+      ...recommendation,
+      calculation: {
+        ...recommendation.calculation,
+        evidence: [
+          { ...recommendation.calculation.evidence[0], expiresAt: now },
+        ],
+      },
+    }),
+  /expired/,
+);
+assert.throws(
+  () =>
+    build(inventory, {
+      ...recommendation,
+      calculation: {
+        ...recommendation.calculation,
+        market: { ...market, range: null },
+      },
+    }),
+  /adequate/,
+);
+assert.ok(
+  previewConflicts(
+    plan,
+    { ...inventory, seller: "other-seller" },
+    recommendation,
+    now,
+  ).includes("inventory-changed"),
+);
+assert.ok(
+  previewConflicts(
+    plan,
+    inventory,
+    { ...recommendation, current: false },
+    now,
+  ).includes("recommendation-changed"),
+);
+assert.ok(
+  previewConflicts(
+    plan,
+    inventory,
+    {
+      ...recommendation,
+      override: { ...recommendation.override!, note: "Changed" },
+    },
+    now,
+  ).includes("reviewed-ask-changed"),
+);
+assert.ok(
+  previewConflicts(plan, inventory, recommendation, plan.expiresAt).includes(
+    "preview-expired",
+  ),
+);
+const changed = structuredClone(inventory);
+changed.snapshot.title = "Changed after preparation";
+assert.notEqual(
+  plan.inventory.snapshot.title,
+  changed.snapshot.title,
+  "The saved plan owns an immutable snapshot",
+);
+console.log(
+  "PASS immutable publication previews, exact price selection, seller constraints, listing conflicts, stale evidence and unsupported types",
+);

--- a/app/features/ebay-slab-pricing/publication/slabPublicationPreview.ts
+++ b/app/features/ebay-slab-pricing/publication/slabPublicationPreview.ts
@@ -1,0 +1,241 @@
+import type { InventoryRow } from "../inventory/slabInventory.server";
+import type { StoredSlabRecommendation } from "../valuation/slabRecommendations.server";
+import { minimumSellerAsk } from "../valuation/slabValuation";
+
+export const SLAB_PUBLICATION_POLICY = "reviewed-price-v1";
+export class SlabPublicationError extends Error {}
+export type PreviewRequest = {
+  intentId: string;
+  inventoryId: string;
+  inventoryRevision: number;
+  recommendationId: string;
+  selection: "calculated" | "reviewed";
+  overrideReviewedAt: string | null;
+};
+export const publicationId = (value: unknown): value is string =>
+  typeof value === "string" &&
+  /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/.test(value);
+export function previewRequest(input: PreviewRequest): PreviewRequest {
+  if (
+    !input ||
+    ![input.intentId, input.inventoryId, input.recommendationId].every(
+      publicationId,
+    ) ||
+    !Number.isSafeInteger(input.inventoryRevision) ||
+    input.inventoryRevision < 1 ||
+    !["calculated", "reviewed"].includes(input.selection) ||
+    (input.selection === "reviewed" &&
+      (typeof input.overrideReviewedAt !== "string" ||
+        !Number.isFinite(Date.parse(input.overrideReviewedAt))))
+  )
+    throw new SlabPublicationError(
+      "Select a saved recommendation and the current listing revision.",
+    );
+  return {
+    intentId: input.intentId,
+    inventoryId: input.inventoryId,
+    inventoryRevision: input.inventoryRevision,
+    recommendationId: input.recommendationId,
+    selection: input.selection,
+    overrideReviewedAt:
+      input.selection === "reviewed" ? input.overrideReviewedAt : null,
+  };
+}
+function cents(value: number) {
+  if (
+    !Number.isFinite(value) ||
+    value <= 0 ||
+    value >= 1e9 ||
+    Math.abs(value * 100 - Math.round(value * 100)) > 1e-5
+  )
+    throw new SlabPublicationError(
+      "The selected USD item price must be positive and use whole cents.",
+    );
+  return Math.round(value * 100);
+}
+export function buildPublicationPreview(
+  request: PreviewRequest,
+  inventory: InventoryRow,
+  recommendation: StoredSlabRecommendation,
+  now: string,
+) {
+  request = previewRequest(request);
+  const calculation = recommendation.calculation;
+  if (
+    !Number.isFinite(Date.parse(now)) ||
+    Date.parse(now) < Date.parse(calculation.market.asOf) ||
+    inventory.id !== request.inventoryId ||
+    inventory.revision !== request.inventoryRevision ||
+    recommendation.id !== request.recommendationId ||
+    !recommendation.current ||
+    inventory.identityId !== calculation.identity.slabId
+  )
+    throw new SlabPublicationError(
+      "The listing, identity or recommendation changed. Reopen the listing and recalculate.",
+    );
+  if (
+    calculation.policyVersion !== "slab-policy-v1" ||
+    !calculation.market.range ||
+    !calculation.evidence.length
+  )
+    throw new SlabPublicationError(
+      "Use a supported recommendation with adequate direct sales evidence.",
+    );
+  const snapshot = inventory.snapshot;
+  if (
+    inventory.state !== "active" ||
+    snapshot.state !== "active" ||
+    snapshot.quantity !== 1 ||
+    snapshot.format !== "fixed-price"
+  )
+    throw new SlabPublicationError(
+      "Only active, single-quantity fixed-price slabs can be previewed.",
+    );
+  if (inventory.variationKey || snapshot.variationKey)
+    throw new SlabPublicationError(
+      "Variation listings need a verified variation publisher and remain in review.",
+    );
+  if (
+    snapshot.reviewReasons.some((reason) => reason !== "certificate-required")
+  )
+    throw new SlabPublicationError(
+      "Resolve the listing's review reasons before preparing its price change.",
+    );
+  if (
+    snapshot.price.currency !== "USD" ||
+    calculation.policy.currency !== "USD" ||
+    calculation.seller.currentAsk !== snapshot.price.amount ||
+    calculation.seller.shippingCharged !== snapshot.shipping.amount ||
+    (snapshot.shipping.amount !== null && snapshot.shipping.currency !== "USD")
+  )
+    throw new SlabPublicationError(
+      "Recalculate using this listing's current USD price and shipping charge.",
+    );
+  const override =
+    request.selection === "reviewed" ? recommendation.override : null;
+  if (
+    request.selection === "reviewed" &&
+    (!override ||
+      override.reviewedAt !== request.overrideReviewedAt ||
+      override.currency !== "USD")
+  )
+    throw new SlabPublicationError(
+      "The reviewed ask changed. Reload it before preparing the price change.",
+    );
+  const amount = override?.itemPrice ?? calculation.ask.proposedItemAsk;
+  if (amount === null)
+    throw new SlabPublicationError(
+      "This recommendation has no item ask to publish.",
+    );
+  const oldCents = cents(snapshot.price.amount),
+    newCents = cents(amount);
+  if (oldCents === newCents)
+    throw new SlabPublicationError(
+      "The selected ask already matches the imported listing price.",
+    );
+  const floor = minimumSellerAsk(calculation.seller);
+  if (
+    floor === null ||
+    !Number.isFinite(floor) ||
+    newCents < Math.ceil(floor * 100 - 1e-9)
+  )
+    throw new SlabPublicationError(
+      "The selected ask does not satisfy the saved seller constraints.",
+    );
+  const expiry = Math.min(
+    Date.parse(now) + 15 * 60000,
+    ...calculation.evidence.map((e) => Date.parse(e.expiresAt ?? "")),
+  );
+  if (!Number.isFinite(expiry) || expiry <= Date.parse(now))
+    throw new SlabPublicationError(
+      "The selected sales evidence expired. Refresh and recalculate.",
+    );
+  return {
+    version: SLAB_PUBLICATION_POLICY,
+    mode: "preview" as const,
+    inventory: {
+      id: inventory.id,
+      revision: inventory.revision,
+      seller: inventory.seller,
+      itemId: inventory.itemId,
+      variationKey: inventory.variationKey,
+      source: inventory.source,
+      observedAt: inventory.observedAt.toISOString(),
+      snapshot: structuredClone(snapshot),
+    },
+    recommendationId: recommendation.id,
+    identity: { ...calculation.identity },
+    policyVersion: calculation.policyVersion,
+    policy: { ...calculation.policy },
+    sellerConstraints: structuredClone(calculation.seller),
+    evidence: calculation.evidence.map((e) => ({
+      revisionId: e.revisionId,
+      expiresAt: e.expiresAt,
+    })),
+    selection: request.selection,
+    override: override ? { ...override } : null,
+    oldPrice: { amount: oldCents / 100, currency: "USD" },
+    newPrice: { amount: newCents / 100, currency: "USD" },
+    changePercent: ((newCents - oldCents) / oldCents) * 100,
+    flags: [
+      ...new Set(
+        [
+          ...calculation.market.flags,
+          ...calculation.ask.flags,
+          ...(Math.abs(newCents - oldCents) / oldCents >
+          calculation.policy.reviewChangeFraction
+            ? [{ code: "large-change-from-current-ask", review: true }]
+            : []),
+        ].map((flag) => flag.code),
+      ),
+    ],
+    createdAt: now,
+    expiresAt: new Date(expiry).toISOString(),
+  };
+}
+export type PublicationPreview = ReturnType<typeof buildPublicationPreview>;
+export function previewConflicts(
+  plan: PublicationPreview,
+  inventory: InventoryRow | null,
+  recommendation: StoredSlabRecommendation | null,
+  now: string,
+) {
+  const reasons: string[] = [];
+  if (
+    !Number.isFinite(Date.parse(now)) ||
+    Date.parse(now) < Date.parse(plan.createdAt) ||
+    Date.parse(now) >= Date.parse(plan.expiresAt)
+  )
+    reasons.push("preview-expired");
+  if (plan.version !== SLAB_PUBLICATION_POLICY)
+    reasons.push("publication-policy-changed");
+  if (
+    !inventory ||
+    inventory.id !== plan.inventory.id ||
+    inventory.revision !== plan.inventory.revision ||
+    inventory.seller !== plan.inventory.seller ||
+    inventory.itemId !== plan.inventory.itemId ||
+    inventory.variationKey !== plan.inventory.variationKey ||
+    inventory.identityId !== plan.identity.slabId ||
+    inventory.state !== "active"
+  )
+    reasons.push("inventory-changed");
+  if (
+    !recommendation ||
+    recommendation.id !== plan.recommendationId ||
+    !recommendation.current ||
+    recommendation.calculation.identity.revision !== plan.identity.revision
+  )
+    reasons.push("recommendation-changed");
+  if (
+    plan.selection === "reviewed" &&
+    (!recommendation?.override ||
+      !plan.override ||
+      recommendation.override.itemPrice !== plan.override.itemPrice ||
+      recommendation.override.currency !== plan.override.currency ||
+      recommendation.override.note !== plan.override.note ||
+      recommendation.override.reviewedAt !== plan.override.reviewedAt)
+  )
+    reasons.push("reviewed-ask-changed");
+  return reasons;
+}

--- a/app/features/ebay-slab-pricing/publication/slabPublicationPreviews.server.ts
+++ b/app/features/ebay-slab-pricing/publication/slabPublicationPreviews.server.ts
@@ -1,0 +1,121 @@
+import { queryOne, withTransaction } from "~/core/db/database.server";
+import type { InventoryRow } from "../inventory/slabInventory.server";
+import { getSlabRecommendation } from "../valuation/slabRecommendations.server";
+import {
+  buildPublicationPreview,
+  previewConflicts,
+  previewRequest,
+  publicationId,
+  SlabPublicationError,
+  type PreviewRequest,
+  type PublicationPreview,
+} from "./slabPublicationPreview";
+
+const columns = `id,seller,item_id AS "itemId",variation_key AS "variationKey",snapshot,source,state,revision,identity_id AS "identityId",identity_source AS "identitySource",identity_note AS "identityNote",observed_at AS "observedAt"`;
+const readInventory = (id: string) =>
+  queryOne<InventoryRow>(`SELECT ${columns} FROM slab_inventory WHERE id=$1`, [
+    id,
+  ]);
+type StoredPreview = {
+  id: string;
+  request: PreviewRequest;
+  plan: PublicationPreview;
+};
+async function describe(row: StoredPreview) {
+  const [inventory, recommendation] = await Promise.all([
+    readInventory(row.plan.inventory.id),
+    getSlabRecommendation(row.plan.recommendationId),
+  ]);
+  return {
+    ...row,
+    conflicts: previewConflicts(
+      row.plan,
+      inventory,
+      recommendation,
+      new Date().toISOString(),
+    ),
+    canPublish: false as const,
+    publicationUnavailableReason:
+      "Seller OAuth and live listing readback are not connected. This saved preview cannot publish a price.",
+  };
+}
+export async function readPublicationPreview(input: {
+  id?: string;
+  inventoryId?: string;
+}) {
+  const id = input.id ?? input.inventoryId;
+  if (!publicationId(id))
+    throw new SlabPublicationError("Choose a saved preview or listing.");
+  const row = await queryOne<StoredPreview>(
+    input.id
+      ? "SELECT id,request,plan FROM slab_publication_previews WHERE id=$1"
+      : "SELECT id,request,plan FROM slab_publication_previews WHERE inventory_id=$1 ORDER BY created_at DESC,id DESC LIMIT 1",
+    [id],
+  );
+  return row ? describe(row) : null;
+}
+export async function preparePublicationPreview(input: PreviewRequest) {
+  const request = previewRequest(input);
+  const previous = await queryOne<StoredPreview>(
+    "SELECT id,request,plan FROM slab_publication_previews WHERE id=$1",
+    [request.intentId],
+  );
+  const matches = (saved: PreviewRequest) =>
+    Object.entries(request).every(
+      ([key, value]) => saved[key as keyof PreviewRequest] === value,
+    );
+  if (previous) {
+    if (!matches(previous.request))
+      throw new SlabPublicationError(
+        "This preview intent was already used for a different selection.",
+      );
+    return describe(previous);
+  }
+  const [inventory, recommendation] = await Promise.all([
+    readInventory(request.inventoryId),
+    getSlabRecommendation(request.recommendationId),
+  ]);
+  if (!inventory || !recommendation)
+    throw new SlabPublicationError(
+      "The listing or recommendation no longer exists.",
+    );
+  const plan = buildPublicationPreview(
+    request,
+    inventory,
+    recommendation,
+    new Date().toISOString(),
+  );
+  const json = JSON.stringify(plan);
+  if (Buffer.byteLength(json) > 64 * 1024)
+    throw new SlabPublicationError(
+      "This listing exceeds the saved preview size limit.",
+    );
+  const row = await withTransaction(async (db) => {
+    await db.query("SET LOCAL statement_timeout = '10s'");
+    // Immutable intent IDs coalesce retry/double-click requests. Never replace a reviewed plan.
+    const result = await db.query<StoredPreview>(
+      `INSERT INTO slab_publication_previews(id,inventory_id,recommendation_id,request,plan,expires_at)
+      VALUES($1,$2,$3,$4,$5,$6) ON CONFLICT(id) DO UPDATE SET id=EXCLUDED.id RETURNING id,request,plan`,
+      [
+        request.intentId,
+        inventory.id,
+        recommendation.id,
+        JSON.stringify(request),
+        json,
+        plan.expiresAt,
+      ],
+    );
+    await db.query(
+      "DELETE FROM slab_publication_previews WHERE id IN (SELECT id FROM slab_publication_previews WHERE expires_at<clock_timestamp()-interval '30 days' ORDER BY expires_at LIMIT 100 FOR UPDATE SKIP LOCKED)",
+    );
+    return result.rows[0];
+  });
+  if (!matches(row.request))
+    throw new SlabPublicationError(
+      "This preview intent was already used for a different selection.",
+    );
+  return describe(row);
+}
+export type SlabPublicationPreview = NonNullable<
+  Awaited<ReturnType<typeof readPublicationPreview>>
+>;

--- a/app/features/ebay-slab-pricing/research/slabResearch.integration.test.ts
+++ b/app/features/ebay-slab-pricing/research/slabResearch.integration.test.ts
@@ -32,6 +32,10 @@ import {
 import { DEFAULT_SLAB_POLICY } from "../valuation/slabValuation";
 import type { SaleEvidence } from "../evidence/slabEvidence";
 import { loadSlabSupply } from "../supply/slabSupply.server";
+import {
+  preparePublicationPreview,
+  readPublicationPreview,
+} from "../publication/slabPublicationPreviews.server";
 
 dotenv.config({
   path: [".env.development.local", ".env.local", ".env.development", ".env"],
@@ -65,6 +69,7 @@ try {
     "030_add_slab_supply_observations.sql",
     "028_add_slab_comp_decisions.sql",
     "029_add_slab_recommendations.sql",
+    "031_add_slab_publication_previews.sql",
   ])
     await db.query(await readFile(`db/migrations/${migration}`, "utf8"));
   const candidate = parseAltCertificate(JSON.stringify(fixture))!;
@@ -117,11 +122,11 @@ try {
     /changed/,
   );
   const csv = [
-    "item_id,title,price,currency,quantity,state,format,grader,certificate_number",
+    "item_id,title,price,currency,quantity,state,format,grader,certificate_number,shipping_amount,shipping_currency",
     ...Array.from(
       { length: 50 },
       (_, i) =>
-        `${900000000000 + i},Workspace sample ${i + 1},100,USD,1,active,fixed-price,PSA,110185364`,
+        `${900000000000 + i},Workspace sample ${i + 1},100,USD,1,active,fixed-price,PSA,110185364,0,USD`,
     ),
   ].join("\n");
   await reconcileInventory(parseInventoryCsv(csv, "workspace-sample"), 0);
@@ -249,6 +254,43 @@ try {
   );
   assert.ok(recommendation.calculation.market.range);
   assert.equal(recommendation.calculation.market.count, 4);
+  const previewInput = {
+    intentId: randomUUID(),
+    inventoryId: first.items[0].id,
+    inventoryRevision: first.items[0].revision,
+    recommendationId: recommendation.id,
+    selection: "calculated" as const,
+    overrideReviewedAt: null,
+  };
+  const [preview, repeated] = await Promise.all([
+    preparePublicationPreview(previewInput),
+    preparePublicationPreview(previewInput),
+  ]);
+  assert.equal(preview.id, repeated.id);
+  assert.deepEqual(
+    preview.plan,
+    repeated.plan,
+    "Concurrent retries return the original immutable plan",
+  );
+  assert.deepEqual(preview.conflicts, []);
+  assert.equal(preview.canPublish, false);
+  assert.equal(
+    (await db.query("SELECT count(*)::int AS n FROM slab_publication_previews"))
+      .rows[0].n,
+    1,
+  );
+  await assert.rejects(
+    () =>
+      preparePublicationPreview({
+        ...previewInput,
+        inventoryId: first.items[1].id,
+      }),
+    /already used/,
+  );
+  assert.equal(
+    (await readPublicationPreview({ inventoryId: first.items[0].id }))!.id,
+    preview.id,
+  );
   const corrected = await slabIdentityService.confirm(
     candidate,
     confirmed.revision,
@@ -266,6 +308,11 @@ try {
   assert.equal(
     (await getSlabRecommendation(recommendation.id))!.current,
     false,
+  );
+  assert.ok(
+    (await readPublicationPreview({ id: preview.id }))!.conflicts.includes(
+      "recommendation-changed",
+    ),
   );
   const recalculated = await calculateSlabRecommendation(
     { ...input, identityRevision: corrected.revision },

--- a/app/features/ebay-slab-pricing/routes/api.slab-publication-previews.server.ts
+++ b/app/features/ebay-slab-pricing/routes/api.slab-publication-previews.server.ts
@@ -1,0 +1,53 @@
+import { data } from "react-router";
+import { readSlabJsonRequest } from "../readJsonRequest.server";
+import { SlabPublicationError } from "../publication/slabPublicationPreview";
+import {
+  readPublicationPreview,
+  preparePublicationPreview,
+} from "../publication/slabPublicationPreviews.server";
+const respond = (body: unknown, status = 200) =>
+  data(body, { status, headers: { "Cache-Control": "no-store" } });
+function failure(error: unknown) {
+  return respond(
+    {
+      error:
+        error instanceof SlabPublicationError
+          ? error.message
+          : "Unable to access the price-change preview.",
+    },
+    error instanceof SlabPublicationError ||
+      error instanceof SyntaxError ||
+      error instanceof TypeError
+      ? 400
+      : 500,
+  );
+}
+export async function loader({ request }: { request: Request }) {
+  try {
+    const p = new URL(request.url).searchParams;
+    return respond(
+      await readPublicationPreview({
+        id: p.get("id") ?? undefined,
+        inventoryId: p.get("inventoryId") ?? undefined,
+      }),
+    );
+  } catch (error) {
+    return failure(error);
+  }
+}
+export async function action({ request }: { request: Request }) {
+  if (request.method !== "POST")
+    return respond({ error: "Method not allowed." }, 405);
+  if (request.headers.get("Origin") !== new URL(request.url).origin)
+    return respond({ error: "Prepare the preview from the application." }, 403);
+  try {
+    const input = await readSlabJsonRequest(request, 16384);
+    if (input.intent !== "prepare")
+      throw new SlabPublicationError(
+        "Only price-change previews are available. No publishing action is connected.",
+      );
+    return respond(await preparePublicationPreview(input));
+  } catch (error) {
+    return failure(error);
+  }
+}

--- a/app/features/ebay-slab-pricing/routes/api.slab-publication-previews.ts
+++ b/app/features/ebay-slab-pricing/routes/api.slab-publication-previews.ts
@@ -1,0 +1,1 @@
+export { loader, action } from "./api.slab-publication-previews.server";

--- a/app/features/ebay-slab-pricing/valuation/slabValuation.ts
+++ b/app/features/ebay-slab-pricing/valuation/slabValuation.ts
@@ -301,6 +301,32 @@ export function validateSellerPriceContext(
     minimumProfit: context.minimumProfit,
   };
 }
+// Null means an explicitly requested profit floor cannot be checked with known seller inputs.
+export function minimumSellerAsk(context: SellerPriceContext): number | null {
+  const floor = context.minimumAsk ?? 0;
+  if (context.minimumProfit === null) return floor;
+  if (
+    context.acquisitionCost === null ||
+    context.shippingCost === null ||
+    context.shippingCharged === null ||
+    !context.fees
+  )
+    return null;
+  const feeShipping =
+    context.fees.basis === "item-plus-shipping"
+      ? context.shippingCharged * context.fees.rate
+      : 0;
+  return Math.max(
+    floor,
+    (context.acquisitionCost +
+      context.shippingCost +
+      context.minimumProfit +
+      context.fees.fixed -
+      context.shippingCharged +
+      feeShipping) /
+      (1 - context.fees.rate),
+  );
+}
 export function proposeSlabAsk(
   market: MarketEstimate,
   context: SellerPriceContext,
@@ -351,32 +377,11 @@ export function proposeSlabAsk(
   let ask =
     market.range.midpoint -
     (market.basis === "item-plus-shipping" ? context.shippingCharged! : 0);
-  let floor = context.minimumAsk ?? 0;
-  if (context.minimumProfit !== null) {
-    if (
-      context.acquisitionCost === null ||
-      context.shippingCost === null ||
-      context.shippingCharged === null ||
-      !context.fees
-    ) {
-      flags.push({ code: "profit-floor-cannot-be-verified", review: true });
-      result.requiresReview = true;
-      return result;
-    }
-    const feeShipping =
-      context.fees.basis === "item-plus-shipping"
-        ? context.shippingCharged * context.fees.rate
-        : 0;
-    floor = Math.max(
-      floor,
-      (context.acquisitionCost +
-        context.shippingCost +
-        context.minimumProfit +
-        context.fees.fixed -
-        context.shippingCharged +
-        feeShipping) /
-        (1 - context.fees.rate),
-    );
+  const floor = minimumSellerAsk(context);
+  if (floor === null) {
+    flags.push({ code: "profit-floor-cannot-be-verified", review: true });
+    result.requiresReview = true;
+    return result;
   }
   if (floor > ask) {
     flags.push({ code: "seller-floor-raised-proposed-ask", review: false });

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -2,6 +2,10 @@ import { type RouteConfig, index } from "@react-router/dev/routes";
 
 export default [
   {
+    path: "/api/slab-publication-previews",
+    file: "features/ebay-slab-pricing/routes/api.slab-publication-previews.ts",
+  },
+  {
     path: "/api/slab-supply",
     file: "features/ebay-slab-pricing/routes/api.slab-supply.ts",
   },

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -1,4 +1,5 @@
 import "../core/clients/baseDomainClient.server.test";
+import "../features/ebay-slab-pricing/publication/slabPublicationPreview.test";
 import "../core/db/repositories/inventoryBatchPricingJobs.server.test";
 import "../core/utils/numberFieldMatching.test";
 import "../core/utils/readJsonResponse.test";

--- a/db/migrations/031_add_slab_publication_previews.sql
+++ b/db/migrations/031_add_slab_publication_previews.sql
@@ -1,0 +1,11 @@
+CREATE TABLE slab_publication_previews (
+  id UUID PRIMARY KEY,
+  inventory_id UUID NOT NULL REFERENCES slab_inventory(id),
+  recommendation_id UUID NOT NULL REFERENCES slab_recommendations(id),
+  request JSONB NOT NULL,
+  plan JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+  expires_at TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX slab_publication_preview_inventory_idx ON slab_publication_previews(inventory_id,created_at DESC,id DESC);
+CREATE INDEX slab_publication_preview_expiry_idx ON slab_publication_previews(expires_at);

--- a/docs/slab-publication-review.md
+++ b/docs/slab-publication-review.md
@@ -1,0 +1,23 @@
+# Reviewed eBay price changes
+
+The slab recommendation panel now saves a price-change preview for one selected listing. Choose the calculated or separately reviewed ask, then save the preview. It records the imported listing snapshot, old/new USD item price, identity/inventory revisions, recommendation, evidence references, policy, seller constraints and review reason. Reopening the listing retrieves its latest saved preview without contacting eBay.
+
+Migration 031 adds one indexed PostgreSQL table. Preview intents are immutable: concurrent retries with the same intent return the first saved plan; reuse for another selection is rejected. Plans expire at the earlier of 15 minutes or their evidence expiry. Reads flag changed inventory, recommendation, identity, comp decisions, evidence or reviewed ask. A new preview is required after changes. Each plan is bounded to 64 KiB; creation removes at most 100 previews expired more than 30 days ago. There is no new dependency, queue, polling loop or always-on worker. The review panel is loaded on demand.
+
+Only active, single-quantity fixed-price listings without variations or unresolved listing reasons can be previewed. A confirmed identity must be assigned to the listing. The recommendation must have a supported policy and adequate direct evidence, with the listing's current USD price and shipping charge. Reviewed overrides must use whole cents and meet saved seller floors; unknown inputs cannot satisfy a requested profit constraint. CSV/manual inventory is supported for preview but is not proof of live seller state.
+
+## Current delivery boundary
+
+This is the preview portion of #31. No approval, publication, retry, restoration or continuous-publication endpoint is connected. `canPublish` is always false. The user interface explicitly explains this, and posting a publishing intent to the preview route is rejected. The shared production eBay keyset still needs activation coordinated with the other app that uses it.
+
+The official [ReviseInventoryStatus contract](https://developer.ebay.com/devzone/xml/docs/reference/ebay/ReviseInventoryStatus.html) is a narrow candidate for supported Trading-model fixed-price listings: send identifiers and price only, omitting quantity. Its response is not proof of the resulting price; use an authenticated [GetItem readback](https://developer.ebay.com/devzone/xml/docs/reference/ebay/GetItem.html). Inventory API/MIP listings require their own compatible publisher. Variations require verified exact variation identity and remain unsupported here. A SKU alone is not a substitute for the saved seller/listing/variation identity.
+
+Before live delivery, #31 still requires an authenticated listing-origin/capability check, a fresh seller read during live plan preparation, explicit approval of that concrete live plan, immediate pre-write conflict checks, durable per-item outcomes, bounded execution, readback and ambiguity reconciliation. Only the price may be sent. A timeout must not cause an automatic repeat write: first reconcile the current listing and prior intent. Restore must be a new reviewed update against the current state. The Trading API has no documented compare-and-swap precondition for this price update, so read-then-write cannot promise protection against every concurrent external edit; surface this limitation in the live workflow and verify all protected fields afterward.
+
+No automatic cohort can publish through a preview. Seller OAuth/readback and the remaining publication acceptance tests, including independently approved native before/after validation, remain open prerequisites. Evidence/model gaps in #29/#30 also keep #32 automation disabled.
+
+## Validation
+
+`npm test` includes offline cases for exact price selection, stale evidence, identity/inventory conflicts, sold/ended items, quantities, variations, currency/shipping changes, override revisions and seller floors. `npx tsx app/features/ebay-slab-pricing/research/slabResearch.integration.test.ts` uses a disposable schema on the guarded local development database to verify concurrent immutable intents, retry mismatch rejection, persisted reload and correction invalidation with provider fetches prohibited.
+
+Chrome validation uses a clearly labeled local synthetic listing: the USD 100 to USD 125 reviewed preview survives reload, and changing the reviewed ask requires replacement of the original preview. This is UI/storage validation, not a live eBay publication. Apply migration 031 before this build; restore its table with the referenced inventory/recommendation tables. The migration enables no background work or price writes.


### PR DESCRIPTION
The recommendation page now saves an immutable price-change preview for a selected slab listing. Operators can choose the calculated or reviewed ask, see the exact old/new USD price and provenance, and reopen the preview without provider requests. Changed inventory, identity, evidence or overrides require a replacement preview.

The feature uses one indexed table, a pure planner, a narrow persistence service and an on-demand React panel. It reuses the seller-floor function for recommendations and reviewed overrides. Intents coalesce concurrent retries; plans expire within 15 minutes, cap at 64 KiB and have bounded retention. No new dependency, queue or background worker.

Validation: npm test, typecheck, production/worker build and isolated workspace/recommendation PostgreSQL integration checks pass. Tests include sold/ended items, quantity/variation restrictions, changed price/currency/shipping, seller floors, stale evidence, concurrent intent retries and correction invalidation. Chrome verified a synthetic USD 100 → USD 125 preview survives reload and stays immutable when the reviewed ask changes to USD 126. Synthetic records were removed. Existing MUI build warnings remain.

Adversarial review improved override revision comparison, explicit large-change warnings and the shared seller-floor capability; the final pass found no remaining actionable defects in the preview scope.

Advances #31; does not close it. Seller OAuth activation is blocked by the shared keyset's other application. Live preparation/approval, provider writes, durable outcomes, ambiguity reconciliation, readback and reviewed restore remain outstanding. No publication endpoint is wired, and previews cannot write to eBay. The supported API boundary and read/write race limitation are documented in docs/slab-publication-review.md.
