### PR TITLE
Verify slab migrations and database recovery

### DIFF
--- a/app/features/ebay-slab-pricing/evaluation/verify-slab-recovery.mjs
+++ b/app/features/ebay-slab-pricing/evaluation/verify-slab-recovery.mjs
@@ -1,0 +1,350 @@
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { readdir, readFile } from "node:fs/promises";
+import pg from "pg";
+import dotenv from "dotenv";
+
+// This test uses only databases it creates on the local development PostgreSQL container.
+dotenv.config({
+  path: [".env.development.local", ".env.local", ".env.development", ".env"],
+  quiet: true,
+});
+const base = new URL(
+  process.env.DATABASE_URL ??
+    "postgresql://postgres:postgres@localhost:5433/tcgplayer_automation",
+);
+assert.ok(
+  ["localhost", "127.0.0.1"].includes(base.hostname) &&
+    base.port === "5433" &&
+    base.pathname === "/tcgplayer_automation",
+  "Recovery verification requires the local development database",
+);
+const run = promisify(execFile),
+  container = "tcgplayer-postgres-db";
+const inspected = JSON.parse(
+  (
+    await run("docker", [
+      "inspect",
+      container,
+      "--format",
+      "{{json .NetworkSettings.Ports}}",
+    ])
+  ).stdout,
+);
+assert.ok(
+  inspected["5432/tcp"]?.some((port) => port.HostPort === "5433"),
+  "The container must be the configured development PostgreSQL instance",
+);
+const nonce = randomUUID().replaceAll("-", ""),
+  prefix = `slab_recovery_${nonce}_`;
+const databaseNames = ["fresh", "upgrade", "restore"].map(
+  (name) => prefix + name,
+);
+const created = [],
+  clients = [];
+const admin = new pg.Client({ connectionString: base.toString() });
+await admin.connect();
+const connection = (name) => {
+  const url = new URL(base);
+  url.pathname = `/${name}`;
+  return url.toString();
+};
+const connect = async (name) => {
+  const client = new pg.Client({ connectionString: connection(name) });
+  await client.connect();
+  clients.push(client);
+  return client;
+};
+const migrate = async (name) => {
+  await run(process.execPath, ["scripts/db-migrate.mjs"], {
+    env: { ...process.env, DATABASE_URL: connection(name) },
+    maxBuffer: 2 * 1024 * 1024,
+    timeout: 60_000,
+  });
+};
+const restore = (name, archive) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(
+      "docker",
+      [
+        "exec",
+        "-i",
+        container,
+        "pg_restore",
+        "-U",
+        base.username,
+        "--single-transaction",
+        "--exit-on-error",
+        "--no-owner",
+        "--no-acl",
+        "--dbname",
+        name,
+      ],
+      { stdio: ["pipe", "ignore", "pipe"], timeout: 60_000 },
+    );
+    let error = "";
+    child.stderr.on("data", (data) => {
+      error = (error + data.toString()).slice(-4000);
+    });
+    child.on("error", reject);
+    child.stdin.on("error", reject);
+    child.on("close", (code) =>
+      code === 0
+        ? resolve()
+        : reject(new Error(`Fixture restore failed (${code}): ${error}`)),
+    );
+    child.stdin.end(archive);
+  });
+const snapshot = async (db) => {
+  const tables = (
+    await db.query(
+      "SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename",
+    )
+  ).rows;
+  const result = {};
+  for (const { tablename } of tables) {
+    assert.match(tablename, /^[a-z0-9_]+$/);
+    result[tablename] = (
+      await db.query(
+        `SELECT count(*)::int AS count, md5(COALESCE(string_agg(to_jsonb(t)::text, E'\\n' ORDER BY to_jsonb(t)::text),'')) AS checksum FROM "${tablename}" t`,
+      )
+    ).rows[0];
+  }
+  return result;
+};
+try {
+  for (const name of databaseNames) {
+    assert.ok(name.startsWith(prefix) && /^[a-z0-9_]+$/.test(name));
+    await admin.query(`CREATE DATABASE "${name}"`);
+    created.push(name);
+  }
+  const [freshName, upgradeName, restoreName] = databaseNames;
+  await migrate(freshName);
+  const fresh = await connect(freshName),
+    freshState = await snapshot(fresh);
+  await migrate(freshName);
+  assert.deepEqual(
+    await snapshot(fresh),
+    freshState,
+    "Fresh migration reruns must not change data",
+  );
+  assert.equal(freshState.slab_maintenance_settings.count, 0);
+  assert.equal(freshState.slab_provider_connections.count, 0);
+  assert.equal(freshState.slab_publications.count, 0);
+
+  const upgrade = await connect(upgradeName);
+  await upgrade.query(
+    "CREATE TABLE schema_migrations(name TEXT PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW())",
+  );
+  const migrations = (await readdir("db/migrations"))
+    .filter((name) => name.endsWith(".sql"))
+    .sort();
+  for (const file of migrations.filter(
+    (name) => Number(name.slice(0, 3)) <= 23,
+  )) {
+    await upgrade.query("BEGIN");
+    try {
+      await upgrade.query(await readFile(`db/migrations/${file}`, "utf8"));
+      await upgrade.query("INSERT INTO schema_migrations(name) VALUES($1)", [
+        file,
+      ]);
+      await upgrade.query("COMMIT");
+    } catch (error) {
+      await upgrade.query("ROLLBACK");
+      throw error;
+    }
+  }
+  await upgrade.query(
+    "INSERT INTO product_lines(product_line_id,product_line_name,product_line_url_name,is_direct) VALUES(999999,'Synthetic recovery marker','synthetic-recovery-marker',false)",
+  );
+  const legacy = await snapshot(upgrade);
+  await migrate(upgradeName);
+  const upgraded = await snapshot(upgrade);
+  for (const [table, value] of Object.entries(legacy)) {
+    if (table !== "schema_migrations")
+      assert.deepEqual(upgraded[table], value, `Upgrade preserves ${table}`);
+  }
+  assert.equal(upgraded.schema_migrations.count, migrations.length);
+  const ids = Object.fromEntries(
+    [
+      "identity",
+      "inventory",
+      "evidence",
+      "scan",
+      "recommendation",
+      "preview",
+      "publication",
+    ].map((name) => [name, randomUUID()]),
+  );
+  const key = "a".repeat(64),
+    version = "b".repeat(64),
+    seller = "synthetic-recovery-fixture";
+  // Structural fixtures exercise the reference graph, not pricing accuracy or provider responses.
+  await upgrade.query(
+    "INSERT INTO slab_identities(id,grader,certificate_number) VALUES($1,'PSA','RECOVERY-FIXTURE')",
+    [ids.identity],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_inventory_accounts(seller) VALUES($1)",
+    [seller],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_inventory(id,seller,item_id,snapshot,source,state,identity_id,observed_at) VALUES($1,$2,'900000000077','{\"title\":\"Synthetic recovery fixture\"}','csv','active',$3,clock_timestamp())",
+    [ids.inventory, seller, ids.identity],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_supply_versions(hash,listing_key,payload) VALUES($1,'synthetic-supply','{\"synthetic\":true}')",
+    [version],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_supply_scans(id,source_key,provider,captured_at,complete,reported_count,stored_count,content_hash) VALUES($1,$2,'alt',clock_timestamp(),false,1,1,$3)",
+    [ids.scan, key, version],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_supply_observations(scan_id,listing_key,version_hash,position) VALUES($1,'synthetic-supply',$2,0)",
+    [ids.scan, version],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_evidence_refreshes(key,spec,state,run_id) VALUES($1,'{\"synthetic\":true}','idle',$2)",
+    [key, ids.evidence],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_evidence_revisions(id,key,payload,fetched_at,byte_count,observation_count,retained,supply_scan_id) VALUES($1,$2,'{\"synthetic\":true}',clock_timestamp(),18,1,true,$3)",
+    [ids.evidence, key, ids.scan],
+  );
+  await upgrade.query(
+    "UPDATE slab_evidence_refreshes SET latest_revision=$2 WHERE key=$1",
+    [key, ids.evidence],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_recommendations(id,input_key,slab_id,identity_revision,valuation_group_key,calculation) VALUES($1,$2,$3,1,'synthetic','{\"synthetic\":true}')",
+    [ids.recommendation, version, ids.identity],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_recommendation_evidence(recommendation_id,revision_id) VALUES($1,$2)",
+    [ids.recommendation, ids.evidence],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_price_overrides(recommendation_id,item_price,currency,note) VALUES($1,125,'USD','Synthetic reviewed ask')",
+    [ids.recommendation],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_publication_previews(id,inventory_id,recommendation_id,request,plan,expires_at) VALUES($1,$2,$3,'{}','{\"synthetic\":true}',clock_timestamp()+interval '5 minutes')",
+    [ids.preview, ids.inventory, ids.recommendation],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_publications(id,preview_id,seller,item_id,variation_key,mode,plan,state,write_started_at) VALUES($1,$2,$3,'900000000077','','live','{\"synthetic\":true}','reconcile',clock_timestamp())",
+    [ids.publication, ids.preview, seller],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_publication_events(publication_id,state,reason) VALUES($1,'reconcile','synthetic-uncertain-response')",
+    [ids.publication],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_maintenance_settings(seller,enabled) VALUES($1,true)",
+    [seller],
+  );
+  await upgrade.query(
+    "INSERT INTO slab_maintenance_items(inventory_id,inventory_revision,identity_revision,recommendation_id,outcome,reason,next_check_at,settings_revision) VALUES($1,1,1,$2,'review-required','synthetic',clock_timestamp(),1)",
+    [ids.inventory, ids.recommendation],
+  );
+  const before = await snapshot(upgrade);
+  const archive = (
+    await run(
+      "docker",
+      [
+        "exec",
+        container,
+        "pg_dump",
+        "-U",
+        base.username,
+        "--format=custom",
+        "--no-owner",
+        "--no-acl",
+        "--dbname",
+        upgradeName,
+      ],
+      { encoding: "buffer", maxBuffer: 16 * 1024 * 1024, timeout: 60_000 },
+    )
+  ).stdout;
+  await restore(restoreName, archive);
+  const restored = await connect(restoreName);
+  assert.deepEqual(
+    await snapshot(restored),
+    before,
+    "Every table and row must survive backup/restore",
+  );
+  await migrate(restoreName);
+  assert.deepEqual(
+    await snapshot(restored),
+    before,
+    "Migrations remain idempotent after restore",
+  );
+  await assert.rejects(
+    () =>
+      restored.query("DELETE FROM slab_evidence_revisions WHERE id=$1", [
+        ids.evidence,
+      ]),
+    (error) => error.code === "23503",
+    "Restored references still protect retained evidence",
+  );
+  await assert.rejects(
+    () =>
+      restored.query(
+        "INSERT INTO slab_publications(id,preview_id,seller,item_id,variation_key,mode,plan,state) VALUES($1,$2,$3,'900000000077','','live','{}','approved')",
+        [randomUUID(), ids.preview, seller],
+      ),
+    (error) => error.code === "23505",
+    "Unresolved publication still holds its listing after restore",
+  );
+  const next = (
+    await restored.query(
+      "INSERT INTO slab_publication_events(publication_id,state,reason) VALUES($1,'reconcile','synthetic-post-restore-check') RETURNING sequence",
+      [ids.publication],
+    )
+  ).rows[0].sequence;
+  assert.equal(
+    Number(next),
+    2,
+    "Audit sequence resumes without overwriting earlier events",
+  );
+  await restored.query(
+    "UPDATE slab_maintenance_settings SET enabled=false,revision=revision+1,lease_id=NULL,lease_until=NULL",
+  );
+  assert.equal(
+    (
+      await restored.query(
+        "SELECT count(*)::int AS n FROM slab_maintenance_settings WHERE enabled",
+      )
+    ).rows[0].n,
+    0,
+  );
+  assert.ok(
+    (
+      await restored.query(
+        "SELECT write_started_at FROM slab_publications WHERE id=$1 AND state='reconcile'",
+        [ids.publication],
+      )
+    ).rows[0].write_started_at,
+    "Pausing after restore does not erase a possible external write",
+  );
+  console.log(
+    `PASS ${migrations.length} fresh/idempotent migrations, upgrade from 23 preserving existing tables, ${Object.keys(before).length}-table backup/restore (${archive.length} archive bytes), retained evidence graph, manual ask, publication lock/sequence and maintenance pause`,
+  );
+} finally {
+  await Promise.allSettled(clients.map((client) => client.end()));
+  try {
+    for (const name of created.reverse()) {
+      assert.ok(
+        databaseNames.includes(name) &&
+          name.startsWith(prefix) &&
+          /^[a-z0-9_]+$/.test(name),
+      );
+      await admin.query(`DROP DATABASE "${name}" WITH (FORCE)`);
+    }
+  } finally {
+    await admin.end();
+  }
+}

--- a/docs/slab-preview-acceptance.md
+++ b/docs/slab-preview-acceptance.md
@@ -41,6 +41,8 @@ Structural gates enforce zero remote calls for the fixture cache workload, one r
 
 ## Build, migration and recovery checks
 
+The measurements below describe the preview-stage build through PR #47. Later checks cover [publication execution](slab-publication-review.md), [opt-in evidence maintenance](slab-evidence-maintenance.md), and a [33-migration backup/restore rehearsal](slab-recovery.md). The original performance figures have not been relabeled as measurements of those later stages.
+
 Host typecheck, offline test suite, production/worker build and targeted PostgreSQL integrations pass, including existing TCGplayer pricing/publication regression tests. Docker `npm ci` and production build pass on Node 20; existing MUI build warnings remain. No new runtime dependencies were added across these merged slab changes. No browser runtime is bundled.
 
 A fresh isolated Docker database applied all 31 migrations and served the slab and existing routes with zero provider connections and zero evidence jobs. Rerunning migrations was idempotent. A second isolated database upgraded from migrations 1–23 to 1–31 and retained a seeded existing marker row. These checks are not a production-data restore rehearsal. Expanded Docker exclusions keep `.env*`, research captures and Codex artifacts out of the build context; runtime inspection found no local environment or research files. Temporary validation containers/databases are removed after evaluation; existing development and production containers are untouched.

--- a/docs/slab-recovery.md
+++ b/docs/slab-recovery.md
@@ -1,0 +1,25 @@
+# Slab database recovery
+
+Slab data lives in the existing PostgreSQL database. Back up the whole database with the matching PostgreSQL `pg_dump` custom format and verify it with `pg_restore --single-transaction --exit-on-error` into a separate, empty database. Preserve access controls for backups because production backups can contain seller/provider credentials. The verification command below uses synthetic data only and never copies the development or production database.
+
+Before an actual backup or deployment, pause slab maintenance and stop its worker. Finish or record in-progress provider requests. Keep every publication with a possible write marked for reconciliation; stopping a worker does not prove that an external request failed. Back up after writers are stopped if the backup will serve as a rollback point.
+
+Restore inventory, identities, comp decisions, evidence, supply scans/versions, recommendations, overrides, previews, publication events and maintenance together. The evidence cache has circular latest-revision references and supply/recommendation links; selected table or data-only restores need additional care and are not the supported procedure here. Apply migrations before starting the new application. Pause restored maintenance settings before starting workers: a backup faithfully restores enabled settings too. Increment the settings revision and clear its lease when pausing, as the application's settings save does.
+
+Revalidate source connections and fresh inventory/evidence after recovery. For publications whose recorded write boundary was crossed, reconnect seller access and reconcile by reading the listing; never replay the write from the restored queue. A database restore cannot undo eBay changes. If eBay changes occurred after the backup, the restored audit can be incomplete: reconcile affected listings against current seller state and any newer audit backup before preparing another change. Native seller reconciliation remains blocked pending OAuth activation, so live publication is still unavailable.
+
+Application rollback can leave additive slab tables in place. Pause maintenance before returning to an older application build. Do not drop the audit or referenced evidence as a rollback mechanism. Normal TCGplayer routes and workers use their existing tables and do not depend on the new slab tables.
+
+## Reproducible local check
+
+With the development PostgreSQL container `tcgplayer-postgres-db` mapped to localhost:5433/tcgplayer_automation, run:
+
+```sh
+node app/features/ebay-slab-pricing/evaluation/verify-slab-recovery.mjs
+```
+
+The command rejects other database targets, verifies the container port, creates three randomly named disposable databases and removes only those databases in `finally`. It runs the real migration command for a fresh installation, an upgrade from migration 23, and idempotent reruns. It uses PostgreSQL's native dump/restore programs in the existing development container, keeps the synthetic archive in memory, and adds no production dependency or service.
+
+On September 6, 2026, against application commit `ec9146cda` and PostgreSQL 16.13, the check passed all 33 migrations. The upgrade preserved every existing table's row checksum. A 114,452-byte custom archive restored identical counts and checksums for all 43 tables, including immutable evidence/supply references, a reviewed ask, an unresolved publication and enabled maintenance. Foreign keys continued to protect referenced evidence; the unresolved publication still prevented a second approved intent; its audit sequence resumed at 2. Pausing restored maintenance preserved the possible-write record.
+
+These fixtures validate storage/recovery mechanics, not market evidence, live eBay behavior or a production-data restore. Existing service integration tests separately validate publication readback/recovery and maintenance leases. Production backup, deployment, native seller verification and full workflow acceptance remain part of #33.


### PR DESCRIPTION
Add a guarded, reproducible database recovery check using the existing local PostgreSQL container and native dump/restore tools. It validates fresh/idempotent migrations, upgrade from the pre-slab schema without changing existing rows, and complete synthetic backup/restore of the slab reference graph, manual ask, unresolved publication lock, audit sequence and maintenance state.

The check creates and removes only its three randomly named databases, keeps the archive in memory and adds no runtime dependency or production code. Recovery instructions explain pausing restored maintenance and reconciling possible external writes without replaying them. Related to #33; production restore/deployment and native seller acceptance remain open.

Validation passed twice: all 33 migrations and identical counts/checksums across 43 restored tables, plus foreign-key, uniqueness and sequence assertions. Adversarial review covered target isolation, cleanup, bounded subprocesses, reference completeness and external-write recovery semantics; the added retained-evidence constraint check passes, with no remaining actionable findings in this scope. Runtime test/build results remain those of #50 because this change only adds an offline verification script and documentation.
