### PR TITLE
Enforce inventory review gates before slab price previews

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,9 @@ logs
 # Development files
 .env.local
 .env.development
+.env*
+.artifacts/
+.codex/
 *.log
 
 # Documentation

--- a/app/features/ebay-slab-pricing/inventory/slabInventory.server.ts
+++ b/app/features/ebay-slab-pricing/inventory/slabInventory.server.ts
@@ -145,30 +145,18 @@ export async function reconcileInventory(
   });
 }
 
-export async function getInventory(seller: string, after = "", limit = 100) {
-  if (
-    !Number.isSafeInteger(limit) ||
-    limit < 1 ||
-    limit > 200 ||
-    (after && !/^[a-f0-9-]{36}$/.test(after))
-  )
-    throw new SlabInventoryError("invalid-input", "Invalid inventory page.");
-  const rows = await query<
-    InventoryRow & {
-      identity: InventoryIdentity | null;
-      duplicateCertificate: boolean;
-    }
-  >(
-    `SELECT ${COLUMNS},
+type InventoryReviewRow = InventoryRow & {
+  identity: InventoryIdentity | null;
+  duplicateCertificate: boolean;
+};
+const REVIEW_COLUMNS = `${COLUMNS},
     (SELECT jsonb_build_object('id', i.id, 'grader', i.grader, 'certificateNumber', i.certificate_number,
       'candidate', i.candidate, 'identity', i.identity, 'status', i.status, 'reviewReasons', i.review_reasons,
       'valuationGroupKey', i.valuation_group_key, 'revision', i.revision) FROM slab_identities i WHERE i.id = s.identity_id) AS identity,
     EXISTS (SELECT 1 FROM slab_inventory other WHERE other.seller = s.seller AND other.id <> s.id AND other.state = 'active'
-      AND s.snapshot->'certificate' <> 'null'::jsonb AND other.snapshot->'certificate' = s.snapshot->'certificate') AS "duplicateCertificate"
-    FROM slab_inventory s WHERE seller = $1 AND ($2 = '' OR id > NULLIF($2, '')::uuid) ORDER BY id LIMIT $3`,
-    [sellerAccount(seller), after, limit + 1],
-  );
-  const page = rows.slice(0, limit).map((row) => ({
+      AND s.snapshot->'certificate' <> 'null'::jsonb AND other.snapshot->'certificate' = s.snapshot->'certificate') AS "duplicateCertificate"`;
+function reviewInventoryRow(row: InventoryReviewRow) {
+  return {
     ...row,
     url: `https://www.ebay.com/itm/${row.itemId}`,
     reviewReasons: [
@@ -191,7 +179,33 @@ export async function getInventory(seller: string, after = "", limit = 100) {
           : []),
       ]),
     ],
-  }));
+  };
+}
+export async function getInventoryListing(id: string) {
+  if (!/^[a-f0-9-]{36}$/.test(id))
+    throw new SlabInventoryError(
+      "invalid-input",
+      "Choose an inventory listing.",
+    );
+  const row = await queryOne<InventoryReviewRow>(
+    `SELECT ${REVIEW_COLUMNS} FROM slab_inventory s WHERE id=$1`,
+    [id],
+  );
+  return row ? reviewInventoryRow(row) : null;
+}
+export async function getInventory(seller: string, after = "", limit = 100) {
+  if (
+    !Number.isSafeInteger(limit) ||
+    limit < 1 ||
+    limit > 200 ||
+    (after && !/^[a-f0-9-]{36}$/.test(after))
+  )
+    throw new SlabInventoryError("invalid-input", "Invalid inventory page.");
+  const rows = await query<InventoryReviewRow>(
+    `SELECT ${REVIEW_COLUMNS} FROM slab_inventory s WHERE seller=$1 AND ($2='' OR id>NULLIF($2,'')::uuid) ORDER BY id LIMIT $3`,
+    [sellerAccount(seller), after, limit + 1],
+  );
+  const page = rows.slice(0, limit).map(reviewInventoryRow);
   return {
     items: page,
     next: rows.length > limit ? page.at(-1)!.id : null,

--- a/app/features/ebay-slab-pricing/publication/slabPublicationPreview.test.ts
+++ b/app/features/ebay-slab-pricing/publication/slabPublicationPreview.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import type { InventoryRow } from "../inventory/slabInventory.server";
+import type { PublicationInventory } from "./slabPublicationPreview";
 import type { StoredSlabRecommendation } from "../valuation/slabRecommendations.server";
 import {
   DEFAULT_SLAB_POLICY,
@@ -85,7 +85,8 @@ const recommendation: StoredSlabRecommendation = {
     ],
   },
 };
-const inventory: InventoryRow = {
+const inventory: PublicationInventory = {
+  reviewReasons: ["certificate-required"],
   id: id(1),
   seller: "fixture",
   itemId: "123456789012",
@@ -124,6 +125,22 @@ const request: PreviewRequest = {
 const build = (row = inventory, rec = recommendation, input = request) =>
   buildPublicationPreview(input, row, rec, now);
 const plan = build();
+assert.throws(
+  () =>
+    build({
+      ...inventory,
+      reviewReasons: ["certificate-used-by-another-active-listing"],
+    }),
+  /review reasons/,
+);
+assert.throws(
+  () =>
+    build({
+      ...inventory,
+      reviewReasons: ["listing-certificate-conflicts-with-manual-identity"],
+    }),
+  /review reasons/,
+);
 assert.equal(plan.mode, "preview");
 assert.equal(plan.oldPrice.amount, 100);
 assert.equal(plan.newPrice.amount, 125);

--- a/app/features/ebay-slab-pricing/publication/slabPublicationPreview.ts
+++ b/app/features/ebay-slab-pricing/publication/slabPublicationPreview.ts
@@ -4,6 +4,7 @@ import { minimumSellerAsk } from "../valuation/slabValuation";
 
 export const SLAB_PUBLICATION_POLICY = "reviewed-price-v1";
 export class SlabPublicationError extends Error {}
+export type PublicationInventory = InventoryRow & { reviewReasons: string[] };
 export type PreviewRequest = {
   intentId: string;
   inventoryId: string;
@@ -55,7 +56,7 @@ function cents(value: number) {
 }
 export function buildPublicationPreview(
   request: PreviewRequest,
-  inventory: InventoryRow,
+  inventory: PublicationInventory,
   recommendation: StoredSlabRecommendation,
   now: string,
 ) {
@@ -96,7 +97,7 @@ export function buildPublicationPreview(
       "Variation listings need a verified variation publisher and remain in review.",
     );
   if (
-    snapshot.reviewReasons.some((reason) => reason !== "certificate-required")
+    inventory.reviewReasons.some((reason) => reason !== "certificate-required")
   )
     throw new SlabPublicationError(
       "Resolve the listing's review reasons before preparing its price change.",
@@ -196,7 +197,7 @@ export function buildPublicationPreview(
 export type PublicationPreview = ReturnType<typeof buildPublicationPreview>;
 export function previewConflicts(
   plan: PublicationPreview,
-  inventory: InventoryRow | null,
+  inventory: PublicationInventory | null,
   recommendation: StoredSlabRecommendation | null,
   now: string,
 ) {
@@ -217,7 +218,8 @@ export function previewConflicts(
     inventory.itemId !== plan.inventory.itemId ||
     inventory.variationKey !== plan.inventory.variationKey ||
     inventory.identityId !== plan.identity.slabId ||
-    inventory.state !== "active"
+    inventory.state !== "active" ||
+    inventory.reviewReasons.some((reason) => reason !== "certificate-required")
   )
     reasons.push("inventory-changed");
   if (

--- a/app/features/ebay-slab-pricing/publication/slabPublicationPreviews.server.ts
+++ b/app/features/ebay-slab-pricing/publication/slabPublicationPreviews.server.ts
@@ -1,5 +1,5 @@
 import { queryOne, withTransaction } from "~/core/db/database.server";
-import type { InventoryRow } from "../inventory/slabInventory.server";
+import { getInventoryListing } from "../inventory/slabInventory.server";
 import { getSlabRecommendation } from "../valuation/slabRecommendations.server";
 import {
   buildPublicationPreview,
@@ -11,11 +11,6 @@ import {
   type PublicationPreview,
 } from "./slabPublicationPreview";
 
-const columns = `id,seller,item_id AS "itemId",variation_key AS "variationKey",snapshot,source,state,revision,identity_id AS "identityId",identity_source AS "identitySource",identity_note AS "identityNote",observed_at AS "observedAt"`;
-const readInventory = (id: string) =>
-  queryOne<InventoryRow>(`SELECT ${columns} FROM slab_inventory WHERE id=$1`, [
-    id,
-  ]);
 type StoredPreview = {
   id: string;
   request: PreviewRequest;
@@ -23,7 +18,7 @@ type StoredPreview = {
 };
 async function describe(row: StoredPreview) {
   const [inventory, recommendation] = await Promise.all([
-    readInventory(row.plan.inventory.id),
+    getInventoryListing(row.plan.inventory.id),
     getSlabRecommendation(row.plan.recommendationId),
   ]);
   return {
@@ -72,7 +67,7 @@ export async function preparePublicationPreview(input: PreviewRequest) {
     return describe(previous);
   }
   const [inventory, recommendation] = await Promise.all([
-    readInventory(request.inventoryId),
+    getInventoryListing(request.inventoryId),
     getSlabRecommendation(request.recommendationId),
   ]);
   if (!inventory || !recommendation)

--- a/app/features/ebay-slab-pricing/research/slabResearch.integration.test.ts
+++ b/app/features/ebay-slab-pricing/research/slabResearch.integration.test.ts
@@ -262,6 +262,15 @@ try {
     selection: "calculated" as const,
     overrideReviewedAt: null,
   };
+  await assert.rejects(
+    () => preparePublicationPreview(previewInput),
+    /review reasons/,
+  );
+  // This stress sample repeats one certificate. Leave only the previewed listing assigned to it.
+  await db.query(
+    "UPDATE slab_inventory SET snapshot=jsonb_set(snapshot,'{certificate}','null'::jsonb),identity_id=NULL WHERE seller=$1 AND id<>$2",
+    ["workspace-sample", first.items[0].id],
+  );
   const [preview, repeated] = await Promise.all([
     preparePublicationPreview(previewInput),
     preparePublicationPreview(previewInput),
@@ -290,6 +299,20 @@ try {
   assert.equal(
     (await readPublicationPreview({ inventoryId: first.items[0].id }))!.id,
     preview.id,
+  );
+  await db.query(
+    "UPDATE slab_inventory SET snapshot=jsonb_set(snapshot,'{certificate}',$2::jsonb) WHERE id=$1",
+    [first.items[1].id, JSON.stringify(first.items[0].snapshot.certificate)],
+  );
+  assert.ok(
+    (await readPublicationPreview({ id: preview.id }))!.conflicts.includes(
+      "inventory-changed",
+    ),
+    "A duplicate created elsewhere invalidates the preview without changing the original listing revision",
+  );
+  await db.query(
+    "UPDATE slab_inventory SET snapshot=jsonb_set(snapshot,'{certificate}','null'::jsonb) WHERE id=$1",
+    [first.items[1].id],
   );
   const corrected = await slabIdentityService.confirm(
     candidate,


### PR DESCRIPTION
Acceptance review found that publication previews checked stored snapshot flags but missed inventory warnings calculated at read time. The preview now composes the same reviewed inventory reader as the inventory page, so duplicate certificates, manual certificate conflicts and expected-identity conflicts block preparation. A duplicate created on another listing also invalidates an existing preview without relying on the original listing revision changing.

The Docker build context now excludes all local environment variants and local research/Codex artifacts. The previous patterns missed .env.development.local; no credentials or research captures are needed to build the image.

Validation: npm test, typecheck, host production/worker build and disposable PostgreSQL workspace/inventory tests pass. Regressions cover duplicate-certificate preparation and invalidation after a second listing acquires the certificate. The 5,000-row inventory test still passes. A Node 20 Docker build passed with the expanded exclusions. Final adversarial review found no additional actionable issues in these changes.

Follow-up to #31 and #33. This enables no live publication or automation.
