### PR TITLE
Validate slab preview coverage and performance

### DIFF
--- a/app/features/ebay-slab-pricing/evaluation/benchmark-slab-http.mjs
+++ b/app/features/ebay-slab-pricing/evaluation/benchmark-slab-http.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { writeFile } from "node:fs/promises";
+const [baselineUrl, currentUrl] = process.argv.slice(2);
+for (const address of [baselineUrl, currentUrl]) {
+  const url = new URL(address);
+  assert.ok(
+    ["127.0.0.1", "localhost"].includes(url.hostname) &&
+      url.protocol === "http:",
+    "Benchmark local validation servers only",
+  );
+}
+const percentile = (values, p) =>
+  [...values].sort((a, b) => a - b)[Math.ceil(values.length * p) - 1];
+async function read(address, route) {
+  const start = performance.now(),
+    response = await fetch(new URL(route, address), {
+      signal: AbortSignal.timeout(10000),
+    });
+  const body = await response.text();
+  assert.equal(response.status, 200, `${route} must render`);
+  return { ms: performance.now() - start, bytes: Buffer.byteLength(body) };
+}
+const results = {};
+for (const route of ["/", "/pricer", "/pending-inventory-pricer"]) {
+  for (let i = 0; i < 5; i++) {
+    await read(baselineUrl, route);
+    await read(currentUrl, route);
+  }
+  const before = [],
+    after = [];
+  for (let i = 0; i < 50; i++) {
+    // Alternate order to reduce warm-up and scheduling bias.
+    if (i % 2) {
+      after.push(await read(currentUrl, route));
+      before.push(await read(baselineUrl, route));
+    } else {
+      before.push(await read(baselineUrl, route));
+      after.push(await read(currentUrl, route));
+    }
+  }
+  const describe = (rows) => ({
+    samples: rows.length,
+    p50Ms: percentile(
+      rows.map((r) => r.ms),
+      0.5,
+    ),
+    p95Ms: percentile(
+      rows.map((r) => r.ms),
+      0.95,
+    ),
+    responseBytes: rows.at(-1).bytes,
+  });
+  results[route] = { before: describe(before), after: describe(after) };
+}
+const newRoutes = {};
+for (const route of [
+  "/slab-pricing",
+  "/slab-connections",
+  "/api/slab-inventory?seller=acceptance-fixture&limit=25",
+]) {
+  const first = await read(currentUrl, route),
+    rows = [];
+  for (let i = 0; i < 30; i++) rows.push(await read(currentUrl, route));
+  newRoutes[route] = {
+    firstRequestMs: first.ms,
+    p50Ms: percentile(
+      rows.map((r) => r.ms),
+      0.5,
+    ),
+    p95Ms: percentile(
+      rows.map((r) => r.ms),
+      0.95,
+    ),
+  };
+}
+const report = {
+  measuredAt: new Date().toISOString(),
+  scope:
+    "Local Docker Node 20 production builds on fresh empty databases, no provider credentials. HTTP render latency only; network market latency and production job contention are unmeasured.",
+  results,
+  newRoutes,
+};
+await writeFile(
+  "docs/slab-preview-http.json",
+  JSON.stringify(report, null, 2) + "\n",
+);
+console.log(JSON.stringify(report, null, 2));

--- a/app/features/ebay-slab-pricing/evaluation/benchmarkSlabPreview.server.ts
+++ b/app/features/ebay-slab-pricing/evaluation/benchmarkSlabPreview.server.ts
@@ -1,0 +1,238 @@
+// Explicit local benchmark only: all mutations use an isolated development schema; provider responses are fixture-backed.
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import pg from "pg";
+import dotenv from "dotenv";
+import Papa from "papaparse";
+import fixture from "./fixtures/pokebash-preview-sample.json";
+import salesFixture from "../evidence/fixtures/alt-sales.json";
+import { parseAltSales } from "../evidence/altEvidenceProvider.server";
+import { getPool } from "~/core/db/database.server";
+import { parseInventoryCsv } from "../inventory/slabInventoryCsv.server";
+import {
+  getInventory,
+  reconcileInventory,
+} from "../inventory/slabInventory.server";
+import {
+  requestEvidence,
+  claimEvidenceJob,
+  getEvidenceRevision,
+  completeEvidenceJob,
+} from "../evidence/evidenceRefreshStore.server";
+import type { EvidenceSpec } from "../evidence/evidenceRefresh";
+dotenv.config({
+  path: [".env.development.local", ".env.local", ".env.development", ".env"],
+  quiet: true,
+});
+const url = new URL(
+  process.env.DATABASE_URL ??
+    "postgresql://postgres:postgres@localhost:5433/tcgplayer_automation",
+);
+assert.ok(
+  ["localhost", "127.0.0.1"].includes(url.hostname) &&
+    url.port === "5433" &&
+    url.pathname === "/tcgplayer_automation",
+  "Benchmark only the configured local development database",
+);
+const schema = `slab_benchmark_${randomUUID().replaceAll("-", "")}`;
+const admin = new pg.Client({ connectionString: url.toString() });
+await admin.connect();
+await admin.query(`CREATE SCHEMA "${schema}"`);
+url.searchParams.set("options", `-c search_path=${schema}`);
+process.env.DATABASE_URL = url.toString();
+const db = getPool(),
+  originalFetch = globalThis.fetch;
+const originalQuery = db.query;
+let poolQueryCalls = 0;
+db.query = function (this: typeof db, ...args: any[]) {
+  poolQueryCalls++;
+  return Reflect.apply(originalQuery, this, args);
+} as typeof db.query;
+let remoteAttempts = 0;
+globalThis.fetch = async () => {
+  remoteAttempts++;
+  throw new Error("No provider/network requests are allowed in this benchmark");
+};
+const percentile = (values: number[], p: number) =>
+  [...values].sort((a, b) => a - b)[Math.ceil(values.length * p) - 1];
+const timings = async (count: number, fn: () => Promise<unknown>) => {
+  const values: number[] = [];
+  const queriesBefore = poolQueryCalls;
+  for (let i = 0; i < count; i++) {
+    const start = performance.now();
+    await fn();
+    values.push(performance.now() - start);
+  }
+  return {
+    samples: count,
+    p50Ms: percentile(values, 0.5),
+    p95Ms: percentile(values, 0.95),
+    pooledQueriesPerSample: (poolQueryCalls - queriesBefore) / count,
+  };
+};
+try {
+  for (const file of [
+    "025_add_slab_identities.sql",
+    "026_add_slab_inventory.sql",
+    "027_add_slab_evidence_refreshes.sql",
+    "028_add_slab_comp_decisions.sql",
+    "029_add_slab_recommendations.sql",
+    "030_add_slab_supply_observations.sql",
+    "031_add_slab_publication_previews.sql",
+  ])
+    await db.query(await readFile(`db/migrations/${file}`, "utf8"));
+  const csv = Papa.unparse(
+    fixture.listings.map((r) => ({
+      item_id: r.itemId,
+      title: r.title,
+      price: r.askingPriceUsd,
+      currency: "USD",
+      quantity: 1,
+      state: "active",
+      format: "fixed-price",
+    })),
+  );
+  let start = performance.now();
+  await reconcileInventory(parseInventoryCsv(csv, "acceptance-fixture"), 0);
+  const import50Ms = performance.now() - start;
+  const read50 = async () => {
+    const a = await getInventory("acceptance-fixture", "", 25),
+      b = await getInventory("acceptance-fixture", a.next!, 25);
+    assert.equal(a.items.length + b.items.length, 50);
+    assert.ok([...a.items, ...b.items].every((r) => !r.identity));
+  };
+  await read50();
+  const inventory50 = await timings(30, read50);
+  const window = { from: "2023-01-01", to: "2026-09-05" };
+  const base = parseAltSales(
+    JSON.stringify(salesFixture),
+    "cd3ecabf-7d43-4375-9428-1a7cdfe66426",
+    window,
+    16,
+    new Date().toISOString(),
+  );
+  const workload: EvidenceSpec[] = Array.from({ length: 50 }, (_, i) => ({
+    kind: "alt-sales",
+    assetId: `benchmark-card-${Math.floor(i / 5)}`,
+    window,
+    limitPerGrade: 16,
+  }));
+  start = performance.now();
+  const statuses = await requestEvidence(workload);
+  assert.equal(statuses.length, 10);
+  let fixtureWorkflows = 0;
+  while (true) {
+    const job = await claimEvidenceJob();
+    if (!job) break;
+    assert.ok(job.spec.kind === "alt-sales");
+    fixtureWorkflows++;
+    await completeEvidenceJob(
+      job,
+      {
+        kind: "alt-sales",
+        data: {
+          ...base,
+          sales: base.sales.map((r) => ({
+            ...r,
+            assetId: (job.spec as Extract<EvidenceSpec, { kind: "alt-sales" }>)
+              .assetId,
+          })),
+        },
+      },
+      0,
+    );
+  }
+  const coldFixtureRefreshMs = performance.now() - start;
+  assert.equal(fixtureWorkflows, 10);
+  const warmEvidence = await timings(30, async () => {
+    const rows = await requestEvidence(workload);
+    assert.equal(rows.length, 10);
+    assert.ok(rows.every((r) => !r.stale));
+    assert.equal(await claimEvidenceJob(), null);
+  });
+  const evidencePages = await timings(30, async () => {
+    for (const status of statuses) {
+      const row = await getEvidenceRevision(status.runId);
+      assert.ok(row);
+    }
+  });
+  const large = parseInventoryCsv(
+    Papa.unparse(
+      Array.from({ length: 5000 }, (_, i) => ({
+        item_id: String(800000000000 + i),
+        title: `Synthetic inventory row ${i}`,
+        price: 100,
+        currency: "USD",
+        quantity: 1,
+        state: "active",
+        format: "fixed-price",
+      })),
+    ),
+    "large-fixture",
+  );
+  start = performance.now();
+  await reconcileInventory(large, 0);
+  const import5000Ms = performance.now() - start;
+  const largePage = await timings(30, async () => {
+    assert.equal(
+      (await getInventory("large-fixture", "", 25)).items.length,
+      25,
+    );
+  });
+  const storage = (
+    await db.query<{ bytes: string }>(
+      "SELECT sum(pg_total_relation_size(c.oid))::text AS bytes FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname=$1 AND c.relkind='r'",
+      [schema],
+    )
+  ).rows[0].bytes;
+  const report = {
+    measuredAt: new Date().toISOString(),
+    node: process.version,
+    platform: process.platform,
+    scope:
+      "Local isolated PostgreSQL feature benchmark. HTTP/provider latency and accepted comp precision are not measured.",
+    historicalSample: {
+      listings: fixture.listings.length,
+      researchQueries: new Set(fixture.listings.map((r) => r.researchQuery))
+        .size,
+      emptySearches: fixture.listings.filter((r) => r.visibleSoldRows === 0)
+        .length,
+      visibleSoldRows: fixture.listings.reduce(
+        (sum, r) => sum + r.visibleSoldRows,
+        0,
+      ),
+      confirmedIdentityCoverage: null,
+      acceptedCompPrecision: null,
+      priceError: null,
+    },
+    import50Ms,
+    inventory50,
+    coldFixtureRefreshMs,
+    fixtureWorkflows,
+    warmEvidence,
+    evidencePages,
+    import5000Ms,
+    largePage,
+    databaseBytes: Number(storage),
+    processMemory: process.memoryUsage(),
+    remoteAttempts,
+    gates: {
+      zeroRemoteRequests: remoteAttempts === 0,
+      coalescedGroups: fixtureWorkflows === 10,
+      maximumInventoryPage: 25,
+      automationEnabled: false,
+    },
+  };
+  assert.equal(remoteAttempts, 0);
+  await writeFile(
+    "docs/slab-preview-benchmark.json",
+    JSON.stringify(report, null, 2) + "\n",
+  );
+  console.log(JSON.stringify(report, null, 2));
+} finally {
+  globalThis.fetch = originalFetch;
+  await db.end();
+  await admin.query(`DROP SCHEMA "${schema}" CASCADE`);
+  await admin.end();
+}

--- a/app/features/ebay-slab-pricing/evaluation/compare-slab-preview-builds.mjs
+++ b/app/features/ebay-slab-pricing/evaluation/compare-slab-preview-builds.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { readFile, readdir, writeFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+const [baseline, current] = process.argv.slice(2);
+assert.ok(
+  baseline && current,
+  "Provide baseline and current build directories",
+);
+async function inspect(directory) {
+  const assets = path.join(directory, "client/assets"),
+    files = await readdir(assets);
+  const manifestFile = files.find((file) => /^manifest-.*\.js$/.test(file));
+  assert.ok(manifestFile);
+  const text = await readFile(path.join(assets, manifestFile), "utf8");
+  const prefix = "window.__reactRouterManifest=";
+  assert.ok(text.startsWith(prefix));
+  const manifest = JSON.parse(text.slice(prefix.length).replace(/;\s*$/, ""));
+  const size = async (url) =>
+    gzipSync(await readFile(path.join(directory, "client", url))).byteLength;
+  const entry = manifest.entry,
+    root = manifest.routes.root;
+  const routes = {};
+  for (const routePath of [
+    "/pricer",
+    "/pending-inventory-pricer",
+    "/slab-pricing",
+  ]) {
+    const route = Object.values(manifest.routes).find(
+      (r) => r.path === routePath,
+    );
+    if (!route) continue;
+    const urls = [
+      ...new Set([
+        entry.module,
+        ...entry.imports,
+        root.module,
+        ...root.imports,
+        route.module,
+        ...route.imports,
+        `/assets/${manifestFile}`,
+      ]),
+    ];
+    routes[routePath] = {
+      gzipBytes: (await Promise.all(urls.map(size))).reduce((a, b) => a + b, 0),
+      slabModules: urls.filter((url) =>
+        /Slab|slabClient|slab-pricing/.test(url),
+      ),
+    };
+  }
+  const lazySlab = {};
+  for (const file of files.filter((name) =>
+    /^Slab(?:CompReview|SupplyPanel|PublicationPreview)-/.test(name),
+  ))
+    lazySlab[file.split("-")[0]] = await size(`/assets/${file}`);
+  const workers = {};
+  for (const file of (await readdir(path.join(directory, "workers"))).filter(
+    (name) => name.endsWith(".js"),
+  ))
+    workers[file] = (await stat(path.join(directory, "workers", file))).size;
+  return { routes, lazySlab, workers };
+}
+const before = await inspect(baseline),
+  after = await inspect(current);
+const deltas = Object.fromEntries(
+  ["/pricer", "/pending-inventory-pricer"].map((route) => [
+    route,
+    after.routes[route].gzipBytes - before.routes[route].gzipBytes,
+  ]),
+);
+for (const route of Object.keys(deltas)) {
+  assert.deepEqual(
+    after.routes[route].slabModules,
+    [],
+    "Existing routes must not load slab implementation chunks",
+  );
+  assert.ok(
+    deltas[route] <= 4096,
+    "Existing route static gzip growth must stay within the 4 KiB navigation/manifest budget",
+  );
+}
+const report = {
+  measuredAt: new Date().toISOString(),
+  basis:
+    "React Router static entry/root/route imports plus route manifest; gzip per asset. Lazy panel figures exclude shared dependencies.",
+  before,
+  after,
+  deltas,
+  gates: { unrelatedSlabModules: 0, unrelatedRouteGrowthBudgetBytes: 4096 },
+};
+await writeFile(
+  "docs/slab-preview-bundles.json",
+  JSON.stringify(report, null, 2) + "\n",
+);
+console.log(JSON.stringify(report, null, 2));

--- a/app/features/ebay-slab-pricing/evaluation/fixtures/pokebash-preview-sample.json
+++ b/app/features/ebay-slab-pricing/evaluation/fixtures/pokebash-preview-sample.json
@@ -1,0 +1,462 @@
+{
+  "capturedAt": "2026-09-05T19:18:41.925Z",
+  "seller": "pokebash",
+  "window": {
+    "start": "2026-06-07",
+    "end": "2026-09-05",
+    "marketplace": "EBAY-US"
+  },
+  "limitations": "Historical public listing titles and asks; certificates, quantity, identity and comparable acceptance are unverified. Sold-row counts are observed search coverage, not accepted comps.",
+  "listings": [
+    {
+      "sample": 1,
+      "itemId": "397802495164",
+      "title": "1999 Pokemon Base Set 1st Edition Shadowless Ponyta 60/102 PSA 9 Mint",
+      "askingPriceUsd": 150,
+      "researchQuery": "Ponyta 60 1st PSA 9",
+      "visibleSoldRows": 21,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 2,
+      "itemId": "396930808378",
+      "title": "Blastoise 017/078 Reverse Holo Rare - SGC 10 GEM MINT - Pokémon GO",
+      "askingPriceUsd": 50,
+      "researchQuery": "Blastoise 017/078 reverse SGC 10",
+      "visibleSoldRows": 0,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 3,
+      "itemId": "397103446770",
+      "title": "2025 Pokémon Marnie’s Morpeko SVP #206 PSA 9 Black Star Promo (Rival Battle Deck",
+      "askingPriceUsd": 86,
+      "researchQuery": "Marnie Morpeko 206 PSA 9",
+      "visibleSoldRows": 40,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 4,
+      "itemId": "397443142203",
+      "title": "2022 Pokémon Astral Radiance Hisuian Samurott VSTAR 209/189 Secret PSA 10",
+      "askingPriceUsd": 65,
+      "researchQuery": "Hisuian Samurott 209 PSA 10",
+      "visibleSoldRows": 7,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 5,
+      "itemId": "397774081597",
+      "title": "2023 Pokemon SWSH Black Star Promo Galarian Zapdos SWSH283 Holo PSA 8",
+      "askingPriceUsd": 16,
+      "researchQuery": "Galarian Zapdos SWSH283 PSA 8",
+      "visibleSoldRows": 15,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 6,
+      "itemId": "397978107194",
+      "title": "1999 Pokemon Jungle 1st Edition Goldeen 53/64 CGC 10 Gem Mint",
+      "askingPriceUsd": 49.99,
+      "researchQuery": "Goldeen 53 1st CGC 10",
+      "visibleSoldRows": 1,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 7,
+      "itemId": "397285478450",
+      "title": "2016 Pokémon M Gengar EX XY166 Black Star Promo – PSA 1 (Poor), English",
+      "askingPriceUsd": 200,
+      "researchQuery": "Gengar XY166 \"PSA 1\"",
+      "visibleSoldRows": 10,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 8,
+      "itemId": "396930795644",
+      "title": "Gardevoir ex 228/198 Ultra Rare Full Art - SGC 10 GEM MINT - Scarlet & Violet",
+      "askingPriceUsd": 28,
+      "researchQuery": "Gardevoir 228 SGC 10",
+      "visibleSoldRows": 2,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 9,
+      "itemId": "397978107163",
+      "title": "2024 Pokemon SVP Mimikyu 075 Paldean Fates PC ETB Promo PSA 9",
+      "askingPriceUsd": 99.99,
+      "researchQuery": "Mimikyu 075 Pokemon Center PSA 9",
+      "visibleSoldRows": 50,
+      "possiblyPageLimited": true
+    },
+    {
+      "sample": 10,
+      "itemId": "397285478481",
+      "title": "Okidogi ex #090/064 SIR Shrouded Fable CGC 10 GEM MINT 2024 Pokémon EN",
+      "askingPriceUsd": 60,
+      "researchQuery": "Okidogi 090/064 CGC 10",
+      "visibleSoldRows": 3,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 11,
+      "itemId": "397282303023",
+      "title": "2023 Pokémon JP Charizard ex SSR #331 sv4a — FCG 9.5 Gem Mint",
+      "askingPriceUsd": 37,
+      "researchQuery": "Charizard 331 FCG 9.5",
+      "visibleSoldRows": 0,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 12,
+      "itemId": "397978107199",
+      "title": "2023 Pokemon Japanese Shiny Treasure ex Penny SAR 354/190 PSA 10",
+      "askingPriceUsd": 94.99,
+      "researchQuery": "Penny 354/190 PSA 10",
+      "visibleSoldRows": 14,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 13,
+      "itemId": "397777166036",
+      "title": "2023 Pokemon Card 151 Japanese Charmander 168/165 Art Rare CGC Pristine 10",
+      "askingPriceUsd": 150,
+      "researchQuery": "Charmander 168/165 CGC pristine 10",
+      "visibleSoldRows": 41,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 14,
+      "itemId": "397978107151",
+      "title": "2024 One Piece Sentomaru ST03-007 Bandai Games Fest CGC 10",
+      "askingPriceUsd": 36.99,
+      "researchQuery": "Sentomaru ST03-007 Games Fest CGC 10",
+      "visibleSoldRows": 9,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 15,
+      "itemId": "397443142191",
+      "title": "2025 Pokemon MEG EN Bulbasaur #133/132 Illustration Rare Holo PSA 9 Mint",
+      "askingPriceUsd": 50,
+      "researchQuery": "Bulbasaur 133/132 PSA 9",
+      "visibleSoldRows": 50,
+      "possiblyPageLimited": true
+    },
+    {
+      "sample": 16,
+      "itemId": "397978107159",
+      "title": "2023 Pokemon Paradox Rift Espathra 081 Two Pack Blister PSA 8",
+      "askingPriceUsd": 14.99,
+      "researchQuery": "Espathra 081 blister PSA 8",
+      "visibleSoldRows": 0,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 17,
+      "itemId": "397443138479",
+      "title": "2024 Pokemon Japanese SV8a Terastal Festival Flareon ex 022/187 RR PSA 10",
+      "askingPriceUsd": 50,
+      "researchQuery": "Flareon 022/187 PSA 10",
+      "visibleSoldRows": 30,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 18,
+      "itemId": "397777166035",
+      "title": "2019 Pokemon Hidden Fates Zorua SV25/SV94 Shiny Vault CGC 9 Mint Holo",
+      "askingPriceUsd": 20,
+      "researchQuery": "Zorua SV25 CGC 9",
+      "visibleSoldRows": 0,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 19,
+      "itemId": "397333090254",
+      "title": "2019 Pokemon Sun & Moon Detective Pikachu Slaking Holo 18/18 PSA 9",
+      "askingPriceUsd": 100,
+      "researchQuery": "Slaking 18/18 PSA 9",
+      "visibleSoldRows": 2,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 20,
+      "itemId": "397802495123",
+      "title": "2007 Pokemon Secret Wonders Weavile 40/132 Countdown Calendar Promo PSA 8 POP 6",
+      "askingPriceUsd": 200,
+      "researchQuery": "Weavile 40 calendar PSA 8",
+      "visibleSoldRows": 0,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 21,
+      "itemId": "397103446782",
+      "title": "Koga’s Beedrill Holo 9/132 Gym Challenge (2000) CGC 8 – Unlimited WotC Vintage",
+      "askingPriceUsd": 37,
+      "researchQuery": "Koga Beedrill 9/132 CGC 8",
+      "visibleSoldRows": 2,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 22,
+      "itemId": "397978107195",
+      "title": "2025 Pokemon Haunter 027 Mega Gengar ex Mega Battle Deck PSA 9",
+      "askingPriceUsd": 98.99,
+      "researchQuery": "Haunter 027 Mega Gengar PSA 9",
+      "visibleSoldRows": 50,
+      "possiblyPageLimited": true
+    },
+    {
+      "sample": 23,
+      "itemId": "397777166037",
+      "title": "2021 Pokemon Japanese 25th Anniversary Collection Kyogre 007/028 CGC Pristine 10",
+      "askingPriceUsd": 55,
+      "researchQuery": "Kyogre 007/028 CGC pristine 10",
+      "visibleSoldRows": 8,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 24,
+      "itemId": "397802495140",
+      "title": "2023 Pokemon Scarlet & Violet 151 Alakazam ex 201/165 SIR CGC Gem Mint 10",
+      "askingPriceUsd": 200,
+      "researchQuery": "Alakazam 201/165 CGC 10 -pristine",
+      "visibleSoldRows": 22,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 25,
+      "itemId": "397443138497",
+      "title": "2024 Pokémon JP SV8a Terastal Festival Vaporeon ex 031/187 PSA 10",
+      "askingPriceUsd": 50,
+      "researchQuery": "Vaporeon 031/187 PSA 10",
+      "visibleSoldRows": 40,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 26,
+      "itemId": "397282303050",
+      "title": "2023 Pokémon JPN sv4M Steelix AR 074/066 — CGC 10 Gem Mint (Future Flash)",
+      "askingPriceUsd": 30,
+      "researchQuery": "Steelix 074/066 CGC 10 -pristine",
+      "visibleSoldRows": 8,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 27,
+      "itemId": "397282303045",
+      "title": "2023 Pokémon Old Maid “Super High Tension” Tatsugiri – CGC 10 Gem Mint",
+      "askingPriceUsd": 19,
+      "researchQuery": "Tatsugiri Old Maid CGC 10",
+      "visibleSoldRows": 9,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 28,
+      "itemId": "397443138495",
+      "title": "2024 Pokemon JP SV8a Terastal Festival Leafeon ex 003/187 PSA 10",
+      "askingPriceUsd": 50,
+      "researchQuery": "Leafeon 003/187 PSA 10",
+      "visibleSoldRows": 48,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 29,
+      "itemId": "397978107189",
+      "title": "2023 Pokemon Crown Zenith Palkia VSTAR GG67/GG70 Secret PSA 9",
+      "askingPriceUsd": 149.99,
+      "researchQuery": "Palkia GG67 PSA 9",
+      "visibleSoldRows": 50,
+      "possiblyPageLimited": true
+    },
+    {
+      "sample": 30,
+      "itemId": "397443138525",
+      "title": "2022 Pokemon JP VSTAR Universe s12a Gengar 048/172 Holo CGC Pristine 10",
+      "askingPriceUsd": 60,
+      "researchQuery": "Gengar 048/172 CGC pristine 10",
+      "visibleSoldRows": 50,
+      "possiblyPageLimited": true
+    },
+    {
+      "sample": 31,
+      "itemId": "397443138474",
+      "title": "2021 JPN VMAX Climax 242/184 Galarian Moltres V CSR CGC Pristine 10",
+      "askingPriceUsd": 75,
+      "researchQuery": "Moltres 242/184 CGC pristine 10",
+      "visibleSoldRows": 12,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 32,
+      "itemId": "397978107155",
+      "title": "2022 Japanese Pokemon VSTAR Universe Leafeon VSTAR 210/172 CGC 9.5",
+      "askingPriceUsd": 87.99,
+      "researchQuery": "Leafeon 210/172 CGC 9.5",
+      "visibleSoldRows": 2,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 33,
+      "itemId": "397285478425",
+      "title": "2001 Pokémon JPN Krabby e-Card 1st Ed #010/128 CGC 9 Base Expansion Pack",
+      "askingPriceUsd": 19,
+      "researchQuery": "Krabby 010/128 1st CGC 9",
+      "visibleSoldRows": 0,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 34,
+      "itemId": "397469789209",
+      "title": "2025 Pokémon Prismatic Evolutions Buneary #083 Master Ball Reverse Holo PSA 10",
+      "askingPriceUsd": 215,
+      "researchQuery": "Buneary 083 Master Ball PSA 10",
+      "visibleSoldRows": 2,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 35,
+      "itemId": "396931194235",
+      "title": "Golbat No. 042 Holo Rare - RCG 9.5 MINT - Rocket Gang - Japanese",
+      "askingPriceUsd": 35,
+      "researchQuery": "Golbat Rocket RCG 9.5",
+      "visibleSoldRows": 0,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 36,
+      "itemId": "397443138542",
+      "title": "Pokemon TCG Classic JP Rapidash 005/032 CGC 10 Gem Mint Holo (CLL)",
+      "askingPriceUsd": 30,
+      "researchQuery": "Rapidash 005/032 CGC 10 -pristine",
+      "visibleSoldRows": 3,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 37,
+      "itemId": "397443138520",
+      "title": "2024 Pokémon JP SV7 Stellar Miracle Ledian 103/102 AR PSA 10 Gem Mint",
+      "askingPriceUsd": 25,
+      "researchQuery": "Ledian 103/102 PSA 10",
+      "visibleSoldRows": 5,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 38,
+      "itemId": "397285478486",
+      "title": "Makuhita 56/109 EX Ruby & Sapphire (2003) CGC 5 | e-Reader | English",
+      "askingPriceUsd": 15,
+      "researchQuery": "Makuhita 56/109 CGC 5",
+      "visibleSoldRows": 1,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 39,
+      "itemId": "397443138503",
+      "title": "2024 Pokémon SV8a JP Glaceon ex 041/187 RR PSA 10 Gem Mint Terastal Fest",
+      "askingPriceUsd": 50,
+      "researchQuery": "Glaceon 041/187 PSA 10",
+      "visibleSoldRows": 46,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 40,
+      "itemId": "397774081600",
+      "title": "2023 Pokemon SWSH Black Star Promo Galarian Zapdos SWSH283 Holo PSA 8",
+      "askingPriceUsd": 16,
+      "researchQuery": "Galarian Zapdos SWSH283 PSA 8",
+      "visibleSoldRows": 15,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 41,
+      "itemId": "397777166031",
+      "title": "2023 Pokemon Japanese sv1V Violet ex Greavard 087/078 AR CGC 10 Pristine",
+      "askingPriceUsd": 45,
+      "researchQuery": "Greavard 087/078 CGC pristine 10",
+      "visibleSoldRows": 14,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 42,
+      "itemId": "397443138531",
+      "title": "2025 Pokémon ME01 Mega Evolution Mega Lucario ex 160/132 PSA 9 Ultra Rare",
+      "askingPriceUsd": 65,
+      "researchQuery": "Lucario 160/132 PSA 9",
+      "visibleSoldRows": 50,
+      "possiblyPageLimited": true
+    },
+    {
+      "sample": 43,
+      "itemId": "397285478477",
+      "title": "2022 Pokémon Roserade TG02 Lost Origin Trainer Gallery — CGC 10 Gem Mint",
+      "askingPriceUsd": 50,
+      "researchQuery": "Roserade TG02 CGC 10 -pristine",
+      "visibleSoldRows": 5,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 44,
+      "itemId": "397777166043",
+      "title": "2021 Pokemon Crobat VMAX SWSH099 Black Star Promo Full Art CGC 10 Gem Mint",
+      "askingPriceUsd": 30,
+      "researchQuery": "Crobat SWSH099 CGC 10 -pristine",
+      "visibleSoldRows": 4,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 45,
+      "itemId": "397443138508",
+      "title": "2023 Pokémon JPN SV4a Shiny Treasure ex Palafin AR 339/190 CGC 10",
+      "askingPriceUsd": 35,
+      "researchQuery": "Palafin 339/190 CGC 10 -pristine",
+      "visibleSoldRows": 3,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 46,
+      "itemId": "397469784919",
+      "title": "2024 Pokemon SVP 129 Pecharunt Shrouded Fable ETB Promo CGC Pristine 10",
+      "askingPriceUsd": 70,
+      "researchQuery": "Pecharunt 129 CGC pristine 10",
+      "visibleSoldRows": 4,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 47,
+      "itemId": "397285478465",
+      "title": "Bellsprout 49/64 Jungle Unlimited 1999 Pokémon CGC 9 Mint WOTC",
+      "askingPriceUsd": 15,
+      "researchQuery": "Bellsprout 49/64 CGC 9 -1st",
+      "visibleSoldRows": 1,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 48,
+      "itemId": "397333090269",
+      "title": "Suicune ex 010/034 TCG Classic Blastoise Deck CGC 9 Mint Holo Pokémon Card",
+      "askingPriceUsd": 18,
+      "researchQuery": "Suicune 010/034 CGC 9",
+      "visibleSoldRows": 49,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 49,
+      "itemId": "397103449453",
+      "title": "1996 Pokémon Playing Cards Doduo Diamonds 7 #84 CGC 8.5 (Japanese Green Deck)",
+      "askingPriceUsd": 40,
+      "researchQuery": "Doduo playing diamonds CGC 8.5",
+      "visibleSoldRows": 0,
+      "possiblyPageLimited": false
+    },
+    {
+      "sample": 50,
+      "itemId": "396965315781",
+      "title": "Latias 195/172 - CGC 9.5 MINT+ - s12a VSTAR Universe AR - Japanese",
+      "askingPriceUsd": 30,
+      "researchQuery": "Latias 195/172 CGC 9.5",
+      "visibleSoldRows": 2,
+      "possiblyPageLimited": false
+    }
+  ]
+}

--- a/app/features/ebay-slab-pricing/evaluation/slabPreviewAcceptance.test.ts
+++ b/app/features/ebay-slab-pricing/evaluation/slabPreviewAcceptance.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import Papa from "papaparse";
+import fixture from "./fixtures/pokebash-preview-sample.json";
+import { parseInventoryCsv } from "../inventory/slabInventoryCsv.server";
+export const acceptanceCsv = Papa.unparse(
+  fixture.listings.map((r) => ({
+    item_id: r.itemId,
+    title: r.title,
+    price: r.askingPriceUsd,
+    currency: "USD",
+    quantity: 1,
+    state: "active",
+    format: "fixed-price",
+  })),
+); // Quantity/format are placeholders for import testing, not facts learned from the historical titles.
+const imported = parseInventoryCsv(acceptanceCsv, "acceptance-fixture");
+assert.equal(imported.listings.length, 50);
+assert.equal(new Set(imported.listings.map((r) => r.itemId)).size, 50);
+assert.equal(new Set(fixture.listings.map((r) => r.researchQuery)).size, 49);
+assert.equal(
+  fixture.listings[4].researchQuery,
+  fixture.listings[39].researchQuery,
+);
+assert.notEqual(imported.listings[4].itemId, imported.listings[39].itemId);
+assert.ok(
+  imported.listings.every(
+    (r) =>
+      r.certificate === null &&
+      r.reviewReasons.includes("certificate-required"),
+  ),
+);
+assert.equal(imported.completeActiveInventory, false);
+for (const marker of [
+  /PSA/,
+  /CGC/,
+  /SGC/,
+  /Japanese|Japan/,
+  /1999/,
+  /One Piece/i,
+])
+  assert.ok(
+    fixture.listings.some((r) => marker.test(r.title)),
+    String(marker),
+  );
+assert.equal(fixture.listings.filter((r) => r.visibleSoldRows === 0).length, 8);
+console.log(
+  "PASS 50 historical listings remain reviewable, two Zapdos records share research without sharing listing identity, and unsupported cohorts remain visible",
+);

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -1,4 +1,5 @@
 import "../core/clients/baseDomainClient.server.test";
+import "../features/ebay-slab-pricing/evaluation/slabPreviewAcceptance.test";
 import "../features/ebay-slab-pricing/publication/slabPublicationPreview.test";
 import "../core/db/repositories/inventoryBatchPricingJobs.server.test";
 import "../core/utils/numberFieldMatching.test";

--- a/docs/slab-preview-acceptance.md
+++ b/docs/slab-preview-acceptance.md
@@ -1,0 +1,63 @@
+# Slab preview acceptance and performance
+
+Validated September 6, 2026 UTC. This report covers inventory import, evidence review, supply context and immutable price-change previews. Live publication and continuous pricing are not enabled and are not validated by these results. Issues #24, #29–#33 remain open where their native-data or live-workflow criteria are unmet.
+
+## Sample and coverage
+
+The committed `evaluation/fixtures/pokebash-preview-sample.json` contains 50 historical public listing titles/asks and observed search-row counts, sanitized from the user's local evaluation. It preserves PSA, CGC labels, SGC, Japanese, vintage and One Piece cases. Two separate Galarian Zapdos listings share one research query: 50 listing identities, 49 queries. Eight searches had no visible sold results. The 800 visible search rows include the repeated query and are **not** 800 accepted comparable transactions.
+
+Certificates and verified card variants are not available for these 50 titles. The fixture cannot establish confirmed identity coverage, accepted-comp precision, pricing error or review time. Those metrics remain null. Import tests deliberately assign placeholder quantity/format and keep every certificate unresolved; they do not infer identity or discard unsupported graders. Existing certificate, screening, eleven-sale deduplication and cross-grade fixtures test their respective contracts separately.
+
+## Measured preview performance
+
+Machine-local PostgreSQL 16 development schema, Node 24.15 on Windows; 30 sequential samples after warm-up. See [raw feature measurements](slab-preview-benchmark.json).
+
+| Operation                                                                   |     p50 |     p95 | Pool queries per sample |
+| --------------------------------------------------------------------------- | ------: | ------: | ----------------------: |
+| Read 50 listings in two 25-row pages                                        |  5.2 ms |  6.1 ms |                       4 |
+| Re-request 50 synthetic slabs / 10 fresh evidence groups and check for work | 10.6 ms | 13.2 ms |                       5 |
+| Read all ten cached evidence revisions                                      |  8.3 ms | 13.7 ms |                      10 |
+| Read 25 rows from 5,000-row inventory                                       |  7.1 ms |  8.9 ms |                       2 |
+
+The 50-row import took 85 ms; 5,000 synthetic rows took 591 ms. The fixture-backed cold evidence workload completed in 164 ms with ten provider workflows; warm repetition issued zero provider requests. No real provider/network latency is included. The isolated workload occupied 5.0 MiB of PostgreSQL table/index storage. Its final Node process RSS sample was 130 MiB, not a peak-memory or production-server measurement. Query counts instrument pool queries during the named read workloads, not transaction-client queries during import.
+
+Supply history has a separate 203-scan/50-listing integration check: 200 recent scans plus one retained scan leave 10,050 small references and 51 listing bodies after one observed price change. Latest/pinned evidence survives retention. See [supply behavior and reproduction](slab-supply-context.md).
+
+## Baseline comparison
+
+Baseline commit `00d7bb3e2` predates slab integration. The current production build is commit `1da700c6c` (through PR #47), with no provider credentials. Both use the same Docker Node 20.20.2 image and fresh databases. Fifty HTTP samples per existing route alternate baseline/current order after five warm-up requests. This measures empty-state rendering, not production job contention or complete pricing sessions. See [raw HTTP measurements](slab-preview-http.json).
+
+| Existing route | Baseline p95 | Current p95 |
+| -------------- | -----------: | ----------: |
+| Dashboard      |      44.9 ms |     50.4 ms |
+| CSV pricer     |      37.5 ms |     37.8 ms |
+| Batch pricer   |      27.3 ms |     28.2 ms |
+
+The new slab page rendered at p95 38.0 ms, connections at 34.4 ms and empty inventory API at 9.0 ms. A one-time Docker RSS sample after the run was 219 MiB baseline / 156 MiB current; garbage collection makes this unsuitable for claiming a memory improvement.
+
+The existing CSV and batch-pricer static assets grew by 395 and 1,076 gzip bytes respectively, including shared navigation and route-manifest metadata. Neither loads slab implementation chunks. The three existing TCGplayer worker files have exactly the same byte sizes. The optional slab evidence worker is 61,609 bytes. The slab page's full static dependency set is 377,705 gzip bytes, including existing React/MUI/grid dependencies. Its lazy comp, supply and publication panels add 7,117 / 3,341 / 2,087 gzip bytes respectively, excluding shared imports. See [raw bundle measurements](slab-preview-bundles.json).
+
+Structural gates enforce zero remote calls for the fixture cache workload, one refresh per evidence group, bounded inventory pages and no slab implementation modules on unrelated routes. The bundle comparison enforces a 4 KiB compressed growth budget for existing route navigation/manifest changes. Based on this baseline, investigate future repeatable p95 increases above 20% plus 5 ms on existing empty-state routes, or local warm inventory p95 above 50 ms. Timing thresholds are advisory on a shared development machine; they do not replace a controlled production comparison.
+
+## Build, migration and recovery checks
+
+Host typecheck, offline test suite, production/worker build and targeted PostgreSQL integrations pass, including existing TCGplayer pricing/publication regression tests. Docker `npm ci` and production build pass on Node 20; existing MUI build warnings remain. No new runtime dependencies were added across these merged slab changes. No browser runtime is bundled.
+
+A fresh isolated Docker database applied all 31 migrations and served the slab and existing routes with zero provider connections and zero evidence jobs. Rerunning migrations was idempotent. A second isolated database upgraded from migrations 1–23 to 1–31 and retained a seeded existing marker row. These checks are not a production-data restore rehearsal. Expanded Docker exclusions keep `.env*`, research captures and Codex artifacts out of the build context; runtime inspection found no local environment or research files. Temporary validation containers/databases are removed after evaluation; existing development and production containers are untouched.
+
+Before deploying, back up the actual PostgreSQL database and verify restore into a separate database. Migrations 024–031 add feature-owned tables/indexes and a supply-reference column; they do not rewrite TCGplayer data. Restore supply scans, evidence references, recommendations and previews together. For application rollback to the pre-slab build, leave additive slab tables intact; do not drop referenced evidence to imitate a price rollback. No production deployment or live eBay write was performed in this evaluation.
+
+Connections, reconnect/cancellation and cache retention are documented in [evidence cache operations](ebay-slab-evidence-cache.md), [slab review](slab-pricing-page.md) and [publication review](slab-publication-review.md). Native session checks were completed for Alt/eBay Research earlier; expired/absent session behavior is covered offline. Seller OAuth remains blocked by production keyset activation shared with another application.
+
+## Reproduction
+
+Run `npm test`, `npm run typecheck`, `npm run build` and `npm run benchmark:slab-preview` in the development checkout. The benchmark explicitly accepts only localhost:5433/tcgplayer_automation and creates/removes a disposable schema. It writes the feature JSON report and prohibits network fetches.
+
+Build the baseline and current Docker images from separate source directories. Start them against separate **disposable** PostgreSQL databases, with no provider credentials, bound to local ports. Copy each image's `/app/build` directory to local baseline/current build directories, then run:
+
+```sh
+node app/features/ebay-slab-pricing/evaluation/compare-slab-preview-builds.mjs BASELINE_BUILD CURRENT_BUILD
+node app/features/ebay-slab-pricing/evaluation/benchmark-slab-http.mjs http://127.0.0.1:BASELINE_PORT http://127.0.0.1:CURRENT_PORT
+```
+
+These commands write the bundle and HTTP JSON reports. Keep build/runtime versions and load comparable. Do not point validation at production. The remaining acceptance work is verified seller import, complete native publication/reconciliation/restore, outcome/exposure validation, approved model cohorts and opt-in scheduling with live request/write budgets and contention measurements. The report does not close #33 or authorize those stages automatically.

--- a/docs/slab-preview-benchmark.json
+++ b/docs/slab-preview-benchmark.json
@@ -1,0 +1,58 @@
+{
+  "measuredAt": "2026-09-06T04:21:42.213Z",
+  "node": "v24.15.0",
+  "platform": "win32",
+  "scope": "Local isolated PostgreSQL feature benchmark. HTTP/provider latency and accepted comp precision are not measured.",
+  "historicalSample": {
+    "listings": 50,
+    "researchQueries": 49,
+    "emptySearches": 8,
+    "visibleSoldRows": 800,
+    "confirmedIdentityCoverage": null,
+    "acceptedCompPrecision": null,
+    "priceError": null
+  },
+  "import50Ms": 84.64449999999988,
+  "inventory50": {
+    "samples": 30,
+    "p50Ms": 5.248700000000099,
+    "p95Ms": 6.128600000000006,
+    "pooledQueriesPerSample": 4
+  },
+  "coldFixtureRefreshMs": 164.09760000000006,
+  "fixtureWorkflows": 10,
+  "warmEvidence": {
+    "samples": 30,
+    "p50Ms": 10.564599999999928,
+    "p95Ms": 13.203899999999976,
+    "pooledQueriesPerSample": 5
+  },
+  "evidencePages": {
+    "samples": 30,
+    "p50Ms": 8.257299999999987,
+    "p95Ms": 13.703600000000051,
+    "pooledQueriesPerSample": 10
+  },
+  "import5000Ms": 591.2339999999999,
+  "largePage": {
+    "samples": 30,
+    "p50Ms": 7.127899999999954,
+    "p95Ms": 8.853700000000117,
+    "pooledQueriesPerSample": 2
+  },
+  "databaseBytes": 5267456,
+  "processMemory": {
+    "rss": 136790016,
+    "heapTotal": 95879168,
+    "heapUsed": 26949584,
+    "external": 6352126,
+    "arrayBuffers": 3664027
+  },
+  "remoteAttempts": 0,
+  "gates": {
+    "zeroRemoteRequests": true,
+    "coalescedGroups": true,
+    "maximumInventoryPage": 25,
+    "automationEnabled": false
+  }
+}

--- a/docs/slab-preview-bundles.json
+++ b/docs/slab-preview-bundles.json
@@ -1,0 +1,60 @@
+{
+  "measuredAt": "2026-09-06T04:19:30.567Z",
+  "basis": "React Router static entry/root/route imports plus route manifest; gzip per asset. Lazy panel figures exclude shared dependencies.",
+  "before": {
+    "routes": {
+      "/pricer": {
+        "gzipBytes": 213690,
+        "slabModules": []
+      },
+      "/pending-inventory-pricer": {
+        "gzipBytes": 238016,
+        "slabModules": []
+      }
+    },
+    "lazySlab": {},
+    "workers": {
+      "continuous-pricing-scheduler.js": 347221,
+      "pricing-worker.js": 331348,
+      "publication-worker.js": 99896
+    }
+  },
+  "after": {
+    "routes": {
+      "/pricer": {
+        "gzipBytes": 214085,
+        "slabModules": []
+      },
+      "/pending-inventory-pricer": {
+        "gzipBytes": 239092,
+        "slabModules": []
+      },
+      "/slab-pricing": {
+        "gzipBytes": 377705,
+        "slabModules": [
+          "/assets/slab-pricing-VmGp0qvo.js",
+          "/assets/slab-pricing-BUh_9-l_.js"
+        ]
+      }
+    },
+    "lazySlab": {
+      "SlabCompReview": 7117,
+      "SlabPublicationPreview": 2087,
+      "SlabSupplyPanel": 3341
+    },
+    "workers": {
+      "continuous-pricing-scheduler.js": 347221,
+      "pricing-worker.js": 331348,
+      "publication-worker.js": 99896,
+      "slab-evidence-worker.js": 61609
+    }
+  },
+  "deltas": {
+    "/pricer": 395,
+    "/pending-inventory-pricer": 1076
+  },
+  "gates": {
+    "unrelatedSlabModules": 0,
+    "unrelatedRouteGrowthBudgetBytes": 4096
+  }
+}

--- a/docs/slab-preview-http.json
+++ b/docs/slab-preview-http.json
@@ -1,0 +1,65 @@
+{
+  "measuredAt": "2026-09-06T04:19:43.892Z",
+  "scope": "Local Docker Node 20 production builds on fresh empty databases, no provider credentials. HTTP render latency only; network market latency and production job contention are unmeasured.",
+  "results": {
+    "/": {
+      "before": {
+        "samples": 50,
+        "p50Ms": 32.579099999999926,
+        "p95Ms": 44.89589999999998,
+        "responseBytes": 44473
+      },
+      "after": {
+        "samples": 50,
+        "p50Ms": 32.93549999999982,
+        "p95Ms": 50.449499999999716,
+        "responseBytes": 44640
+      }
+    },
+    "/pricer": {
+      "before": {
+        "samples": 50,
+        "p50Ms": 28.149099999999635,
+        "p95Ms": 37.48080000000027,
+        "responseBytes": 52294
+      },
+      "after": {
+        "samples": 50,
+        "p50Ms": 27.563000000000102,
+        "p95Ms": 37.76970000000074,
+        "responseBytes": 52461
+      }
+    },
+    "/pending-inventory-pricer": {
+      "before": {
+        "samples": 50,
+        "p50Ms": 21.902399999999034,
+        "p95Ms": 27.343300000000454,
+        "responseBytes": 37927
+      },
+      "after": {
+        "samples": 50,
+        "p50Ms": 23.091700000000856,
+        "p95Ms": 28.176499999999578,
+        "responseBytes": 38328
+      }
+    }
+  },
+  "newRoutes": {
+    "/slab-pricing": {
+      "firstRequestMs": 39.725899999999456,
+      "p50Ms": 29.71860000000015,
+      "p95Ms": 37.987200000001394
+    },
+    "/slab-connections": {
+      "firstRequestMs": 49.01250000000073,
+      "p50Ms": 31.6171000000013,
+      "p95Ms": 34.41350000000057
+    },
+    "/api/slab-inventory?seller=acceptance-fixture&limit=25": {
+      "firstRequestMs": 17.71230000000105,
+      "p50Ms": 7.0049999999992,
+      "p95Ms": 9.017900000000736
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev:db": "docker compose exec postgres psql -U postgres -d tcgplayer_automation",
     "dev:db:refresh": "node scripts/dev-db-refresh.mjs",
     "test": "tsx app/test/run-tests.ts",
+    "benchmark:slab-preview": "tsx app/features/ebay-slab-pricing/evaluation/benchmarkSlabPreview.server.ts",
     "evaluate:slab-grades": "tsx app/features/ebay-slab-pricing/model/evaluateGradeModel.server.ts",
     "build": "node scripts/run-with-node-options.mjs react-router build && node scripts/build-workers.mjs",
     "start:pricing-worker": "node build/workers/pricing-worker.js",


### PR DESCRIPTION
Commit a sanitized 50-listing acceptance sample and reproducible preview benchmarks. The two Zapdos listings remain separate inventory records with one research query; missing certificates and unsupported cohorts remain reviewable. Search-row counts are explicitly not accepted comps or pricing ground truth.

The report compares the pre-slab commit 00d7bb3e2 with the preview build through #47. Local 50-listing reads measured p95 6.1 ms; 5,000-row import took 591 ms. Fifty repeated slabs coalesced into ten fixture workflows and warm requests performed zero network calls. Existing route assets grew by 395/1,076 gzip bytes with no slab implementation chunks; TCGplayer worker byte sizes are unchanged. Docker CSV-pricer p95 was 37.8 ms versus 37.5 ms baseline. Raw reports retain scope and limitations.

Validation: npm test and typecheck pass; host and Node 20 production/worker builds passed for the measured runtime. Fresh Docker migration 1–31, idempotent rerun, upgrade 23–31 with retained marker data, absent provider credentials and existing/slab route rendering passed. Temporary validation containers/databases were removed. Evaluation utilities remain feature-local and are not copied into the production runtime.

Adversarial review checked data provenance, uncertainty labels, measurement boundaries, query-count scope, local database guards, bundle gates and runtime footprint; no additional actionable issues remain in this validation scope. The broader acceptance review's inventory gate and Docker context fixes were landed separately in #47.

Advances #33 without closing it. Confirmed identity coverage, accepted-comp precision and pricing error remain unmeasured; native seller import/publication/reconciliation, approved models, scheduling and production contention/restore validation are outstanding. No production deployment, live price write or automation enablement was performed.
