### PR TITLE
Maintain slab evidence and recommendations in bounded groups

### DIFF
--- a/app/features/ebay-slab-pricing/components/SlabInventoryPanel.tsx
+++ b/app/features/ebay-slab-pricing/components/SlabInventoryPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import {
   Alert,
   Button,
@@ -22,6 +22,7 @@ import {
 export type SlabListing = Json<
   Awaited<ReturnType<typeof getInventory>>
 >["items"][number];
+const MaintenancePanel = lazy(() => import("./SlabMaintenancePanel"));
 export function SlabInventoryPanel({
   onOpen,
 }: {
@@ -38,6 +39,7 @@ export function SlabInventoryPanel({
   const [cursors, setCursors] = useState([""]);
   const [csv, setCsv] = useState("");
   const [importing, setImporting] = useState(false);
+  const [showMaintenance, setShowMaintenance] = useState(false);
   const action = useSlabAction();
   const load = async (name: string, after = "") => {
     const result = await slabRequest<Awaited<ReturnType<typeof getInventory>>>(
@@ -220,6 +222,21 @@ export function SlabInventoryPanel({
               {loadedSeller} · Saved inventory · Page {cursors.length}. Open a
               slab to review or assign its certificate.
             </Typography>
+            <Button
+              sx={{ alignSelf: "start" }}
+              onClick={() => setShowMaintenance((v) => !v)}
+            >
+              {showMaintenance
+                ? "Hide evidence maintenance"
+                : "Evidence maintenance"}
+            </Button>
+            {showMaintenance && (
+              <Suspense
+                fallback={<Typography>Loading maintenance…</Typography>}
+              >
+                <MaintenancePanel key={loadedSeller} seller={loadedSeller} />
+              </Suspense>
+            )}
             <div style={{ height: 440 }}>
               <ClientOnlyDataGrid
                 rows={page.items}

--- a/app/features/ebay-slab-pricing/components/SlabMaintenancePanel.tsx
+++ b/app/features/ebay-slab-pricing/components/SlabMaintenancePanel.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useState } from "react";
+import {
+  Alert,
+  Button,
+  Checkbox,
+  FormControlLabel,
+  Link,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import type { MaintenanceSettings } from "../maintenance/slabMaintenance";
+import type { MaintenanceView } from "../routes/api.slab-maintenance.server";
+import { slabRequest, useSlabAction, words, type Json } from "./slabClient";
+export default function SlabMaintenancePanel({ seller }: { seller: string }) {
+  const [view, setView] = useState<Json<MaintenanceView> | null>(null),
+    [draft, setDraft] = useState<MaintenanceSettings | null>(null),
+    [reload, setReload] = useState(0);
+  const [error, setError] = useState<string | null>(null),
+    action = useSlabAction();
+  useEffect(() => {
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const read = async () => {
+      try {
+        const data = await slabRequest<MaintenanceView>(
+          `/api/slab-maintenance?${new URLSearchParams({ seller })}`,
+          undefined,
+          controller.signal,
+        );
+        if (controller.signal.aborted) return;
+        setView(data);
+        setDraft((previous) => previous ?? data.settings);
+        setError(null);
+        if (data.settings.enabled) timer = setTimeout(read, 5000);
+      } catch (error) {
+        if (!controller.signal.aborted)
+          setError(
+            error instanceof Error
+              ? error.message
+              : "Maintenance status unavailable.",
+          );
+      }
+    };
+    void read();
+    return () => {
+      controller.abort();
+      clearTimeout(timer);
+    };
+  }, [seller, reload]);
+  return (
+    <Paper variant="outlined" sx={{ p: 2 }}>
+      <Stack spacing={2}>
+        <Typography variant="h6">Evidence maintenance · {seller}</Typography>
+        <Typography variant="body2">
+          Refresh confirmed inventory in small groups and update recommendations
+          from fresh saved evidence. Reviewed price overrides stay in manual
+          review. This never publishes prices.
+        </Typography>
+        {(error || action.error) && (
+          <Alert severity="error">{error ?? action.error}</Alert>
+        )}
+        {draft && (
+          <>
+            <Stack direction="row" gap={2} useFlexGap flexWrap="wrap">
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={draft.enabled}
+                    onChange={(e) =>
+                      setDraft({ ...draft, enabled: e.target.checked })
+                    }
+                  />
+                }
+                label="Enable maintenance"
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={draft.includeSupply}
+                    onChange={(e) =>
+                      setDraft({ ...draft, includeSupply: e.target.checked })
+                    }
+                  />
+                }
+                label="Include active supply"
+              />
+              {(
+                [
+                  ["intervalMinutes", "Refresh interval (minutes)"],
+                  ["batchSize", "Listings per cycle"],
+                  ["refreshBudget", "Refresh jobs per cycle"],
+                ] as const
+              ).map(([field, label]) => (
+                <TextField
+                  key={field}
+                  size="small"
+                  type="number"
+                  label={label}
+                  value={draft[field]}
+                  onChange={(e) =>
+                    setDraft({ ...draft, [field]: Number(e.target.value) })
+                  }
+                />
+              ))}
+            </Stack>
+            <Stack direction="row" gap={1}>
+              <Button
+                disabled={action.busy}
+                onClick={() =>
+                  void action.run(async () => {
+                    const result = await slabRequest<{
+                      settings: MaintenanceSettings;
+                    }>("/api/slab-maintenance", {
+                      intent: "save",
+                      settings: draft,
+                    });
+                    setDraft(result.settings);
+                    setReload((v) => v + 1);
+                  })
+                }
+              >
+                Save maintenance settings
+              </Button>
+              <Button
+                disabled={action.busy}
+                onClick={() => setReload((v) => v + 1)}
+              >
+                Reload status
+              </Button>
+              <Button
+                disabled={action.busy || !view}
+                onClick={() => setDraft(view!.settings)}
+              >
+                Reset edits
+              </Button>
+            </Stack>
+            {view && draft.revision !== view.settings.revision && (
+              <Alert severity="warning">
+                Settings changed elsewhere. Reset edits before saving.
+              </Alert>
+            )}
+          </>
+        )}
+        {view && (
+          <>
+            <Typography>
+              {view.settings.enabled ? "Enabled" : "Paused"} · Last cycle:{" "}
+              {view.settings.lastCycleAt
+                ? new Date(view.settings.lastCycleAt).toLocaleString()
+                : "Not run"}
+            </Typography>
+            <Typography variant="body2">
+              Next worker check:{" "}
+              {view.settings.enabled && view.settings.nextCycleAt
+                ? new Date(view.settings.nextCycleAt).toLocaleString()
+                : "Paused"}
+              . Turning maintenance off stops further work; already requested
+              evidence and an in-progress calculation may finish.
+            </Typography>
+            {view.workerMode === "external" && (
+              <Alert severity="info">
+                Maintenance requires the existing slab evidence worker to be
+                running.
+              </Alert>
+            )}
+            {view.settings.lastError && (
+              <Alert severity="warning">{words(view.settings.lastError)}</Alert>
+            )}
+            {view.settings.lastSummary && (
+              <Typography variant="body2">
+                Last cycle: {view.settings.lastSummary.checked} listings checked
+                · {view.settings.lastSummary.queued} queued source jobs ·{" "}
+                {view.settings.lastSummary.recalculated} recalculated ·{" "}
+                {view.settings.lastSummary.held} held for review.
+              </Typography>
+            )}
+            <Typography variant="body2">
+              Connections:{" "}
+              {view.providers
+                .map((p) => `${p.provider}: ${words(p.status)}`)
+                .join(" · ")}
+              . <Link href="/slab-connections">Manage connections</Link>
+            </Typography>
+            <Alert severity="info">
+              Automatic publication is unavailable. Live seller access and
+              adopted automation cohorts are required.
+            </Alert>
+            <details>
+              <summary>Recent listing checks</summary>
+              {view.items.map((item) => (
+                <Typography key={item.id} variant="body2">
+                  {item.title}: {words(item.outcome)} · {words(item.reason)}
+                </Typography>
+              ))}
+              {view.items.length === 0 && (
+                <Typography variant="body2">No listing checks yet.</Typography>
+              )}
+            </details>
+          </>
+        )}
+      </Stack>
+    </Paper>
+  );
+}

--- a/app/features/ebay-slab-pricing/evidence/evidenceRefreshWorker.server.ts
+++ b/app/features/ebay-slab-pricing/evidence/evidenceRefreshWorker.server.ts
@@ -1,4 +1,5 @@
 import { ProviderRequestError } from "../connections/providerRequest.server";
+import { runSlabMaintenanceCycle } from "../maintenance/slabMaintenanceCycle.server";
 import { fetchEvidence } from "./evidenceRefreshProvider.server";
 import {
   claimEvidenceJob,
@@ -105,6 +106,9 @@ export function startEvidenceWorker() {
       if (job) {
         waitMs = 2_000;
         await runEvidenceJob(job, { signal: worker.controller.signal });
+      } else {
+        const maintenance = await runSlabMaintenanceCycle();
+        if (maintenance?.queued) waitMs = 2000;
       }
       if (Date.now() - worker.lastCleanup > 3600_000) {
         await cleanEvidenceCache();

--- a/app/features/ebay-slab-pricing/evidence/slabEvidenceRefresh.server.ts
+++ b/app/features/ebay-slab-pricing/evidence/slabEvidenceRefresh.server.ts
@@ -11,7 +11,10 @@ import { requestEvidence } from "./evidenceRefreshStore.server";
 import type { EvidenceWindow } from "./slabEvidence";
 
 export function planSlabEvidence(
-  records: StoredSlabIdentity[],
+  records: Pick<
+    StoredSlabIdentity,
+    "id" | "revision" | "status" | "identity" | "valuationGroupKey"
+  >[],
   window: EvidenceWindow,
   includeSupply = false,
 ) {

--- a/app/features/ebay-slab-pricing/maintenance/slabMaintenance.integration.test.ts
+++ b/app/features/ebay-slab-pricing/maintenance/slabMaintenance.integration.test.ts
@@ -1,0 +1,441 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import pg from "pg";
+import dotenv from "dotenv";
+import Papa from "papaparse";
+import { getPool } from "~/core/db/database.server";
+import certFixture from "../identity/fixtures/alt-cert-110185364.json";
+import { parseAltCertificate } from "../identity/altIdentityProvider.server";
+import {
+  slabIdentityStore,
+  slabIdentityService,
+} from "../identity/slabIdentities.server";
+import { parseInventoryCsv } from "../inventory/slabInventoryCsv.server";
+import {
+  reconcileInventory,
+  getInventory,
+} from "../inventory/slabInventory.server";
+import {
+  claimEvidenceJob,
+  completeEvidenceJob,
+} from "../evidence/evidenceRefreshStore.server";
+import type { SaleEvidence } from "../evidence/slabEvidence";
+import {
+  calculateSlabRecommendation,
+  getSlabRecommendation,
+  overrideSlabPrice,
+} from "../valuation/slabRecommendations.server";
+import { DEFAULT_SLAB_POLICY } from "../valuation/slabValuation";
+import { defaultMaintenanceSettings } from "./slabMaintenance";
+import {
+  getMaintenanceSettings,
+  saveMaintenanceSettings,
+  claimMaintenance,
+  maintenanceActive,
+  maintenanceCheckpoint,
+} from "./slabMaintenanceStore.server";
+import {
+  maintenanceWindow,
+  runSlabMaintenanceCycle,
+} from "./slabMaintenanceCycle.server";
+dotenv.config({
+  path: [".env.development.local", ".env.local", ".env.development", ".env"],
+  quiet: true,
+});
+const url = new URL(
+  process.env.DATABASE_URL ??
+    "postgresql://postgres:postgres@localhost:5433/tcgplayer_automation",
+);
+assert.ok(
+  ["localhost", "127.0.0.1"].includes(url.hostname) &&
+    url.port === "5433" &&
+    url.pathname === "/tcgplayer_automation",
+);
+const schema = `slab_maintenance_test_${randomUUID().replaceAll("-", "")}`,
+  admin = new pg.Client({ connectionString: url.toString() });
+await admin.connect();
+await admin.query(`CREATE SCHEMA "${schema}"`);
+url.searchParams.set("options", `-c search_path=${schema}`);
+process.env.DATABASE_URL = url.toString();
+process.env.WORKERS_RUN_IN_PROCESS = "false";
+const db = getPool(),
+  originalFetch = globalThis.fetch;
+let remote = 0;
+globalThis.fetch = async () => {
+  remote++;
+  throw new Error("Maintenance must only enqueue fixture evidence");
+};
+try {
+  for (const file of [
+    "024_add_slab_provider_connections.sql",
+    "025_add_slab_identities.sql",
+    "026_add_slab_inventory.sql",
+    "027_add_slab_evidence_refreshes.sql",
+    "028_add_slab_comp_decisions.sql",
+    "029_add_slab_recommendations.sql",
+    "030_add_slab_supply_observations.sql",
+    "031_add_slab_publication_previews.sql",
+    "032_add_slab_publications.sql",
+    "033_add_slab_evidence_maintenance.sql",
+  ])
+    await db.query(await readFile(`db/migrations/${file}`, "utf8"));
+  const seller = "maintenance-fixture";
+  assert.equal((await getMaintenanceSettings(seller)).enabled, false);
+  assert.equal(await runSlabMaintenanceCycle(), null);
+  const candidate = parseAltCertificate(JSON.stringify(certFixture))!;
+  candidate.identity.card = {
+    ...candidate.identity.card,
+    language: "English",
+    edition: "Unlimited",
+    stamp: "None",
+  };
+  const identities = [];
+  for (let n = 0; n < 6; n++) {
+    const value = { ...candidate, certificateNumber: `MAINTENANCE-${n}` };
+    const row = await slabIdentityStore.saveCandidate(value, value, [
+      "fixture",
+    ]);
+    identities.push(
+      await slabIdentityService.confirm(
+        value,
+        row.revision,
+        value.identity,
+        "Synthetic maintenance fixture",
+      ),
+    );
+  }
+  await reconcileInventory(
+    parseInventoryCsv(
+      Papa.unparse(
+        identities.map((identity, n) => ({
+          item_id: String(900000000000 + n),
+          title: "Hitmonlee maintenance fixture",
+          price: 100,
+          currency: "USD",
+          quantity: 1,
+          state: "active",
+          format: "fixed-price",
+          grader: "PSA",
+          certificate_number: identity.certificateNumber,
+          shipping_amount: 0,
+          shipping_currency: "USD",
+        })),
+      ),
+      seller,
+    ),
+    0,
+  );
+  await db.query(
+    "INSERT INTO slab_provider_connections(provider,credential,status) VALUES('alt','SYNTHETIC','connected')",
+  );
+  const settings = await saveMaintenanceSettings({
+    ...defaultMaintenanceSettings(seller),
+    enabled: true,
+    batchSize: 3,
+    refreshBudget: 1,
+  });
+  await assert.rejects(
+    () => saveMaintenanceSettings({ ...settings, revision: 0 }),
+    /changed/,
+  );
+  const first = (await runSlabMaintenanceCycle())!;
+  assert.equal(first.checked, 3);
+  assert.equal(first.requested, 1);
+  assert.equal(first.queued, 1);
+  assert.equal(
+    (
+      await db.query(
+        "SELECT count(*)::int AS n FROM slab_evidence_refreshes WHERE state='queued'",
+      )
+    ).rows[0].n,
+    1,
+    "Shared valuation groups enqueue one source job",
+  );
+  const job = (await claimEvidenceJob())!;
+  assert.ok(job.spec.kind === "alt-sales");
+  const window = maintenanceWindow(),
+    sales: SaleEvidence[] = [100, 110, 120, 130].map((amount, n) => ({
+      provider: "alt",
+      providerId: `maintenance-sale-${n}`,
+      assetId: candidate.identity.providerAsset!.id,
+      sourceUrl: null,
+      sourceReference: null,
+      sourceItemId: null,
+      venue: "Synthetic",
+      kind: "transaction",
+      date: window.to,
+      format: "auction",
+      title: null,
+      card: candidate.identity.card,
+      grading: candidate.identity.grading,
+      certificateNumber: null,
+      price: { amount, currency: "USD" },
+      convertedPrice: null,
+      shipping: { amount: 0, currency: "USD" },
+      fees: null,
+      shippingIncluded: false,
+      buyerPremiumIncluded: false,
+      quantity: 1,
+      subjectToChange: false,
+      skippedReason: null,
+    }));
+  await completeEvidenceJob(
+    job,
+    {
+      kind: "alt-sales",
+      data: {
+        sales,
+        asOf: new Date().toISOString(),
+        coverage: {
+          requestedWindow: window,
+          observedWindow: { from: window.to, to: window.to },
+          complete: false,
+          reason: "capped-per-grade",
+          sourceCount: 4,
+          limitPerGrade: 16,
+        },
+      },
+    },
+    1,
+  );
+  for (const identity of identities)
+    await calculateSlabRecommendation({
+      slabId: identity.id,
+      identityRevision: identity.revision,
+      revisionIds: [job.runId],
+      policy: DEFAULT_SLAB_POLICY,
+      seller: {
+        currency: "USD",
+        currentAsk: 100,
+        shippingCharged: 0,
+        shippingCost: null,
+        acquisitionCost: null,
+        fees: null,
+        minimumAsk: null,
+        minimumProfit: null,
+      },
+    });
+  const tick = async (all = false) => {
+    await db.query(
+      "UPDATE slab_maintenance_settings SET next_cycle_at=clock_timestamp() WHERE seller=$1",
+      [seller],
+    );
+    if (all)
+      await db.query(
+        "UPDATE slab_maintenance_items SET next_check_at=clock_timestamp()",
+      );
+    return (await runSlabMaintenanceCycle())!;
+  };
+  assert.equal((await tick()).recalculated, 3);
+  assert.equal((await tick()).recalculated, 3);
+  const count = (
+    await db.query("SELECT count(*)::int AS n FROM slab_recommendations")
+  ).rows[0].n;
+  assert.equal((await tick(true)).recalculated, 0);
+  assert.equal((await tick()).recalculated, 0);
+  assert.equal(
+    (await db.query("SELECT count(*)::int AS n FROM slab_recommendations"))
+      .rows[0].n,
+    count,
+    "Warm unchanged cycles do not create recommendation churn",
+  );
+  assert.equal(await claimEvidenceJob(), null);
+  const inventory = (await getInventory(seller, "", 25)).items;
+  const latest = (
+    await db.query(
+      "SELECT recommendation_id FROM slab_maintenance_items WHERE inventory_id=$1",
+      [inventory[0].id],
+    )
+  ).rows[0].recommendation_id;
+  await overrideSlabPrice({
+    recommendationId: latest,
+    itemPrice: 125,
+    currency: "USD",
+    note: "Preserve the reviewed price",
+  });
+  const reviewed = (await getSlabRecommendation(latest))!;
+  const recalculate = (saved: typeof reviewed, currentAsk: number) =>
+    calculateSlabRecommendation(
+      {
+        slabId: saved.calculation.identity.slabId,
+        identityRevision: saved.calculation.identity.revision,
+        revisionIds: saved.calculation.evidence.map((e) => e.revisionId),
+        policy: saved.calculation.policy,
+        seller: { ...saved.calculation.seller, currentAsk },
+      },
+      undefined,
+      { expectedRecommendationId: saved.id },
+    );
+  await assert.rejects(() => recalculate(reviewed, 101), /reviewed price/);
+  const otherId = (
+    await db.query(
+      "SELECT recommendation_id FROM slab_maintenance_items WHERE inventory_id=$1",
+      [inventory[1].id],
+    )
+  ).rows[0].recommendation_id;
+  const other = (await getSlabRecommendation(otherId))!;
+  const raced = await Promise.allSettled([
+    overrideSlabPrice({
+      recommendationId: otherId,
+      itemPrice: 127,
+      currency: "USD",
+      note: "Concurrent manual review",
+    }),
+    recalculate(other, 101),
+  ]);
+  assert.equal(
+    raced.filter((result) => result.status === "fulfilled").length,
+    1,
+    "Manual review and automatic replacement cannot both succeed from one recommendation",
+  );
+  if (raced[0].status === "fulfilled") {
+    assert.equal(
+      (
+        await db.query(
+          "SELECT id FROM slab_recommendations WHERE slab_id=$1 ORDER BY created_at DESC,id DESC LIMIT 1",
+          [other.calculation.identity.slabId],
+        )
+      ).rows[0].id,
+      otherId,
+      "An accepted manual price remains the latest recommendation",
+    );
+  } else {
+    await assert.rejects(() => recalculate(other, 102), /changed/);
+    await assert.rejects(
+      () =>
+        overrideSlabPrice({
+          recommendationId: otherId,
+          itemPrice: 127,
+          currency: "USD",
+          note: "Stale review",
+        }),
+      /changed/,
+    );
+  }
+  await tick(true);
+  await tick();
+  assert.equal(
+    (
+      await db.query(
+        "SELECT reason FROM slab_maintenance_items WHERE inventory_id=$1",
+        [inventory[0].id],
+      )
+    ).rows[0].reason,
+    "reviewed-price-held",
+  );
+  await db.query(
+    "UPDATE slab_provider_connections SET status='reconnect-required' WHERE provider='alt'",
+  );
+  await db.query(
+    "UPDATE slab_evidence_refreshes SET expires_at=clock_timestamp()-interval '1 second'",
+  );
+  await db.query(
+    "INSERT INTO slab_provider_connections(provider,credential,user_agent,status) VALUES('ebayResearch','SYNTHETIC','fixture','connected')",
+  );
+  const failedSource = await tick(true);
+  assert.equal(failedSource.requested, 1);
+  assert.equal(
+    (
+      await db.query(
+        "SELECT spec->>'kind' AS kind FROM slab_evidence_refreshes WHERE state='queued'",
+      )
+    ).rows[0].kind,
+    "ebay-sales",
+    "One expired provider does not block another provider's queue",
+  );
+  await db.query(
+    "UPDATE slab_maintenance_settings SET next_cycle_at=clock_timestamp() WHERE seller=$1",
+    [seller],
+  );
+  const [a, b] = await Promise.all([claimMaintenance(), claimMaintenance()]);
+  const claimed = a ?? b;
+  assert.ok(claimed);
+  assert.ok(!a || !b);
+  await db.query(
+    "UPDATE slab_maintenance_settings SET lease_until=clock_timestamp()-interval '1 second' WHERE seller=$1",
+    [seller],
+  );
+  const replacement = await claimMaintenance();
+  assert.ok(replacement);
+  assert.equal(await maintenanceActive(claimed), false);
+  const previous = await getMaintenanceSettings(seller);
+  await saveMaintenanceSettings({ ...previous, enabled: false });
+  assert.equal(await maintenanceActive(replacement), false);
+  assert.equal(await runSlabMaintenanceCycle(), null);
+  await maintenanceCheckpoint(claimed, {
+    inventoryId: inventory[0].id,
+    inventoryRevision: 999,
+    identityRevision: null,
+    inputKey: null,
+    recommendationId: null,
+    outcome: "invalid",
+    reason: "stale",
+    waiting: false,
+  });
+  assert.notEqual(
+    (
+      await db.query(
+        "SELECT inventory_revision FROM slab_maintenance_items WHERE inventory_id=$1",
+        [inventory[0].id],
+      )
+    ).rows[0].inventory_revision,
+    999,
+    "A stale lease cannot overwrite its checkpoint",
+  );
+  const largeSeller = "maintenance-large-fixture";
+  await reconcileInventory(
+    parseInventoryCsv(
+      Papa.unparse(
+        Array.from({ length: 5000 }, (_, n) => ({
+          item_id: String(910000000000 + n),
+          title: "Unconfirmed synthetic slab",
+          price: 100,
+          currency: "USD",
+          quantity: 1,
+          state: "active",
+          format: "fixed-price",
+        })),
+      ),
+      largeSeller,
+    ),
+    0,
+  );
+  await saveMaintenanceSettings({
+    ...defaultMaintenanceSettings(largeSeller),
+    enabled: true,
+    batchSize: 25,
+    refreshBudget: 1,
+  });
+  const timings: number[] = [];
+  for (let n = 0; n < 5; n++) {
+    await db.query(
+      "UPDATE slab_maintenance_settings SET next_cycle_at=clock_timestamp() WHERE seller=$1",
+      [largeSeller],
+    );
+    const started = performance.now(),
+      cycle = (await runSlabMaintenanceCycle())!;
+    timings.push(performance.now() - started);
+    assert.equal(cycle.checked, 25);
+    assert.equal(cycle.requested, 0);
+    assert.equal(cycle.recalculated, 0);
+  }
+  timings.sort((a, b) => a - b);
+  console.log(
+    `5,000-listing fixture / 25-listing cycles: p50 ${timings[2].toFixed(1)} ms, max ${timings[4].toFixed(1)} ms; zero remote requests`,
+  );
+  assert.equal(
+    (await db.query("SELECT count(*)::int AS n FROM slab_publications")).rows[0]
+      .n,
+    0,
+  );
+  assert.equal(remote, 0);
+  console.log(
+    "PASS opt-in maintenance, bounded/coalesced refresh, unchanged warm cycles, reviewed-price hold, source isolation, leases, pause and zero publication",
+  );
+} finally {
+  globalThis.fetch = originalFetch;
+  await db.end();
+  await admin.query(`DROP SCHEMA "${schema}" CASCADE`);
+  await admin.end();
+}

--- a/app/features/ebay-slab-pricing/maintenance/slabMaintenance.test.ts
+++ b/app/features/ebay-slab-pricing/maintenance/slabMaintenance.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import {
+  automaticSlabPublication,
+  defaultMaintenanceSettings,
+  maintenanceSettings,
+} from "./slabMaintenance";
+import { maintenanceWindow } from "./slabMaintenanceCycle.server";
+const defaults = defaultMaintenanceSettings("PokeBash");
+assert.equal(defaults.enabled, false);
+assert.equal(defaults.seller, "pokebash");
+assert.deepEqual(maintenanceSettings(defaults), defaults);
+for (const value of [
+  { intervalMinutes: 0 },
+  { intervalMinutes: 1441 },
+  { batchSize: 0 },
+  { batchSize: 26 },
+  { refreshBudget: 0 },
+  { refreshBudget: 51 },
+  { revision: -1 },
+  { enabled: "true" },
+])
+  assert.throws(() =>
+    maintenanceSettings({ ...defaults, ...value } as typeof defaults),
+  );
+assert.equal(automaticSlabPublication().enabled, false);
+assert.deepEqual(maintenanceWindow(new Date("2026-09-06T01:00:00Z")), {
+  from: "2025-09-05",
+  to: "2026-09-05",
+});
+console.log(
+  "PASS opt-in maintenance defaults, bounded settings, Chicago windows and unavailable automatic publication",
+);

--- a/app/features/ebay-slab-pricing/maintenance/slabMaintenance.ts
+++ b/app/features/ebay-slab-pricing/maintenance/slabMaintenance.ts
@@ -1,0 +1,59 @@
+import { sellerAccount } from "../inventory/slabInventory";
+export class SlabMaintenanceError extends Error {}
+export type MaintenanceSettings = {
+  seller: string;
+  enabled: boolean;
+  includeSupply: boolean;
+  intervalMinutes: number;
+  batchSize: number;
+  refreshBudget: number;
+  revision: number;
+};
+export const defaultMaintenanceSettings = (
+  seller: string,
+): MaintenanceSettings => ({
+  seller: sellerAccount(seller),
+  enabled: false,
+  includeSupply: false,
+  intervalMinutes: 360,
+  batchSize: 10,
+  refreshBudget: 20,
+  revision: 0,
+});
+export function maintenanceSettings(
+  input: MaintenanceSettings,
+): MaintenanceSettings {
+  if (
+    !input ||
+    typeof input.enabled !== "boolean" ||
+    typeof input.includeSupply !== "boolean" ||
+    !Number.isInteger(input.intervalMinutes) ||
+    input.intervalMinutes < 15 ||
+    input.intervalMinutes > 1440 ||
+    !Number.isInteger(input.batchSize) ||
+    input.batchSize < 1 ||
+    input.batchSize > 25 ||
+    !Number.isInteger(input.refreshBudget) ||
+    input.refreshBudget < 1 ||
+    input.refreshBudget > 50 ||
+    !Number.isInteger(input.revision) ||
+    input.revision < 0
+  )
+    throw new SlabMaintenanceError(
+      "Choose a 15–1,440 minute interval, 1–25 listings and 1–50 refresh jobs per cycle.",
+    );
+  return {
+    seller: sellerAccount(input.seller),
+    enabled: input.enabled,
+    includeSupply: input.includeSupply,
+    intervalMinutes: input.intervalMinutes,
+    batchSize: input.batchSize,
+    refreshBudget: input.refreshBudget,
+    revision: input.revision,
+  };
+}
+// Current delivery has no adopted publication cohort or connected live publisher. Maintenance never grants publication authority.
+export const automaticSlabPublication = () => ({
+  enabled: false as const,
+  reasons: ["live-publisher-not-connected", "no-adopted-automation-cohorts"],
+});

--- a/app/features/ebay-slab-pricing/maintenance/slabMaintenanceCycle.server.ts
+++ b/app/features/ebay-slab-pricing/maintenance/slabMaintenanceCycle.server.ts
@@ -1,0 +1,242 @@
+import { createHash } from "node:crypto";
+import { queryOne } from "~/core/db/database.server";
+import { getInventoryListing } from "../inventory/slabInventory.server";
+import { getProviderConnections } from "../connections/providerConnections.server";
+import { planSlabEvidence } from "../evidence/slabEvidenceRefresh.server";
+import { evidenceKey } from "../evidence/evidenceRefreshProvider.server";
+import {
+  normalizeEvidenceSpec,
+  type EvidenceSpec,
+} from "../evidence/evidenceRefresh";
+import {
+  evidenceStatuses,
+  requestEvidence,
+} from "../evidence/evidenceRefreshStore.server";
+import {
+  calculateSlabRecommendation,
+  getSlabRecommendation,
+} from "../valuation/slabRecommendations.server";
+import {
+  claimMaintenance,
+  maintenanceActive,
+  maintenanceCandidates,
+  maintenanceCheckpoint,
+  maintenanceItemState,
+  finishMaintenance,
+} from "./slabMaintenanceStore.server";
+// One rolling Chicago-date year, matching the review page default. Never import browser/client UI code into a worker.
+export function maintenanceWindow(now = new Date()) {
+  const to = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Chicago",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(now);
+  const from = new Date(`${to}T12:00:00Z`);
+  from.setUTCDate(from.getUTCDate() - 365);
+  return { from: from.toISOString().slice(0, 10), to };
+}
+export async function runSlabMaintenanceCycle() {
+  const job = await claimMaintenance();
+  if (!job) return null;
+  const summary = {
+    checked: 0,
+    queued: 0,
+    requested: 0,
+    recalculated: 0,
+    held: 0,
+    waiting: 0,
+    refreshBudget: job.refreshBudget,
+  };
+  try {
+    const connections = await getProviderConnections();
+    const available = new Set(
+      connections
+        .filter(
+          (c) =>
+            c.configured &&
+            ["connected", "busy", "rate-limited", "unavailable"].includes(
+              c.status,
+            ),
+        )
+        .map((c) => c.provider),
+    );
+    const candidates = await maintenanceCandidates(job),
+      window = maintenanceWindow();
+    for (const candidate of candidates) {
+      if (!(await maintenanceActive(job))) break;
+      const row = await getInventoryListing(candidate.id);
+      if (!row || row.state !== "active") continue;
+      const previous = await maintenanceItemState(row.id);
+      let recommendationId = previous?.recommendationId ?? null,
+        inputKey: string | null = null,
+        outcome = "review-required",
+        reason = "confirm-listing-identity",
+        waiting = false;
+      try {
+        const identity = row.identity;
+        if (
+          identity?.status === "confirmed" &&
+          identity.identity &&
+          !row.reviewReasons.some((r) => r !== "certificate-required") &&
+          row.snapshot.quantity === 1 &&
+          row.snapshot.format === "fixed-price" &&
+          !row.variationKey
+        ) {
+          const latest = await queryOne<{ id: string }>(
+            "SELECT id FROM slab_recommendations WHERE slab_id=$1 ORDER BY created_at DESC,id DESC LIMIT 1",
+            [identity.id],
+          );
+          const recommendation = latest
+            ? await getSlabRecommendation(latest.id)
+            : null;
+          recommendationId = recommendation?.id ?? null;
+          const plan = planSlabEvidence([identity], window, job.includeSupply);
+          const calcSpecs: EvidenceSpec[] =
+            recommendation?.calculation.evidence.map((e) =>
+              normalizeEvidenceSpec(
+                e.spec.kind === "alt-sales" || e.spec.kind === "ebay-sales"
+                  ? { ...e.spec, window }
+                  : e.spec,
+              ),
+            ) ?? [];
+          const specs = [
+            ...new Map(
+              [...calcSpecs, ...plan.requests].map((spec) => [
+                evidenceKey(spec),
+                spec,
+              ]),
+            ).values(),
+          ];
+          const keys = specs.map(evidenceKey),
+            statuses = await evidenceStatuses(keys),
+            byKey = new Map(statuses.map((s) => [s.key, s]));
+          const requested: EvidenceSpec[] = [];
+          for (const spec of specs) {
+            const state = byKey.get(evidenceKey(spec));
+            if (requested.length + summary.requested >= job.refreshBudget)
+              break;
+            if (
+              available.has(
+                spec.kind.startsWith("alt-") ? "alt" : "ebayResearch",
+              ) &&
+              (!state || state.stale) &&
+              state?.state !== "queued" &&
+              state?.state !== "running"
+            )
+              requested.push(spec);
+          }
+          if (requested.length && (await maintenanceActive(job))) {
+            const refreshed = await requestEvidence(requested, { priority: 0 });
+            summary.requested += requested.length;
+            summary.queued += refreshed.filter(
+              (s) => s.state === "queued",
+            ).length;
+            for (const status of refreshed) byKey.set(status.key, status);
+          }
+          const selected = calcSpecs.map((spec) =>
+            byKey.get(evidenceKey(spec)),
+          );
+          const ready =
+            selected.length > 0 &&
+            selected.every(
+              (s) => s?.latestRevision && !s.stale && s.state === "idle",
+            );
+          if (!recommendation) {
+            reason = "save-seller-context-before-repricing";
+          } else if (recommendation.override) {
+            reason = "reviewed-price-held";
+          } else if (!ready) {
+            outcome = "waiting";
+            reason = "fresh-selected-evidence-required";
+            waiting = true;
+          } else if (
+            row.snapshot.price.currency !== "USD" ||
+            (row.snapshot.shipping.amount !== null &&
+              row.snapshot.shipping.currency !== "USD")
+          ) {
+            reason = "pricing-currency-unresolved";
+          } else {
+            const seller = {
+              ...recommendation.calculation.seller,
+              currentAsk: row.snapshot.price.amount,
+              shippingCharged: row.snapshot.shipping.amount,
+            };
+            const revisionIds = [
+              ...new Set(selected.map((s) => s!.latestRevision!)),
+            ].sort();
+            inputKey = createHash("sha256")
+              .update(
+                JSON.stringify([
+                  row.revision,
+                  identity.revision,
+                  revisionIds,
+                  recommendation.calculation.policy,
+                  seller,
+                ]),
+              )
+              .digest("hex");
+            if (previous?.inputKey === inputKey && recommendation.current) {
+              outcome = "unchanged";
+              reason = "fresh-inputs-unchanged";
+            } else if (await maintenanceActive(job)) {
+              const calculated = await calculateSlabRecommendation(
+                {
+                  slabId: identity.id,
+                  identityRevision: identity.revision,
+                  revisionIds,
+                  policy: recommendation.calculation.policy,
+                  seller,
+                },
+                undefined,
+                { expectedRecommendationId: recommendation.id },
+              );
+              recommendationId = calculated.id;
+              summary.recalculated++;
+              outcome = calculated.calculation.ask.requiresReview
+                ? "review-required"
+                : "recalculated";
+              reason = calculated.calculation.ask.requiresReview
+                ? "recommendation-needs-review"
+                : "publication-remains-disabled";
+            }
+          }
+          // Continue promptly after scheduled reads; unrelated sources do not block already fresh selected evidence.
+          waiting ||= [...byKey.values()].some(
+            (s) => s.state === "queued" || s.state === "running",
+          );
+          waiting ||= specs.some(
+            (spec) =>
+              available.has(
+                spec.kind.startsWith("alt-") ? "alt" : "ebayResearch",
+              ) &&
+              (!byKey.get(evidenceKey(spec)) ||
+                byKey.get(evidenceKey(spec))!.stale),
+          );
+        }
+      } catch {
+        outcome = "review-required";
+        reason = "recalculation-unavailable";
+      }
+      if (!(await maintenanceActive(job))) break;
+      await maintenanceCheckpoint(job, {
+        inventoryId: row.id,
+        inventoryRevision: row.revision,
+        identityRevision: row.identity?.revision ?? null,
+        inputKey,
+        recommendationId,
+        outcome,
+        reason,
+        waiting,
+      });
+      summary.checked++;
+      if (outcome === "review-required") summary.held++;
+      if (waiting) summary.waiting++;
+    }
+    await finishMaintenance(job, summary);
+    return summary;
+  } catch {
+    await finishMaintenance(job, summary, "maintenance-unavailable");
+    return summary;
+  }
+}

--- a/app/features/ebay-slab-pricing/maintenance/slabMaintenanceStore.server.ts
+++ b/app/features/ebay-slab-pricing/maintenance/slabMaintenanceStore.server.ts
@@ -1,0 +1,161 @@
+import { randomUUID } from "node:crypto";
+import { query, queryOne } from "~/core/db/database.server";
+import { sellerAccount } from "../inventory/slabInventory";
+import {
+  defaultMaintenanceSettings,
+  maintenanceSettings,
+  SlabMaintenanceError,
+  type MaintenanceSettings,
+} from "./slabMaintenance";
+type Summary = {
+  checked: number;
+  queued: number;
+  requested: number;
+  recalculated: number;
+  held: number;
+  waiting: number;
+  refreshBudget: number;
+};
+export type StoredMaintenance = MaintenanceSettings & {
+  nextCycleAt: Date;
+  lastCycleAt: Date | null;
+  lastError: string | null;
+  lastSummary: Summary | null;
+};
+export type MaintenanceJob = StoredMaintenance & { leaseId: string };
+const fields = `seller,enabled,include_supply AS "includeSupply",interval_minutes AS "intervalMinutes",batch_size AS "batchSize",refresh_budget AS "refreshBudget",revision,
+  next_cycle_at AS "nextCycleAt",last_cycle_at AS "lastCycleAt",last_error AS "lastError",last_summary AS "lastSummary"`;
+export async function getMaintenanceSettings(seller: string) {
+  seller = sellerAccount(seller);
+  return (
+    (await queryOne<StoredMaintenance>(
+      `SELECT ${fields} FROM slab_maintenance_settings WHERE seller=$1`,
+      [seller],
+    )) ?? {
+      ...defaultMaintenanceSettings(seller),
+      nextCycleAt: null,
+      lastCycleAt: null,
+      lastError: null,
+      lastSummary: null,
+    }
+  );
+}
+export async function saveMaintenanceSettings(input: MaintenanceSettings) {
+  const value = maintenanceSettings(input);
+  const row = await queryOne<StoredMaintenance>(
+    `INSERT INTO slab_maintenance_settings(seller,enabled,include_supply,interval_minutes,batch_size,refresh_budget)
+    SELECT $1,$2,$3,$4,$5,$6 WHERE $7=0 ON CONFLICT(seller) DO NOTHING RETURNING ${fields}`,
+    [
+      value.seller,
+      value.enabled,
+      value.includeSupply,
+      value.intervalMinutes,
+      value.batchSize,
+      value.refreshBudget,
+      value.revision,
+    ],
+  );
+  if (row) return row;
+  const updated = await queryOne<StoredMaintenance>(
+    `UPDATE slab_maintenance_settings SET enabled=$2,include_supply=$3,interval_minutes=$4,batch_size=$5,refresh_budget=$6,
+    revision=revision+1,lease_id=NULL,lease_until=NULL,next_cycle_at=clock_timestamp(),last_error=NULL WHERE seller=$1 AND revision=$7 RETURNING ${fields}`,
+    [
+      value.seller,
+      value.enabled,
+      value.includeSupply,
+      value.intervalMinutes,
+      value.batchSize,
+      value.refreshBudget,
+      value.revision,
+    ],
+  );
+  if (!updated)
+    throw new SlabMaintenanceError(
+      "Maintenance settings changed. Reload before saving.",
+    );
+  return updated;
+}
+export async function claimMaintenance(): Promise<MaintenanceJob | null> {
+  return queryOne<MaintenanceJob>(
+    `UPDATE slab_maintenance_settings SET lease_id=$1,lease_until=clock_timestamp()+interval '90 seconds'
+    WHERE seller=(SELECT seller FROM slab_maintenance_settings WHERE enabled AND next_cycle_at<=clock_timestamp() AND (lease_until IS NULL OR lease_until<=clock_timestamp())
+      ORDER BY next_cycle_at,seller FOR UPDATE SKIP LOCKED LIMIT 1) RETURNING ${fields},lease_id AS "leaseId"`,
+    [randomUUID()],
+  );
+}
+export async function maintenanceActive(job: MaintenanceJob) {
+  return !!(await queryOne(
+    "SELECT 1 FROM slab_maintenance_settings WHERE seller=$1 AND enabled AND revision=$2 AND lease_id=$3 AND lease_until>clock_timestamp()",
+    [job.seller, job.revision, job.leaseId],
+  ));
+}
+export async function maintenanceCandidates(job: MaintenanceJob) {
+  return query<{ id: string }>(
+    `SELECT i.id FROM slab_inventory i LEFT JOIN slab_identities d ON d.id=i.identity_id LEFT JOIN slab_maintenance_items m ON m.inventory_id=i.id
+  WHERE i.seller=$1 AND i.state='active' AND (m.inventory_id IS NULL OR m.inventory_revision<>i.revision OR m.identity_revision IS DISTINCT FROM d.revision OR m.settings_revision<>$2 OR m.next_check_at<=clock_timestamp()
+    OR m.recommendation_id IS DISTINCT FROM (SELECT r.id FROM slab_recommendations r WHERE r.slab_id=i.identity_id ORDER BY r.created_at DESC,r.id DESC LIMIT 1))
+  ORDER BY (m.inventory_id IS NULL OR m.inventory_revision<>i.revision OR m.identity_revision IS DISTINCT FROM d.revision) DESC,m.checked_at NULLS FIRST,i.id LIMIT $3`,
+    [job.seller, job.revision, job.batchSize],
+  );
+}
+export async function maintenanceCheckpoint(
+  job: MaintenanceJob,
+  input: {
+    inventoryId: string;
+    inventoryRevision: number;
+    identityRevision: number | null;
+    inputKey: string | null;
+    recommendationId: string | null;
+    outcome: string;
+    reason: string;
+    waiting: boolean;
+  },
+) {
+  return query(
+    `INSERT INTO slab_maintenance_items(inventory_id,inventory_revision,identity_revision,input_key,recommendation_id,outcome,reason,next_check_at,settings_revision)
+    SELECT $1,$2,$3,$4,$5,$6,$7,clock_timestamp()+$8*interval '1 second',$9 WHERE EXISTS(SELECT 1 FROM slab_maintenance_settings WHERE seller=$10 AND enabled AND revision=$9 AND lease_id=$11 AND lease_until>clock_timestamp())
+    ON CONFLICT(inventory_id) DO UPDATE SET inventory_revision=EXCLUDED.inventory_revision,identity_revision=EXCLUDED.identity_revision,input_key=EXCLUDED.input_key,
+      recommendation_id=EXCLUDED.recommendation_id,outcome=EXCLUDED.outcome,reason=EXCLUDED.reason,checked_at=clock_timestamp(),next_check_at=EXCLUDED.next_check_at,settings_revision=EXCLUDED.settings_revision`,
+    [
+      input.inventoryId,
+      input.inventoryRevision,
+      input.identityRevision,
+      input.inputKey,
+      input.recommendationId,
+      input.outcome,
+      input.reason,
+      input.waiting ? 30 : job.intervalMinutes * 60,
+      job.revision,
+      job.seller,
+      job.leaseId,
+    ],
+  );
+}
+export async function finishMaintenance(
+  job: MaintenanceJob,
+  summary: Summary,
+  error: string | null = null,
+) {
+  await query(
+    "UPDATE slab_maintenance_settings SET last_cycle_at=clock_timestamp(),last_error=$4,last_summary=$5,next_cycle_at=clock_timestamp()+interval '30 seconds',lease_id=NULL,lease_until=NULL WHERE seller=$1 AND revision=$2 AND lease_id=$3 AND lease_until>clock_timestamp()",
+    [job.seller, job.revision, job.leaseId, error, JSON.stringify(summary)],
+  );
+}
+export async function maintenanceItemState(inventoryId: string) {
+  return queryOne<{ inputKey: string | null; recommendationId: string | null }>(
+    `SELECT input_key AS "inputKey",recommendation_id AS "recommendationId" FROM slab_maintenance_items WHERE inventory_id=$1`,
+    [inventoryId],
+  );
+}
+export async function maintenanceOverview(seller: string) {
+  return query<{
+    id: string;
+    title: string;
+    outcome: string;
+    reason: string;
+    checkedAt: Date;
+  }>(
+    `SELECT i.id,i.snapshot->>'title' AS title,m.outcome,m.reason,m.checked_at AS "checkedAt" FROM slab_maintenance_items m JOIN slab_inventory i ON i.id=m.inventory_id WHERE i.seller=$1 ORDER BY m.checked_at DESC,i.id LIMIT 25`,
+    [sellerAccount(seller)],
+  );
+}

--- a/app/features/ebay-slab-pricing/routes/api.slab-maintenance.server.ts
+++ b/app/features/ebay-slab-pricing/routes/api.slab-maintenance.server.ts
@@ -1,0 +1,79 @@
+import { data } from "react-router";
+import { readSlabJsonRequest } from "../readJsonRequest.server";
+import { SlabInventoryError } from "../inventory/slabInventory";
+import {
+  automaticSlabPublication,
+  SlabMaintenanceError,
+} from "../maintenance/slabMaintenance";
+import {
+  getMaintenanceSettings,
+  saveMaintenanceSettings,
+  maintenanceOverview,
+} from "../maintenance/slabMaintenanceStore.server";
+import { getProviderConnections } from "../connections/providerConnections.server";
+import { ensureEvidenceWorker } from "../evidence/evidenceRefreshWorker.server";
+const respond = (body: unknown, status = 200) =>
+  data(body, { status, headers: { "Cache-Control": "no-store" } });
+const failure = (error: unknown) =>
+  respond(
+    {
+      error:
+        error instanceof SlabMaintenanceError ||
+        error instanceof SlabInventoryError
+          ? error.message
+          : "Maintenance is unavailable.",
+    },
+    error instanceof SlabMaintenanceError ||
+      error instanceof SlabInventoryError ||
+      error instanceof TypeError ||
+      error instanceof SyntaxError
+      ? 400
+      : 500,
+  );
+export async function maintenanceView(seller: string) {
+  const settings = await getMaintenanceSettings(seller);
+  if (settings.enabled) ensureEvidenceWorker();
+  return {
+    settings,
+    items: await maintenanceOverview(seller),
+    providers: await getProviderConnections(),
+    automaticPublication: automaticSlabPublication(),
+    workerMode:
+      process.env.WORKERS_RUN_IN_PROCESS === "false"
+        ? "external"
+        : "in-process",
+  };
+}
+export type MaintenanceView = Awaited<ReturnType<typeof maintenanceView>>;
+export async function loader({ request }: { request: Request }) {
+  try {
+    return respond(
+      await maintenanceView(
+        new URL(request.url).searchParams.get("seller") ?? "",
+      ),
+    );
+  } catch (error) {
+    return failure(error);
+  }
+}
+export async function action({ request }: { request: Request }) {
+  if (request.method !== "POST")
+    return respond({ error: "Method not allowed." }, 405);
+  if (request.headers.get("Origin") !== new URL(request.url).origin)
+    return respond({ error: "Change maintenance from the application." }, 403);
+  try {
+    const input = await readSlabJsonRequest(request, 16384);
+    if (input.intent !== "save" || input.autoPublish === true)
+      throw new SlabMaintenanceError(
+        "Save evidence maintenance settings. Automatic publication is unavailable.",
+      );
+    const settings = await saveMaintenanceSettings(input.settings);
+    if (settings.enabled) ensureEvidenceWorker();
+    return respond({
+      settings,
+      automaticPublication: automaticSlabPublication(),
+    });
+  } catch (error) {
+    return failure(error);
+  }
+}

--- a/app/features/ebay-slab-pricing/routes/api.slab-maintenance.ts
+++ b/app/features/ebay-slab-pricing/routes/api.slab-maintenance.ts
@@ -1,0 +1,1 @@
+export { loader, action } from "./api.slab-maintenance.server";

--- a/app/features/ebay-slab-pricing/valuation/slabRecommendations.server.ts
+++ b/app/features/ebay-slab-pricing/valuation/slabRecommendations.server.ts
@@ -40,6 +40,7 @@ type EvidenceRow = {
 export async function calculateSlabRecommendation(
   input: RecommendationInput,
   asOf = new Date().toISOString(),
+  options: { expectedRecommendationId?: string } = {},
 ) {
   if (
     !input ||
@@ -49,7 +50,9 @@ export async function calculateSlabRecommendation(
     !Array.isArray(input.revisionIds) ||
     input.revisionIds.length > 20 ||
     input.revisionIds.some((id) => !uuid(id)) ||
-    !Number.isFinite(Date.parse(asOf))
+    !Number.isFinite(Date.parse(asOf)) ||
+    (options.expectedRecommendationId !== undefined &&
+      !uuid(options.expectedRecommendationId))
   )
     throw new SlabValuationError(
       "Choose a current slab identity and at most twenty evidence revisions.",
@@ -65,7 +68,7 @@ export async function calculateSlabRecommendation(
     const target = (
       await db.query<StoredSlabIdentity>(
         `SELECT id, grader, certificate_number AS "certificateNumber", identity, status, revision, valuation_group_key AS "valuationGroupKey" FROM slab_identities
-      WHERE id = $1 AND revision = $2 AND status = 'confirmed' FOR SHARE`,
+      WHERE id = $1 AND revision = $2 AND status = 'confirmed' FOR ${options.expectedRecommendationId ? "UPDATE" : "SHARE"}`,
         [input.slabId, input.identityRevision],
       )
     ).rows[0];
@@ -73,6 +76,20 @@ export async function calculateSlabRecommendation(
       throw new SlabValuationError(
         "The slab identity changed or is unconfirmed. Reload before calculating.",
       );
+    // Serialize background recalculation with manual review on the identity.
+    if (options.expectedRecommendationId) {
+      const latest = (
+        await db.query<{ id: string; reviewed: boolean }>(
+          `SELECT r.id, EXISTS(SELECT 1 FROM slab_price_overrides o WHERE o.recommendation_id=r.id) AS reviewed
+         FROM slab_recommendations r WHERE r.slab_id=$1 ORDER BY r.created_at DESC,r.id DESC LIMIT 1`,
+          [input.slabId],
+        )
+      ).rows[0];
+      if (latest?.id !== options.expectedRecommendationId || latest.reviewed)
+        throw new SlabValuationError(
+          "The recommendation changed or has a reviewed price. Reload before recalculating.",
+        );
+    }
     const size = (
       await db.query<{ count: number; bytes: number }>(
         "SELECT count(*)::int AS count, COALESCE(sum(byte_count),0)::int AS bytes FROM slab_evidence_revisions WHERE id=ANY($1::uuid[])",
@@ -289,18 +306,28 @@ export async function overrideSlabPrice(input: {
     throw new SlabValuationError(
       "Provide an explicit item price, currency and review reason.",
     );
-  const saved = await queryOne(
-    `INSERT INTO slab_price_overrides(recommendation_id,item_price,currency,note)
+  const saved = await withTransaction(async (db) => {
+    await db.query("SET LOCAL statement_timeout = '15s'");
+    await db.query(
+      "SELECT i.id FROM slab_identities i JOIN slab_recommendations r ON r.slab_id=i.id WHERE r.id=$1 FOR UPDATE OF i",
+      [input.recommendationId],
+    );
+    return (
+      await db.query(
+        `INSERT INTO slab_price_overrides(recommendation_id,item_price,currency,note)
     SELECT r.id,$2,$3,$4 FROM slab_recommendations r JOIN slab_identities i ON i.id=r.slab_id
     WHERE r.id=$1 AND i.revision=r.identity_revision AND i.status='confirmed' AND i.valuation_group_key=r.valuation_group_key AND r.calculation->'policy'->>'currency'=$3
+    AND r.id=(SELECT latest.id FROM slab_recommendations latest WHERE latest.slab_id=r.slab_id ORDER BY latest.created_at DESC,latest.id DESC LIMIT 1)
     ON CONFLICT(recommendation_id) DO UPDATE SET item_price=EXCLUDED.item_price,currency=EXCLUDED.currency,note=EXCLUDED.note,reviewed_at=clock_timestamp() RETURNING recommendation_id`,
-    [
-      input.recommendationId,
-      input.itemPrice,
-      input.currency,
-      input.note.trim(),
-    ],
-  );
+        [
+          input.recommendationId,
+          input.itemPrice,
+          input.currency,
+          input.note.trim(),
+        ],
+      )
+    ).rows[0];
+  });
   if (!saved)
     throw new SlabValuationError(
       "The recommendation changed or uses another currency. Recalculate before overriding.",

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -2,6 +2,10 @@ import { type RouteConfig, index } from "@react-router/dev/routes";
 
 export default [
   {
+    path: "/api/slab-maintenance",
+    file: "features/ebay-slab-pricing/routes/api.slab-maintenance.ts",
+  },
+  {
     path: "/api/slab-publications",
     file: "features/ebay-slab-pricing/routes/api.slab-publications.ts",
   },

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -1,4 +1,5 @@
 import "../core/clients/baseDomainClient.server.test";
+import "../features/ebay-slab-pricing/maintenance/slabMaintenance.test";
 import "../features/ebay-slab-pricing/publication/slabPublication.test";
 import "../features/ebay-slab-pricing/evaluation/slabPreviewAcceptance.test";
 import "../features/ebay-slab-pricing/publication/slabPublicationPreview.test";

--- a/db/migrations/033_add_slab_evidence_maintenance.sql
+++ b/db/migrations/033_add_slab_evidence_maintenance.sql
@@ -1,0 +1,29 @@
+CREATE TABLE slab_maintenance_settings (
+  seller TEXT PRIMARY KEY,
+  enabled BOOLEAN NOT NULL DEFAULT false,
+  include_supply BOOLEAN NOT NULL DEFAULT false,
+  interval_minutes INTEGER NOT NULL DEFAULT 360 CHECK(interval_minutes BETWEEN 15 AND 1440),
+  batch_size INTEGER NOT NULL DEFAULT 10 CHECK(batch_size BETWEEN 1 AND 25),
+  refresh_budget INTEGER NOT NULL DEFAULT 20 CHECK(refresh_budget BETWEEN 1 AND 50),
+  revision INTEGER NOT NULL DEFAULT 1,
+  lease_id UUID,
+  lease_until TIMESTAMPTZ,
+  next_cycle_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+  last_cycle_at TIMESTAMPTZ,
+  last_error TEXT,
+  last_summary JSONB
+);
+CREATE INDEX slab_maintenance_due_idx ON slab_maintenance_settings(next_cycle_at,seller) WHERE enabled;
+CREATE TABLE slab_maintenance_items (
+  inventory_id UUID PRIMARY KEY REFERENCES slab_inventory(id) ON DELETE CASCADE,
+  inventory_revision INTEGER NOT NULL,
+  identity_revision INTEGER,
+  input_key TEXT,
+  recommendation_id UUID REFERENCES slab_recommendations(id),
+  outcome TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  checked_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+  next_check_at TIMESTAMPTZ NOT NULL,
+  settings_revision INTEGER NOT NULL
+);
+CREATE INDEX slab_maintenance_item_due_idx ON slab_maintenance_items(next_check_at,inventory_id);

--- a/docs/slab-evidence-maintenance.md
+++ b/docs/slab-evidence-maintenance.md
@@ -1,0 +1,27 @@
+# Opt-in slab evidence maintenance
+
+Open a seller's saved inventory, then **Evidence maintenance**. Enable it explicitly, choose whether to collect active supply, and save. Migration 033 defaults every seller to paused. The panel is loaded on demand; the existing slab evidence worker handles maintenance when its evidence queue has no ready work. No new service or dependency is introduced, and TCGplayer pricing/publication workers are unchanged.
+
+Each cycle checks at most 25 listings and requests at most 50 source jobs. Defaults are 10 listings, 20 requests and a six-hour interval. Confirmed, active, single-quantity fixed-price inventory is eligible for collection; variations, contradictory identities and unresolved listing warnings stay in review. Shared evidence keys coalesce across listings. Existing cache freshness, provider cooldowns, retry limits and job priority apply. Missing, unchecked or expired-auth connections pause that source while other sources can progress. Opening paused maintenance makes no provider requests.
+
+The worker checks for due groups every 30 seconds. A listing's next ordinary check follows its configured 15–1,440 minute interval. New/changed inventory or identities take priority; changed settings and newly saved recommendations become eligible immediately. Queued evidence and work deferred by the request budget are checked again after 30 seconds. A rolling 365-day Chicago-date window matches the review page default. Selected sales sources/pages are retained from the previous recommendation with their windows advanced; optional supply is collected separately and never becomes sold evidence.
+
+Recalculation requires a first manually saved recommendation, which supplies the seller's costs, fees, policy and constraints. Maintenance uses the current imported ask and shipping charge and fresh selected evidence. Identical inputs do not create another recommendation. A reviewed price override is held, including when review races a background calculation: both serialize on the slab identity, and a superseded review must be reloaded before saving. Insufficient evidence continues to require review. Maintenance does not import seller inventory or publish prices; automatic publication remains unavailable without a connected live publisher and adopted cohorts.
+
+Settings and listing checkpoints persist in PostgreSQL. Revision checks prevent stale settings saves, and 90-second leases fence competing workers and stale checkpoints. Pause stops new work from subsequent checks; already queued shared evidence and an in-progress calculation may finish. Restarting the optional standalone slab evidence worker resumes saved enabled settings. In-process mode resumes when the maintenance panel or an evidence workflow starts the existing worker; it requires a running app process. With `WORKERS_RUN_IN_PROCESS=false`, start `npm run start:slab-evidence-worker` after building. The panel reports that requirement rather than claiming a worker heartbeat.
+
+Apply migration 033 before starting this build. Back up/restore its settings and checkpoints with the referenced inventory, identity, recommendation and evidence tables. Pause maintenance before an application rollback. Leave the additive tables intact; older builds do not execute this scheduler. After restoring a backup, keep maintenance paused until connections, inventory and evidence are checked. Do not automatically replay an unresolved publication: its recorded write boundary still requires independent reconciliation.
+
+## Validation
+
+Run `npm test`, `npm run typecheck`, `npm run build`, and:
+
+```sh
+npx tsx app/features/ebay-slab-pricing/maintenance/slabMaintenance.integration.test.ts
+npx tsx app/features/ebay-slab-pricing/valuation/slabRecommendations.integration.test.ts
+npx tsx app/features/ebay-slab-pricing/research/slabResearch.integration.test.ts
+```
+
+The guarded local PostgreSQL maintenance test creates and removes a disposable schema. It verifies six distinct certificates sharing one source job, request budgets, fresh recalculation, unchanged warm cycles, concurrent manual-review protection, unavailable-source isolation, competing/expired leases, pause fencing and zero publication/provider calls. A 5,000-listing unconfirmed fixture stays bounded to 25 checks per cycle: five local samples on September 6, 2026 measured p50 221.8 ms and maximum 318.0 ms. These are database-only development measurements, not provider latency or production contention results.
+
+Local browser validation imported a clearly labeled synthetic listing, verified paused defaults, enabled a one-listing cycle, observed the identity-required hold, then paused and removed the fixture. No provider request or live price write was made for it. This completes the evidence-maintenance portion of #32; seller import, verified model cohorts, live write budgets and end-to-end automation acceptance remain open.


### PR DESCRIPTION
Confirmed slab inventory can now opt into bounded evidence refresh and recommendation recalculation through the existing slab worker. Shared source requests coalesce, unchanged inputs avoid new calculations, and manual price reviews are preserved even when they race a background calculation. A lazy inventory panel exposes pause, cadence, budgets and persisted status. Automatic publication stays disabled.

Related to #32 and #33; neither issue closes because live seller integration, validated cohorts and complete workflow acceptance are still pending. Migration 033 is additive and defaults to paused. No dependency or service was added.

Validation: full offline suite, typecheck, production/worker build, maintenance/valuation/workspace PostgreSQL integration suites and local browser enable/hold/pause checks pass. A 5,000-row fixture checks only 25 rows per cycle (five samples: p50 221.8 ms, max 318.0 ms), with zero remote requests. Synthetic UI data was removed.

Adversarial review found and fixed the manual-review race and a weak stale-checkpoint assertion. A second pass covered composition, failure isolation, bounded requests/pagination, lease recovery, pause semantics, bundle isolation and publication separation; no further actionable findings remain in this scope. Recovery and worker startup limitations are documented in docs/slab-evidence-maintenance.md.
