### PR TITLE
Preserve inventory intake receipt history

### DIFF
--- a/app/core/clients/baseDomainClient.server.test.ts
+++ b/app/core/clients/baseDomainClient.server.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  ConcurrencyLimiter,
   RequestThrottler,
 } from "./baseDomainClient.server";
 import {
@@ -64,6 +65,33 @@ const testCases: TestCase[] = [
         { requestDelayMs: 400, learnedMinDelayMs: 200 },
         { requestDelayMs: 300, learnedMinDelayMs: 200 },
       ]);
+    },
+  },
+  {
+    name: "aborted requests leave limiter and throttle queues",
+    run: async () => {
+      const limiter = new ConcurrencyLimiter();
+      await limiter.acquire(1);
+      const limiterAbort = new AbortController();
+      const waitingForLimiter = limiter.acquire(1, limiterAbort.signal);
+      limiterAbort.abort();
+      await assert.rejects(waitingForLimiter, { name: "AbortError" });
+      limiter.release();
+      await limiter.acquire(1);
+      limiter.release();
+
+      const delayedStarts: Array<() => void> = [];
+      const throttler = new RequestThrottler(
+        DOMAIN_KEYS.MP_GATEWAY,
+        async () => createDomainConfig({ requestDelayMs: 1_000 }),
+        async () => undefined,
+        () => new Promise<void>((resolve) => delayedStarts.push(resolve)),
+      );
+      await throttler.waitToStart();
+      const throttleAbort = new AbortController();
+      const waitingForThrottle = throttler.waitToStart(throttleAbort.signal);
+      throttleAbort.abort();
+      await assert.rejects(waitingForThrottle, { name: "AbortError" });
     },
   },
 ];

--- a/app/core/clients/baseDomainClient.server.ts
+++ b/app/core/clients/baseDomainClient.server.ts
@@ -23,7 +23,12 @@ const RETRYABLE_STATUS_CODES = new Set([403, 429, 502, 503, 504]);
 export class RequestThrottler {
   private lastRequestStartTime = 0;
   private rateLimitedUntil = 0;
-  private readonly startQueue: Array<() => void> = [];
+  private readonly startQueue: Array<{
+    resolve: () => void;
+    reject: (error: Error) => void;
+    signal?: AbortSignal;
+    onAbort?: () => void;
+  }> = [];
   private isProcessingQueue = false;
   private consecutiveSuccesses = 0;
 
@@ -105,7 +110,10 @@ export class RequestThrottler {
    * Ensures requests are staggered by requestDelayMs, but allows up to
    * maxConcurrentRequests to be in-flight simultaneously.
    */
-  async waitToStart(): Promise<void> {
+  async waitToStart(signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
+      throw new DOMException("Request was aborted", "AbortError");
+    }
     // Wait out any active rate limit cooldown first
     const now = Date.now();
     if (this.rateLimitedUntil > now) {
@@ -115,12 +123,28 @@ export class RequestThrottler {
           waitTime / 1000,
         )}s...`,
       );
-      await this.sleep(waitTime);
+      await Promise.race([
+        this.sleep(waitTime),
+        new Promise<never>((_, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("Request was aborted", "AbortError")),
+            { once: true },
+          );
+        }),
+      ]);
     }
 
     // Queue this request and process sequentially to ensure proper staggering
-    await new Promise<void>((resolve) => {
-      this.startQueue.push(resolve);
+    await new Promise<void>((resolve, reject) => {
+      const entry: (typeof this.startQueue)[number] = { resolve, reject, signal };
+      entry.onAbort = () => {
+        const index = this.startQueue.indexOf(entry);
+        if (index >= 0) this.startQueue.splice(index, 1);
+        reject(new DOMException("Request was aborted", "AbortError"));
+      };
+      signal?.addEventListener("abort", entry.onAbort, { once: true });
+      this.startQueue.push(entry);
       void this.processQueue();
     });
   }
@@ -141,7 +165,13 @@ export class RequestThrottler {
 
       this.lastRequestStartTime = Date.now();
       const next = this.startQueue.shift();
-      next?.();
+      if (!next) continue;
+      if (next.onAbort) next.signal?.removeEventListener("abort", next.onAbort);
+      if (next.signal?.aborted) {
+        next.reject(new DOMException("Request was aborted", "AbortError"));
+      } else {
+        next.resolve();
+      }
     }
 
     this.isProcessingQueue = false;
@@ -162,23 +192,42 @@ export class RequestThrottler {
 // Concurrency Control (per-domain instance)
 // ============================================================================
 
-class ConcurrencyLimiter {
+export class ConcurrencyLimiter {
   private activeRequests = 0;
-  private readonly queue: Array<() => void> = [];
+  private readonly queue: Array<{
+    resolve: () => void;
+    reject: (error: Error) => void;
+    signal?: AbortSignal;
+    onAbort?: () => void;
+  }> = [];
 
-  async acquire(maxConcurrent: number): Promise<void> {
+  async acquire(maxConcurrent: number, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
+      throw new DOMException("Request was aborted", "AbortError");
+    }
     if (this.activeRequests < maxConcurrent) {
       this.activeRequests++;
       return;
     }
-    await new Promise<void>((resolve) => this.queue.push(resolve));
+    await new Promise<void>((resolve, reject) => {
+      const entry: (typeof this.queue)[number] = { resolve, reject, signal };
+      entry.onAbort = () => {
+        const index = this.queue.indexOf(entry);
+        if (index >= 0) this.queue.splice(index, 1);
+        reject(new DOMException("Request was aborted", "AbortError"));
+      };
+      signal?.addEventListener("abort", entry.onAbort, { once: true });
+      this.queue.push(entry);
+    });
     this.activeRequests++;
   }
 
   release(): void {
     this.activeRequests--;
     const next = this.queue.shift();
-    next?.();
+    if (!next) return;
+    if (next.onAbort) next.signal?.removeEventListener("abort", next.onAbort);
+    next.resolve();
   }
 }
 
@@ -252,7 +301,7 @@ export class DomainHttpClient {
   async get<TResponse, TParams = unknown>(
     path: string,
     params?: TParams,
-    options?: Pick<AxiosRequestConfig, "headers" | "responseType"> & {
+    options?: Pick<AxiosRequestConfig, "headers" | "responseType" | "timeout" | "signal"> & {
       retry?: boolean;
     },
   ): Promise<TResponse> {
@@ -264,6 +313,7 @@ export class DomainHttpClient {
         this.axiosClient.get<TResponse>(path, { params, ...requestOptions }),
       params ? { params } : undefined,
       retry ? MAX_RETRIES : 0,
+      requestOptions.signal as AbortSignal | undefined,
     );
   }
 
@@ -273,7 +323,7 @@ export class DomainHttpClient {
   async post<TResponse, TData = unknown>(
     path: string,
     data?: TData,
-    options?: Pick<AxiosRequestConfig, "headers" | "responseType"> & {
+    options?: Pick<AxiosRequestConfig, "headers" | "responseType" | "timeout" | "signal"> & {
       retry?: boolean;
     },
   ): Promise<TResponse> {
@@ -284,6 +334,7 @@ export class DomainHttpClient {
       () => this.axiosClient.post<TResponse>(path, data, requestOptions),
       data ? { data } : undefined,
       retry ? MAX_RETRIES : 0,
+      requestOptions.signal as AbortSignal | undefined,
     );
   }
 
@@ -296,6 +347,7 @@ export class DomainHttpClient {
     requestFn: () => Promise<AxiosResponse<T>>,
     logContext?: unknown,
     maxRetries: number = MAX_RETRIES,
+    signal?: AbortSignal,
   ): Promise<T> {
     // Get fresh config for each request execution (may have been updated by adaptive logic)
     const httpConfig = await getHttpConfig();
@@ -306,11 +358,14 @@ export class DomainHttpClient {
     let hasRecordedRateLimit = false;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      if (signal?.aborted) {
+        throw new DOMException("Request was aborted", "AbortError");
+      }
       domainConfig = await getDomainConfig(this.domainKey);
-      await this.limiter.acquire(domainConfig.maxConcurrentRequests);
+      await this.limiter.acquire(domainConfig.maxConcurrentRequests, signal);
 
       try {
-        await this.throttler.waitToStart();
+        await this.throttler.waitToStart(signal);
 
         if (attempt === 0) {
           console.log(

--- a/app/core/db/inventoryReceiptMigration.integration.test.ts
+++ b/app/core/db/inventoryReceiptMigration.integration.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import pg from "pg";
+import { getDatabaseUrl } from "./database.server";
+
+const migration = readFileSync(
+  new URL("../../../db/migrations/035_add_inventory_receipt_history.sql", import.meta.url),
+  "utf8",
+);
+const schema = `receipt_migration_${Date.now()}`;
+const client = new pg.Client({ connectionString: getDatabaseUrl() });
+
+await client.connect();
+try {
+  await client.query("BEGIN");
+  await client.query(`CREATE SCHEMA ${schema}`);
+  await client.query(`SET LOCAL search_path TO ${schema}`);
+  await client.query(`CREATE TABLE pending_inventory (
+    sku INTEGER PRIMARY KEY,
+    quantity INTEGER NOT NULL,
+    product_line_id INTEGER NOT NULL,
+    set_id INTEGER NOT NULL,
+    product_id INTEGER NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+  )`);
+  await client.query(`CREATE TABLE inventory_batches (
+    batch_number INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY
+  )`);
+  const originalCreatedAt = new Date("2025-01-02T03:04:05.000Z");
+  const originalUpdatedAt = new Date("2025-02-03T04:05:06.000Z");
+  await client.query(
+    `INSERT INTO pending_inventory
+      (sku, quantity, product_line_id, set_id, product_id, created_at, updated_at)
+    VALUES (7001, 12, 4, 5, 6, $1, $2)`,
+    [originalCreatedAt, originalUpdatedAt],
+  );
+
+  await client.query(migration);
+
+  const pending = await client.query(`SELECT * FROM pending_inventory WHERE sku = 7001`);
+  assert.equal(pending.rows[0]?.quantity, 12);
+  assert.equal(pending.rows[0]?.created_at.toISOString(), originalCreatedAt.toISOString());
+  assert.equal(pending.rows[0]?.updated_at.toISOString(), originalUpdatedAt.toISOString());
+
+  const receipt = await client.query(`SELECT * FROM inventory_receipts WHERE sku = 7001`);
+  assert.equal(receipt.rows[0]?.original_quantity, 12);
+  assert.equal(receipt.rows[0]?.intake_at, null);
+  assert.equal(receipt.rows[0]?.market_value, null);
+  assert.equal(receipt.rows[0]?.market_observed_at, null);
+  assert.equal(receipt.rows[0]?.market_calculated_at, null);
+  assert.equal(
+    new Date(receipt.rows[0]?.source_evidence.legacyPendingCreatedAt).toISOString(),
+    originalCreatedAt.toISOString(),
+  );
+  assert.equal(
+    new Date(receipt.rows[0]?.source_evidence.legacyPendingUpdatedAt).toISOString(),
+    originalUpdatedAt.toISOString(),
+  );
+
+  console.log("PASS legacy pending inventory migrates with unknown intake evidence");
+} finally {
+  await client.query("ROLLBACK");
+  await client.end();
+}

--- a/app/core/db/repositories/inventoryBatches.server.ts
+++ b/app/core/db/repositories/inventoryBatches.server.ts
@@ -55,6 +55,13 @@ interface CreateImportedBatchParams {
   items: CreateInventoryBatchItemInput[];
 }
 
+export class InventoryBatchRequestConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InventoryBatchRequestConflictError";
+  }
+}
+
 const batchSelect = `SELECT
   b.batch_number AS "batchNumber",
   b.status,
@@ -477,8 +484,32 @@ export const inventoryBatchesRepository = {
     );
   },
 
-  async createFromPendingInventory(): Promise<InventoryBatch | null> {
+  async createFromPendingInventory(
+    requestId: string,
+  ): Promise<InventoryBatch | null> {
     return withTransaction(async (client) => {
+      await execute(`SELECT pg_advisory_xact_lock(55, 0)`, [], client);
+
+      const repeated = await queryOne<{ batchNumber: number }>(
+        `SELECT batch_number AS "batchNumber"
+        FROM inventory_batch_intake_requests
+        WHERE request_id = $1`,
+        [requestId],
+        client,
+      );
+      if (repeated) {
+        const repeatedBatch = await inventoryBatchesRepository.findByBatchNumber(
+          repeated.batchNumber,
+          client,
+        );
+        if (!repeatedBatch) {
+          throw new InventoryBatchRequestConflictError(
+            `Request ID ${requestId} already created deleted batch ${repeated.batchNumber}`,
+          );
+        }
+        return repeatedBatch;
+      }
+
       const pendingRows = await query<{ sku: number }>(
         `SELECT sku
         FROM pending_inventory
@@ -493,16 +524,25 @@ export const inventoryBatchesRepository = {
       }
 
       const createdBatch = await queryOne<{ batchNumber: number }>(
-        `INSERT INTO inventory_batches (status, source_type, source_label)
-        VALUES ('pending', 'pending_inventory', 'Inventory Manager')
+        `INSERT INTO inventory_batches (
+          status, source_type, source_label, source_request_id
+        )
+        VALUES ('pending', 'pending_inventory', 'Inventory Manager', $1)
         RETURNING batch_number AS "batchNumber"`,
-        [],
+        [requestId],
         client,
       );
 
       if (!createdBatch) {
         throw new Error("Failed to create inventory batch");
       }
+
+      await execute(
+        `INSERT INTO inventory_batch_intake_requests (request_id, batch_number)
+        VALUES ($1, $2)`,
+        [requestId, createdBatch.batchNumber],
+        client,
+      );
 
       await execute(
         `INSERT INTO inventory_batch_items (
@@ -531,6 +571,32 @@ export const inventoryBatchesRepository = {
           created_at,
           updated_at
         FROM pending_inventory`,
+        [createdBatch.batchNumber],
+        client,
+      );
+
+      await execute(
+        `WITH adjusted_receipts AS (
+          SELECT
+            receipt.receipt_id,
+            receipt.original_quantity
+              + COALESCE(SUM(adjustment.quantity_delta), 0)::integer AS quantity
+          FROM inventory_receipts receipt
+          JOIN pending_inventory pending ON pending.sku = receipt.sku
+          LEFT JOIN inventory_receipt_adjustments adjustment
+            ON adjustment.receipt_id = receipt.receipt_id
+          WHERE NOT EXISTS (
+            SELECT 1 FROM inventory_receipt_batch_links existing_link
+            WHERE existing_link.receipt_id = receipt.receipt_id
+          )
+          GROUP BY receipt.receipt_id
+        )
+        INSERT INTO inventory_receipt_batch_links (
+          receipt_id, batch_number, linked_quantity
+        )
+        SELECT receipt_id, $1, quantity
+        FROM adjusted_receipts
+        WHERE quantity > 0`,
         [createdBatch.batchNumber],
         client,
       );

--- a/app/core/db/repositories/pendingInventory.server.integration.test.ts
+++ b/app/core/db/repositories/pendingInventory.server.integration.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import { execute, getPool, query, queryOne } from "../database.server";
+import {
+  PendingInventoryConflictError,
+  pendingInventoryRepository,
+} from "./pendingInventory.server";
+import {
+  InventoryBatchRequestConflictError,
+  inventoryBatchesRepository,
+} from "./inventoryBatches.server";
+
+const prefix = `receipt-test-${Date.now()}`;
+const sku = 9_100_001;
+const metadata = { productLineId: 1, setId: 2, productId: 3 };
+const market = {
+  marketValue: 4.25,
+  observedAt: new Date("2026-09-07T14:06:00.000Z"),
+  calculatedAt: new Date("2026-09-07T14:05:00.000Z"),
+  provenance: "tcgplayer_price_points" as const,
+};
+let batchNumber: number | null = null;
+
+try {
+  await pendingInventoryRepository.mutate({
+    type: "add",
+    requestId: `${prefix}-first`,
+    sku,
+    quantity: 2,
+    metadata,
+    intakeAt: new Date("2026-09-07T14:00:00.000Z"),
+    market,
+  });
+  const repeated = await pendingInventoryRepository.mutate({
+    type: "add",
+    requestId: `${prefix}-first`,
+    sku,
+    quantity: 2,
+    metadata,
+    intakeAt: new Date("2026-09-07T15:00:00.000Z"),
+    market: { ...market, marketValue: 999 },
+  });
+  assert.equal(repeated.repeated, true);
+  assert.equal(repeated.quantity, 2);
+
+  await pendingInventoryRepository.mutate({
+    type: "add",
+    requestId: `${prefix}-second`,
+    sku,
+    quantity: 3,
+    metadata,
+    intakeAt: new Date("2026-09-07T16:00:00.000Z"),
+    market: {
+      marketValue: null,
+      observedAt: null,
+      calculatedAt: null,
+      provenance: "tcgplayer_price_points_unavailable",
+    },
+  });
+
+  let pending = await pendingInventoryRepository.findAll();
+  assert.equal(pending.find((entry) => entry.sku === sku)?.quantity, 5);
+  let receipts = (await pendingInventoryRepository.findReceipts()).filter(
+    (receipt) => receipt.requestId.startsWith(prefix),
+  );
+  assert.equal(receipts.length, 2);
+  assert.deepEqual(receipts.map((receipt) => receipt.originalQuantity), [2, 3]);
+  assert.equal(receipts[0].marketValue, 4.25);
+  assert.equal(receipts[0].marketCalculatedAt?.toISOString(), market.calculatedAt.toISOString());
+  assert.equal(receipts[1].marketValue, null);
+  assert.equal(receipts[0].sellerKey, null);
+  await assert.rejects(
+    execute(
+      `UPDATE inventory_receipts SET market_value = 99 WHERE receipt_id = $1`,
+      [receipts[0].receiptId],
+    ),
+    /receipt evidence is immutable/i,
+  );
+  await execute(
+    `UPDATE inventory_receipts SET seller_key = 'seller-a' WHERE receipt_id = $1`,
+    [receipts[0].receiptId],
+  );
+  await assert.rejects(
+    execute(
+      `UPDATE inventory_receipts SET seller_key = 'seller-b' WHERE receipt_id = $1`,
+      [receipts[0].receiptId],
+    ),
+    /seller ownership cannot be reassigned/i,
+  );
+
+  await assert.rejects(
+    pendingInventoryRepository.mutate({
+      type: "add",
+      requestId: `${prefix}-first`,
+      sku,
+      quantity: 2,
+      metadata: { ...metadata, productId: 4 },
+      intakeAt: new Date(),
+      market,
+    }),
+    PendingInventoryConflictError,
+  );
+
+  await pendingInventoryRepository.mutate({
+    type: "set",
+    requestId: `${prefix}-correct`,
+    sku,
+    quantity: 4,
+    expectedQuantity: 5,
+    metadata,
+    intakeAt: new Date(),
+    market,
+  });
+  await assert.rejects(
+    pendingInventoryRepository.mutate({
+      type: "set",
+      requestId: `${prefix}-stale`,
+      sku,
+      quantity: 2,
+      expectedQuantity: 5,
+      metadata,
+      intakeAt: new Date(),
+      market,
+    }),
+    PendingInventoryConflictError,
+  );
+
+  await Promise.all([
+    pendingInventoryRepository.mutate({
+      type: "add",
+      requestId: `${prefix}-concurrent-a`,
+      sku,
+      quantity: 1,
+      metadata,
+      intakeAt: new Date(),
+      market,
+    }),
+    pendingInventoryRepository.mutate({
+      type: "add",
+      requestId: `${prefix}-concurrent-b`,
+      sku,
+      quantity: 1,
+      metadata,
+      intakeAt: new Date(),
+      market,
+    }),
+  ]);
+  pending = await pendingInventoryRepository.findAll();
+  assert.equal(pending.find((entry) => entry.sku === sku)?.quantity, 6);
+
+  const batchRequestId = `${prefix}-batch`;
+  const batch = await inventoryBatchesRepository.createFromPendingInventory(batchRequestId);
+  assert.ok(batch);
+  batchNumber = batch.batchNumber;
+  const repeatedBatch =
+    await inventoryBatchesRepository.createFromPendingInventory(batchRequestId);
+  assert.equal(repeatedBatch?.batchNumber, batchNumber);
+  assert.equal((await pendingInventoryRepository.findAll()).length, 0);
+
+  const linked = await queryOne<{ quantity: number }>(
+    `SELECT SUM(linked_quantity)::int AS quantity
+    FROM inventory_receipt_batch_links
+    WHERE batch_number = $1`,
+    [batchNumber],
+  );
+  assert.equal(linked?.quantity, 6);
+
+  await inventoryBatchesRepository.deleteBatch(batchNumber);
+  await pendingInventoryRepository.mutate({
+    type: "add",
+    requestId: `${prefix}-after-delete`,
+    sku,
+    quantity: 1,
+    metadata,
+    intakeAt: new Date(),
+    market,
+  });
+  await assert.rejects(
+    inventoryBatchesRepository.createFromPendingInventory(batchRequestId),
+    InventoryBatchRequestConflictError,
+  );
+  assert.equal((await pendingInventoryRepository.findAll())[0]?.quantity, 1);
+
+  await pendingInventoryRepository.mutate({
+    type: "clear",
+    requestId: `${prefix}-clear`,
+  });
+  assert.equal((await pendingInventoryRepository.findAll()).length, 0);
+  receipts = (await pendingInventoryRepository.findReceipts()).filter(
+    (receipt) => receipt.requestId.startsWith(prefix),
+  );
+  assert.equal(receipts.reduce((sum, receipt) => sum + receipt.originalQuantity, 0), 8);
+
+  const correctionTotal = await queryOne<{ quantity: number }>(
+    `SELECT COALESCE(SUM(adjustment.quantity_delta), 0)::int AS quantity
+    FROM inventory_receipt_adjustments adjustment
+    JOIN inventory_pending_mutations mutation
+      ON mutation.request_id = adjustment.mutation_request_id
+    WHERE mutation.request_id LIKE $1`,
+    [`${prefix}%`],
+  );
+  assert.equal(correctionTotal?.quantity, -2);
+
+  console.log("PASS inventory receipts conserve pending quantity, requests, and batch history");
+} finally {
+  await execute(
+    `DELETE FROM inventory_receipt_batch_links
+    WHERE receipt_id IN (SELECT receipt_id FROM inventory_receipts WHERE request_id LIKE $1)`,
+    [`${prefix}%`],
+  );
+  await execute(
+    `DELETE FROM inventory_receipt_adjustments
+    WHERE mutation_request_id LIKE $1`,
+    [`${prefix}%`],
+  );
+  await execute(`DELETE FROM inventory_receipts WHERE request_id LIKE $1`, [`${prefix}%`]);
+  await execute(`DELETE FROM inventory_pending_mutations WHERE request_id LIKE $1`, [`${prefix}%`]);
+  await execute(`DELETE FROM inventory_batch_intake_requests WHERE request_id LIKE $1`, [`${prefix}%`]);
+  if (batchNumber !== null) {
+    await execute(`DELETE FROM inventory_batches WHERE batch_number = $1`, [batchNumber]);
+  }
+  await execute(`DELETE FROM pending_inventory WHERE sku = $1`, [sku]);
+  await getPool().end();
+}

--- a/app/core/db/repositories/pendingInventory.server.ts
+++ b/app/core/db/repositories/pendingInventory.server.ts
@@ -1,11 +1,291 @@
 import type { PendingInventoryEntry } from "~/features/pending-inventory/types/pendingInventory";
-import { execute, query, type Queryable } from "../database.server";
+import { reducePendingReceipts } from "~/features/inventory-history/domain/receiptBalances";
+import type {
+  InventoryReceipt,
+  PendingInventoryMutation,
+  PendingInventoryMutationResult,
+} from "~/features/inventory-history/types/inventoryReceipt";
+import {
+  execute,
+  query,
+  queryOne,
+  withTransaction,
+  type Queryable,
+} from "../database.server";
 
-type PendingInventoryRow = PendingInventoryEntry;
+type StoredMutation = {
+  requestId: string;
+  mutationType: PendingInventoryMutation["type"];
+  sku: number | null;
+  requestedQuantity: number | null;
+  expectedQuantity: number | null;
+  productLineId: number | null;
+  setId: number | null;
+  productId: number | null;
+  quantityDelta: number;
+  resultingQuantity: number;
+};
+
+type PendingReceiptBalance = {
+  receiptId: number;
+  sku: number;
+  quantity: number;
+};
+
+export class PendingInventoryConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PendingInventoryConflictError";
+  }
+}
+
+const mutationSelect = `SELECT
+  request_id AS "requestId",
+  mutation_type AS "mutationType",
+  sku,
+  requested_quantity AS "requestedQuantity",
+  expected_quantity AS "expectedQuantity",
+  product_line_id AS "productLineId",
+  set_id AS "setId",
+  product_id AS "productId",
+  quantity_delta AS "quantityDelta",
+  resulting_quantity AS "resultingQuantity"
+FROM inventory_pending_mutations`;
+
+const pendingReceiptBalanceQuery = `WITH adjusted_receipts AS (
+  SELECT
+    receipt.receipt_id AS "receiptId",
+    receipt.sku,
+    receipt.intake_at AS "intakeAt",
+    receipt.recorded_at AS "recordedAt",
+    receipt.original_quantity
+      + COALESCE(SUM(adjustment.quantity_delta), 0)::integer AS adjusted_quantity
+  FROM inventory_receipts receipt
+  JOIN pending_inventory pending ON pending.sku = receipt.sku
+  LEFT JOIN inventory_receipt_adjustments adjustment
+    ON adjustment.receipt_id = receipt.receipt_id
+  WHERE NOT EXISTS (
+    SELECT 1 FROM inventory_receipt_batch_links linked
+    WHERE linked.receipt_id = receipt.receipt_id
+  )
+  GROUP BY receipt.receipt_id
+), receipt_balances AS (
+  SELECT
+    receipt."receiptId",
+    receipt.sku,
+    receipt."intakeAt",
+    receipt."recordedAt",
+    receipt.adjusted_quantity
+      - COALESCE(SUM(link.linked_quantity), 0)::integer AS quantity
+  FROM adjusted_receipts receipt
+  LEFT JOIN inventory_receipt_batch_links link
+    ON link.receipt_id = receipt."receiptId"
+  GROUP BY
+    receipt."receiptId",
+    receipt.sku,
+    receipt."intakeAt",
+    receipt."recordedAt",
+    receipt.adjusted_quantity
+)
+SELECT "receiptId", sku, quantity, "intakeAt", "recordedAt"
+FROM receipt_balances
+WHERE quantity > 0`;
+
+function requestQuantity(mutation: PendingInventoryMutation): number | null {
+  return mutation.type === "clear" ? null : mutation.quantity;
+}
+
+function requestExpectedQuantity(
+  mutation: PendingInventoryMutation,
+): number | null {
+  return mutation.type === "set" ? mutation.expectedQuantity : null;
+}
+
+function assertSameRequest(
+  stored: StoredMutation,
+  mutation: PendingInventoryMutation,
+): void {
+  const sku = mutation.type === "clear" ? null : mutation.sku;
+  const metadata = mutation.type === "clear" ? null : mutation.metadata;
+  if (
+    stored.mutationType !== mutation.type ||
+    stored.sku !== sku ||
+    stored.requestedQuantity !== requestQuantity(mutation) ||
+    stored.expectedQuantity !== requestExpectedQuantity(mutation) ||
+    stored.productLineId !== (metadata?.productLineId ?? null) ||
+    stored.setId !== (metadata?.setId ?? null) ||
+    stored.productId !== (metadata?.productId ?? null)
+  ) {
+    throw new PendingInventoryConflictError(
+      `Request ID ${mutation.requestId} was already used for a different inventory mutation`,
+    );
+  }
+}
+
+async function lockInventory(executor: Queryable): Promise<void> {
+  await execute(`SELECT pg_advisory_xact_lock(55, 0)`, [], executor);
+}
+
+async function findStoredMutation(
+  requestId: string,
+  executor: Queryable,
+): Promise<StoredMutation | null> {
+  return queryOne<StoredMutation>(
+    `${mutationSelect} WHERE request_id = $1`,
+    [requestId],
+    executor,
+  );
+}
+
+async function insertMutation(
+  mutation: PendingInventoryMutation,
+  quantityDelta: number,
+  resultingQuantity: number,
+  executor: Queryable,
+): Promise<void> {
+  await execute(
+    `INSERT INTO inventory_pending_mutations (
+      request_id,
+      mutation_type,
+      sku,
+      requested_quantity,
+      expected_quantity,
+      product_line_id,
+      set_id,
+      product_id,
+      quantity_delta,
+      resulting_quantity
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+    [
+      mutation.requestId,
+      mutation.type,
+      mutation.type === "clear" ? null : mutation.sku,
+      requestQuantity(mutation),
+      requestExpectedQuantity(mutation),
+      mutation.type === "clear" ? null : mutation.metadata.productLineId,
+      mutation.type === "clear" ? null : mutation.metadata.setId,
+      mutation.type === "clear" ? null : mutation.metadata.productId,
+      quantityDelta,
+      resultingQuantity,
+    ],
+    executor,
+  );
+}
+
+async function insertReceipt(
+  mutation: Extract<PendingInventoryMutation, { type: "add" | "set" }>,
+  quantity: number,
+  executor: Queryable,
+): Promise<void> {
+  await execute(
+    `INSERT INTO inventory_receipts (
+      request_id,
+      sku,
+      original_quantity,
+      product_line_id,
+      set_id,
+      product_id,
+      intake_at,
+      market_value,
+      market_observed_at,
+      market_calculated_at,
+      market_provenance,
+      source_evidence
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb)`,
+    [
+      mutation.requestId,
+      mutation.sku,
+      quantity,
+      mutation.metadata.productLineId,
+      mutation.metadata.setId,
+      mutation.metadata.productId,
+      mutation.intakeAt,
+      mutation.market.marketValue,
+      mutation.market.observedAt,
+      mutation.market.calculatedAt,
+      mutation.market.provenance,
+      JSON.stringify({ source: "inventory_manager" }),
+    ],
+    executor,
+  );
+}
+
+async function findPendingReceiptBalances(
+  executor: Queryable,
+  sku?: number,
+): Promise<PendingReceiptBalance[]> {
+  return query<PendingReceiptBalance>(
+    `${pendingReceiptBalanceQuery}
+    ${sku === undefined ? "" : "AND sku = $1"}
+    ORDER BY "intakeAt" DESC NULLS LAST, "recordedAt" DESC, "receiptId" DESC`,
+    sku === undefined ? [] : [sku],
+    executor,
+  );
+}
+
+async function applyRemoval(
+  requestId: string,
+  quantity: number,
+  reason: "correction" | "clear",
+  executor: Queryable,
+  sku?: number,
+): Promise<void> {
+  const receipts = await findPendingReceiptBalances(executor, sku);
+  const adjustments = reducePendingReceipts(receipts, quantity);
+
+  for (const adjustment of adjustments) {
+    await execute(
+      `INSERT INTO inventory_receipt_adjustments (
+        receipt_id,
+        mutation_request_id,
+        quantity_delta,
+        reason
+      ) VALUES ($1, $2, $3, $4)`,
+      [adjustment.receiptId, requestId, adjustment.quantityDelta, reason],
+      executor,
+    );
+  }
+}
+
+async function findPendingEntry(
+  sku: number,
+  executor: Queryable,
+): Promise<PendingInventoryEntry | null> {
+  return queryOne<PendingInventoryEntry>(
+    `SELECT
+      sku,
+      quantity,
+      product_line_id AS "productLineId",
+      set_id AS "setId",
+      product_id AS "productId",
+      created_at AS "createdAt",
+      updated_at AS "updatedAt"
+    FROM pending_inventory
+    WHERE sku = $1`,
+    [sku],
+    executor,
+  );
+}
+
+function assertMatchingMetadata(
+  existing: PendingInventoryEntry | null,
+  mutation: Exclude<PendingInventoryMutation, { type: "clear" }>,
+): void {
+  if (
+    existing &&
+    (existing.productLineId !== mutation.metadata.productLineId ||
+      existing.setId !== mutation.metadata.setId ||
+      existing.productId !== mutation.metadata.productId)
+  ) {
+    throw new PendingInventoryConflictError(
+      `SKU ${mutation.sku} already has different pending product metadata`,
+    );
+  }
+}
 
 export const pendingInventoryRepository = {
   async findAll(executor?: Queryable): Promise<PendingInventoryEntry[]> {
-    return query<PendingInventoryRow>(
+    return query<PendingInventoryEntry>(
       `SELECT
         sku,
         quantity,
@@ -21,47 +301,137 @@ export const pendingInventoryRepository = {
     );
   },
 
-  async clearAll(executor?: Queryable): Promise<number> {
-    return execute(`DELETE FROM pending_inventory`, [], executor);
+  async mutate(
+    mutation: PendingInventoryMutation,
+  ): Promise<PendingInventoryMutationResult> {
+    return withTransaction(async (client) => {
+      await lockInventory(client);
+
+      const stored = await findStoredMutation(mutation.requestId, client);
+      if (stored) {
+        assertSameRequest(stored, mutation);
+        return {
+          requestId: stored.requestId,
+          quantity: stored.resultingQuantity,
+          quantityDelta: stored.quantityDelta,
+          repeated: true,
+        };
+      }
+
+      if (mutation.type === "clear") {
+        const entries = await pendingInventoryRepository.findAll(client);
+        const total = entries.reduce((sum, entry) => sum + entry.quantity, 0);
+        await insertMutation(mutation, -total, 0, client);
+        if (total > 0) {
+          await applyRemoval(mutation.requestId, total, "clear", client);
+        }
+        await execute(`DELETE FROM pending_inventory`, [], client);
+        return {
+          requestId: mutation.requestId,
+          quantity: 0,
+          quantityDelta: -total,
+          repeated: false,
+        };
+      }
+
+      const existing = await findPendingEntry(mutation.sku, client);
+      assertMatchingMetadata(existing, mutation);
+      const current = existing?.quantity ?? 0;
+      let delta: number;
+
+      if (mutation.type === "add") {
+        delta = mutation.quantity;
+      } else if (mutation.type === "remove") {
+        delta = -mutation.quantity;
+      } else {
+        if (current !== mutation.expectedQuantity) {
+          throw new PendingInventoryConflictError(
+            `Pending quantity changed from ${mutation.expectedQuantity} to ${current}; reload before replacing it`,
+          );
+        }
+        delta = mutation.quantity - current;
+      }
+
+      const resultingQuantity = current + delta;
+      if (resultingQuantity < 0) {
+        throw new PendingInventoryConflictError(
+          `Cannot remove ${Math.abs(delta)} from pending quantity ${current}`,
+        );
+      }
+
+      await insertMutation(mutation, delta, resultingQuantity, client);
+
+      if (delta > 0) {
+        if (mutation.type === "remove") {
+          throw new Error("Remove mutations cannot add inventory");
+        }
+        await insertReceipt(mutation, delta, client);
+      } else if (delta < 0) {
+        await applyRemoval(
+          mutation.requestId,
+          -delta,
+          "correction",
+          client,
+          mutation.sku,
+        );
+      }
+
+      if (resultingQuantity === 0) {
+        await execute(`DELETE FROM pending_inventory WHERE sku = $1`, [mutation.sku], client);
+      } else if (existing) {
+        await execute(
+          `UPDATE pending_inventory
+          SET quantity = $2, updated_at = NOW()
+          WHERE sku = $1`,
+          [mutation.sku, resultingQuantity],
+          client,
+        );
+      } else {
+        await execute(
+          `INSERT INTO pending_inventory (
+            sku, quantity, product_line_id, set_id, product_id, created_at, updated_at
+          ) VALUES ($1, $2, $3, $4, $5, NOW(), NOW())`,
+          [
+            mutation.sku,
+            resultingQuantity,
+            mutation.metadata.productLineId,
+            mutation.metadata.setId,
+            mutation.metadata.productId,
+          ],
+          client,
+        );
+      }
+
+      return {
+        requestId: mutation.requestId,
+        quantity: resultingQuantity,
+        quantityDelta: delta,
+        repeated: false,
+      };
+    });
   },
 
-  async removeBySku(sku: number, executor?: Queryable): Promise<number> {
-    return execute(
-      `DELETE FROM pending_inventory WHERE sku = $1`,
-      [sku],
-      executor,
-    );
-  },
-
-  async upsert(
-    entry: PendingInventoryEntry,
-    executor?: Queryable,
-  ): Promise<void> {
-    await execute(
-      `INSERT INTO pending_inventory (
+  async findReceipts(executor?: Queryable): Promise<InventoryReceipt[]> {
+    return query<InventoryReceipt>(
+      `SELECT
+        receipt_id AS "receiptId",
+        request_id AS "requestId",
         sku,
-        quantity,
-        product_line_id,
-        set_id,
-        product_id,
-        created_at,
-        updated_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7)
-      ON CONFLICT (sku) DO UPDATE SET
-        quantity = EXCLUDED.quantity,
-        product_line_id = EXCLUDED.product_line_id,
-        set_id = EXCLUDED.set_id,
-        product_id = EXCLUDED.product_id,
-        updated_at = EXCLUDED.updated_at`,
-      [
-        entry.sku,
-        entry.quantity,
-        entry.productLineId,
-        entry.setId,
-        entry.productId,
-        entry.createdAt,
-        entry.updatedAt,
-      ],
+        original_quantity AS "originalQuantity",
+        product_line_id AS "productLineId",
+        set_id AS "setId",
+        product_id AS "productId",
+        seller_key AS "sellerKey",
+        intake_at AS "intakeAt",
+        recorded_at AS "recordedAt",
+        market_value::float8 AS "marketValue",
+        market_observed_at AS "marketObservedAt",
+        market_calculated_at AS "marketCalculatedAt",
+        market_provenance AS "marketProvenance",
+        source_evidence AS "sourceEvidence"
+      FROM inventory_receipts
+      ORDER BY receipt_id`,
+      [],
       executor,
     );
   },
@@ -72,13 +442,25 @@ export const pendingInventoryRepository = {
     setId: number,
     executor?: Queryable,
   ): Promise<number> {
-    return execute(
+    const updated = await execute(
       `UPDATE pending_inventory
-      SET set_id = $1,
-          updated_at = NOW()
+      SET set_id = $1, updated_at = NOW()
       WHERE product_id = $2 AND product_line_id = $3`,
       [setId, productId, productLineId],
       executor,
     );
+    await execute(
+      `UPDATE inventory_receipts receipt
+      SET set_id = $1
+      WHERE receipt.product_id = $2
+        AND receipt.product_line_id = $3
+        AND NOT EXISTS (
+          SELECT 1 FROM inventory_receipt_batch_links link
+          WHERE link.receipt_id = receipt.receipt_id
+        )`,
+      [setId, productId, productLineId],
+      executor,
+    );
+    return updated;
   },
 };

--- a/app/features/inventory-history/domain/receiptBalances.test.ts
+++ b/app/features/inventory-history/domain/receiptBalances.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { reducePendingReceipts } from "./receiptBalances";
+
+assert.deepEqual(
+  reducePendingReceipts(
+    [
+      { receiptId: 3, quantity: 2 },
+      { receiptId: 2, quantity: 1 },
+      { receiptId: 1, quantity: 4 },
+    ],
+    5,
+  ),
+  [
+    { receiptId: 3, quantityDelta: -2 },
+    { receiptId: 2, quantityDelta: -1 },
+    { receiptId: 1, quantityDelta: -2 },
+  ],
+);
+assert.deepEqual(reducePendingReceipts([{ receiptId: 1, quantity: 1 }], 0), []);
+assert.throws(
+  () => reducePendingReceipts([{ receiptId: 1, quantity: 1 }], 2),
+  /more than the pending quantity/,
+);
+
+console.log("PASS pending receipt reductions preserve receipt quantities");

--- a/app/features/inventory-history/domain/receiptBalances.ts
+++ b/app/features/inventory-history/domain/receiptBalances.ts
@@ -1,0 +1,46 @@
+export type ReceiptBalance = {
+  receiptId: number;
+  quantity: number;
+};
+
+export type ReceiptAdjustment = {
+  receiptId: number;
+  quantityDelta: number;
+};
+
+export function reducePendingReceipts(
+  receiptsNewestFirst: readonly ReceiptBalance[],
+  quantityToRemove: number,
+): ReceiptAdjustment[] {
+  if (!Number.isInteger(quantityToRemove) || quantityToRemove < 0) {
+    throw new Error("Quantity to remove must be a non-negative integer");
+  }
+
+  const available = receiptsNewestFirst.reduce(
+    (total, receipt) => total + receipt.quantity,
+    0,
+  );
+  if (quantityToRemove > available) {
+    throw new Error("Cannot remove more than the pending quantity");
+  }
+
+  let remaining = quantityToRemove;
+  const adjustments: ReceiptAdjustment[] = [];
+
+  for (const receipt of receiptsNewestFirst) {
+    if (remaining === 0) {
+      break;
+    }
+
+    const removed = Math.min(receipt.quantity, remaining);
+    if (removed > 0) {
+      adjustments.push({
+        receiptId: receipt.receiptId,
+        quantityDelta: -removed,
+      });
+      remaining -= removed;
+    }
+  }
+
+  return adjustments;
+}

--- a/app/features/inventory-history/types/inventoryReceipt.ts
+++ b/app/features/inventory-history/types/inventoryReceipt.ts
@@ -1,0 +1,74 @@
+export type InventoryMarketObservation = {
+  marketValue: number | null;
+  observedAt: Date | null;
+  calculatedAt: Date | null;
+  provenance: "tcgplayer_price_points" | "tcgplayer_price_points_unavailable";
+};
+
+export type InventoryReceipt = {
+  receiptId: number;
+  requestId: string;
+  sku: number;
+  originalQuantity: number;
+  productLineId: number;
+  setId: number;
+  productId: number;
+  sellerKey: string | null;
+  intakeAt: Date | null;
+  recordedAt: Date;
+  marketValue: number | null;
+  marketObservedAt: Date | null;
+  marketCalculatedAt: Date | null;
+  marketProvenance: string;
+  sourceEvidence: Record<string, unknown> | null;
+};
+
+export type PendingInventoryMetadata = {
+  productLineId: number;
+  setId: number;
+  productId: number;
+};
+
+type PendingMutationIdentity = {
+  requestId: string;
+  sku: number;
+  metadata: PendingInventoryMetadata;
+};
+
+export type AddPendingInventory = PendingMutationIdentity & {
+  type: "add";
+  quantity: number;
+  intakeAt: Date;
+  market: InventoryMarketObservation;
+};
+
+export type RemovePendingInventory = PendingMutationIdentity & {
+  type: "remove";
+  quantity: number;
+};
+
+export type SetPendingInventory = PendingMutationIdentity & {
+  type: "set";
+  quantity: number;
+  expectedQuantity: number;
+  intakeAt: Date;
+  market: InventoryMarketObservation;
+};
+
+export type ClearPendingInventory = {
+  type: "clear";
+  requestId: string;
+};
+
+export type PendingInventoryMutation =
+  | AddPendingInventory
+  | RemovePendingInventory
+  | SetPendingInventory
+  | ClearPendingInventory;
+
+export type PendingInventoryMutationResult = {
+  requestId: string;
+  quantity: number;
+  quantityDelta: number;
+  repeated: boolean;
+};

--- a/app/features/inventory-management/components/InventoryEntryTable.tsx
+++ b/app/features/inventory-management/components/InventoryEntryTable.tsx
@@ -45,6 +45,7 @@ import {
   getQuantityKeyboardAction,
   type QuantityNavigationDirection,
 } from "./quantityKeyboard";
+import { finishQuantityEdit } from "../services/inventoryQuantityEdit";
 
 interface SkuWithDisplayInfo extends Sku {
   cardNumber?: string | null;
@@ -98,9 +99,15 @@ type AutosizedColumnField = "setName" | "sku";
 interface InventoryEntryTableProps {
   skus: SkuWithDisplayInfo[];
   pendingInventory: PendingInventoryEntry[];
-  onUpdateQuantity: (
+  onAdjustQuantity: (
+    sku: number,
+    quantityDelta: number,
+    metadata: { productLineId: number; setId: number; productId: number },
+  ) => void;
+  onSetQuantity: (
     sku: number,
     quantity: number,
+    expectedQuantity: number,
     metadata: { productLineId: number; setId: number; productId: number },
   ) => void;
   searchScope: "set" | "allSets";
@@ -263,7 +270,11 @@ interface QuantityGridCellProps {
   activeSku: SkuWithDisplayInfo | null;
   currentQty: number;
   selectedCondition: InventorySelectableCondition;
-  onQuantityChange: (sku: number, value: string) => void;
+  onQuantityCommit: (
+    sku: number,
+    quantity: number,
+    expectedQuantity: number,
+  ) => void;
   onQuickAdd: (
     activeSku: SkuWithDisplayInfo | null,
     amount: number,
@@ -287,7 +298,7 @@ const QuantityGridCell = React.memo(
     activeSku,
     currentQty,
     selectedCondition,
-    onQuantityChange,
+    onQuantityCommit,
     onQuickAdd,
     onFocusSearchInput,
     onFocusAdjacentQuantityInput,
@@ -298,6 +309,9 @@ const QuantityGridCell = React.memo(
     const quantityInputRef = useRef<HTMLInputElement | null>(null);
     const untouchedSinceFocusRef = useRef(true);
     const shouldReselectAfterSyncRef = useRef(false);
+    const editBaselineRef = useRef(currentQty);
+    const typedSinceFocusRef = useRef(false);
+    const editingSkuRef = useRef(activeSku?.sku);
 
     const selectQuantityInput = useCallback(() => {
       const input = quantityInputRef.current;
@@ -321,6 +335,17 @@ const QuantityGridCell = React.memo(
     );
 
     useEffect(() => {
+      if (editingSkuRef.current !== activeSku?.sku) {
+        editingSkuRef.current = activeSku?.sku;
+        typedSinceFocusRef.current = false;
+        editBaselineRef.current = currentQty;
+        setDisplayValue(currentQty.toString());
+        return;
+      }
+      if (typedSinceFocusRef.current) {
+        return;
+      }
+      editBaselineRef.current = currentQty;
       setDisplayValue(currentQty.toString());
 
       if (shouldReselectAfterSyncRef.current) {
@@ -337,8 +362,31 @@ const QuantityGridCell = React.memo(
       );
     }
 
+    const commitTypedQuantity = () => {
+      if (!typedSinceFocusRef.current) return;
+      typedSinceFocusRef.current = false;
+      const result = finishQuantityEdit(
+        activeSku.sku,
+        displayValue,
+        editBaselineRef.current,
+        true,
+      );
+      setDisplayValue(result.displayValue);
+      if (result.commit) {
+        onQuantityCommit(
+          result.commit.sku,
+          result.commit.quantity,
+          result.commit.expectedQuantity,
+        );
+      }
+      editBaselineRef.current = Number(result.displayValue);
+    };
+
     const applyKeyboardQuantityDelta = (amount: number) => {
-      const nextQty = Math.max(0, currentQty + amount);
+      const displayed = Number.parseInt(displayValue, 10);
+      const startingQuantity = Number.isFinite(displayed) ? displayed : currentQty;
+      commitTypedQuantity();
+      const nextQty = Math.max(0, startingQuantity + amount);
       untouchedSinceFocusRef.current = false;
       shouldReselectAfterSyncRef.current = true;
       setDisplayValue(nextQty.toString());
@@ -369,11 +417,13 @@ const QuantityGridCell = React.memo(
       event.stopPropagation();
 
       if (action.type === "change-condition") {
+        commitTypedQuantity();
         onChangeCondition(action.direction);
         return;
       }
 
       if (action.type === "move-focus") {
+        commitTypedQuantity();
         onFocusAdjacentQuantityInput(rowId, action.direction);
         return;
       }
@@ -382,6 +432,8 @@ const QuantityGridCell = React.memo(
         if (action.incrementQuantity) {
           untouchedSinceFocusRef.current = false;
           onQuickAdd(activeSku, 1, false);
+        } else {
+          commitTypedQuantity();
         }
 
         onFocusSearchInput();
@@ -396,7 +448,11 @@ const QuantityGridCell = React.memo(
         <Button
           size="small"
           onClick={() => {
-            const nextQty = Math.max(0, currentQty - 1);
+            const displayed = Number.parseInt(displayValue, 10);
+            const nextQty = Math.max(
+              0,
+              (Number.isFinite(displayed) ? displayed : currentQty) - 1,
+            );
             setDisplayValue(nextQty.toString());
             onQuickAdd(activeSku, -1);
           }}
@@ -414,14 +470,17 @@ const QuantityGridCell = React.memo(
           inputRef={handleQuantityInputRef}
           onFocus={() => {
             untouchedSinceFocusRef.current = true;
+            typedSinceFocusRef.current = false;
+            editBaselineRef.current = currentQty;
             selectQuantityInput();
           }}
+          onBlur={commitTypedQuantity}
           onKeyDown={handleQuantityKeyDown}
           onChange={(event) => {
             const nextValue = event.target.value;
             untouchedSinceFocusRef.current = false;
+            typedSinceFocusRef.current = true;
             setDisplayValue(nextValue);
-            onQuantityChange(activeSku.sku, nextValue);
           }}
           inputProps={{
             min: 0,
@@ -433,7 +492,8 @@ const QuantityGridCell = React.memo(
         <Button
           size="small"
           onClick={() => {
-            const nextQty = currentQty + 1;
+            const displayed = Number.parseInt(displayValue, 10);
+            const nextQty = (Number.isFinite(displayed) ? displayed : currentQty) + 1;
             setDisplayValue(nextQty.toString());
             onQuickAdd(activeSku, 1);
           }}
@@ -451,7 +511,7 @@ const QuantityGridCell = React.memo(
     previousProps.activeSku === nextProps.activeSku &&
     previousProps.currentQty === nextProps.currentQty &&
     previousProps.selectedCondition === nextProps.selectedCondition &&
-    previousProps.onQuantityChange === nextProps.onQuantityChange &&
+    previousProps.onQuantityCommit === nextProps.onQuantityCommit &&
     previousProps.onQuickAdd === nextProps.onQuickAdd &&
     previousProps.onFocusSearchInput === nextProps.onFocusSearchInput &&
     previousProps.onFocusAdjacentQuantityInput ===
@@ -465,7 +525,8 @@ export const InventoryEntryTable: React.FC<InventoryEntryTableProps> =
     ({
       skus,
       pendingInventory,
-      onUpdateQuantity,
+      onAdjustQuantity,
+      onSetQuantity,
       searchScope,
       allSetsSearchTerm,
       selectedCondition,
@@ -877,18 +938,16 @@ export const InventoryEntryTable: React.FC<InventoryEntryTableProps> =
         return getPendingQuantity(pendingInventoryRef.current, sku);
       }, []);
 
-      const handleQuantityChange = useCallback(
-        (sku: number, value: string) => {
-          const numValue = parseInt(value) || 0;
-
+      const handleQuantityCommit = useCallback(
+        (sku: number, quantity: number, expectedQuantity: number) => {
           try {
             const metadata = getSkuMetadata(sku);
-            onUpdateQuantity(sku, numValue, metadata);
+            onSetQuantity(sku, quantity, expectedQuantity, metadata);
           } catch (error) {
             console.error("Failed to get SKU metadata:", error);
           }
         },
-        [onUpdateQuantity, getSkuMetadata],
+        [onSetQuantity, getSkuMetadata],
       );
 
       const handleQuickAdd = useCallback(
@@ -901,12 +960,9 @@ export const InventoryEntryTable: React.FC<InventoryEntryTableProps> =
             return;
           }
 
-          const currentQty = getCurrentPendingQuantity(activeSku.sku);
-          const newQty = Math.max(0, currentQty + amount);
-
           try {
             const metadata = getSkuMetadata(activeSku.sku);
-            onUpdateQuantity(activeSku.sku, newQty, metadata);
+            onAdjustQuantity(activeSku.sku, amount, metadata);
           } catch (error) {
             console.error("Failed to get SKU metadata:", error);
           }
@@ -920,7 +976,7 @@ export const InventoryEntryTable: React.FC<InventoryEntryTableProps> =
             }, 0);
           }
         },
-        [getCurrentPendingQuantity, onUpdateQuantity, getSkuMetadata],
+        [onAdjustQuantity, getSkuMetadata],
       );
 
       const CustomToolbar = () => {
@@ -1148,7 +1204,7 @@ export const InventoryEntryTable: React.FC<InventoryEntryTableProps> =
                   activeSku={activeSku}
                   currentQty={currentQty}
                   selectedCondition={selectedCondition}
-                onQuantityChange={handleQuantityChange}
+                onQuantityCommit={handleQuantityCommit}
                 onQuickAdd={handleQuickAdd}
                 onFocusSearchInput={focusSearchInput}
                 onFocusAdjacentQuantityInput={focusAdjacentQuantityInput}
@@ -1182,7 +1238,7 @@ export const InventoryEntryTable: React.FC<InventoryEntryTableProps> =
       focusAdjacentQuantityInput,
       focusSearchInput,
       getActiveSku,
-      handleQuantityChange,
+      handleQuantityCommit,
       handleQuickAdd,
       handleThumbnailClick,
       getCurrentPendingQuantity,

--- a/app/features/inventory-management/components/InventoryEntryTable.tsx
+++ b/app/features/inventory-management/components/InventoryEntryTable.tsx
@@ -45,7 +45,10 @@ import {
   getQuantityKeyboardAction,
   type QuantityNavigationDirection,
 } from "./quantityKeyboard";
-import { finishQuantityEdit } from "../services/inventoryQuantityEdit";
+import {
+  adjustDisplayedQuantity,
+  finishQuantityEdit,
+} from "../services/inventoryQuantityEdit";
 
 interface SkuWithDisplayInfo extends Sku {
   cardNumber?: string | null;
@@ -383,14 +386,17 @@ const QuantityGridCell = React.memo(
     };
 
     const applyKeyboardQuantityDelta = (amount: number) => {
-      const displayed = Number.parseInt(displayValue, 10);
-      const startingQuantity = Number.isFinite(displayed) ? displayed : currentQty;
       commitTypedQuantity();
-      const nextQty = Math.max(0, startingQuantity + amount);
+      const adjustment = adjustDisplayedQuantity(
+        displayValue,
+        amount,
+      );
       untouchedSinceFocusRef.current = false;
       shouldReselectAfterSyncRef.current = true;
-      setDisplayValue(nextQty.toString());
-      onQuickAdd(activeSku, amount, false);
+      setDisplayValue(adjustment.displayValue);
+      if (adjustment.quantityDelta !== 0) {
+        onQuickAdd(activeSku, adjustment.quantityDelta, false);
+      }
     };
 
     const handleQuantityKeyDown = (
@@ -448,13 +454,14 @@ const QuantityGridCell = React.memo(
         <Button
           size="small"
           onClick={() => {
-            const displayed = Number.parseInt(displayValue, 10);
-            const nextQty = Math.max(
-              0,
-              (Number.isFinite(displayed) ? displayed : currentQty) - 1,
+            const adjustment = adjustDisplayedQuantity(
+              displayValue,
+              -1,
             );
-            setDisplayValue(nextQty.toString());
-            onQuickAdd(activeSku, -1);
+            setDisplayValue(adjustment.displayValue);
+            if (adjustment.quantityDelta !== 0) {
+              onQuickAdd(activeSku, adjustment.quantityDelta);
+            }
           }}
           color="secondary"
           variant="outlined"
@@ -492,10 +499,12 @@ const QuantityGridCell = React.memo(
         <Button
           size="small"
           onClick={() => {
-            const displayed = Number.parseInt(displayValue, 10);
-            const nextQty = (Number.isFinite(displayed) ? displayed : currentQty) + 1;
-            setDisplayValue(nextQty.toString());
-            onQuickAdd(activeSku, 1);
+            const adjustment = adjustDisplayedQuantity(
+              displayValue,
+              1,
+            );
+            setDisplayValue(adjustment.displayValue);
+            onQuickAdd(activeSku, adjustment.quantityDelta);
           }}
           color="primary"
           variant="outlined"

--- a/app/features/inventory-management/hooks/useInventoryProcessor.ts
+++ b/app/features/inventory-management/hooks/useInventoryProcessor.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import type { InventoryEntry, InventoryFilter } from "../types/inventoryEntry";
 import type { PendingInventoryEntry } from "../../pending-inventory/types/pendingInventory";
 import type { InventoryBatch } from "../../pending-inventory/types/inventoryBatch";
@@ -11,6 +11,7 @@ import {
   getPreviousInventoryCondition,
   type InventorySelectableCondition,
 } from "../../../core/utils/conditionOrder";
+import { InventoryMutationState } from "../services/inventoryMutationState";
 
 // Extended interface for SKUs with display information
 interface SkuWithDisplayInfo extends Sku {
@@ -61,9 +62,15 @@ export interface InventoryProcessorReturn extends InventoryProcessorState {
   setSearchScope: (searchScope: "set" | "allSets") => Promise<void>;
   loadCurrentInventory: () => Promise<void>;
   loadPendingInventory: () => Promise<void>;
-  updatePendingInventory: (
+  adjustPendingInventory: (
+    sku: number,
+    quantityDelta: number,
+    metadata: { productLineId: number; setId: number; productId: number }
+  ) => void;
+  setPendingInventory: (
     sku: number,
     quantity: number,
+    expectedQuantity: number,
     metadata: { productLineId: number; setId: number; productId: number }
   ) => void;
   clearPendingInventory: () => void;
@@ -79,6 +86,8 @@ export interface InventoryProcessorReturn extends InventoryProcessorState {
 
 export const useInventoryProcessor = (): InventoryProcessorReturn => {
   const baseProcessor = useProcessorBase();
+  const inventoryMutationQueue = useRef<Promise<unknown>>(Promise.resolve());
+  const inventoryMutationState = useRef(new InventoryMutationState());
   const [state, setState] = useState<InventoryProcessorState>({
     productLines: [],
     sets: [],
@@ -280,56 +289,181 @@ export const useInventoryProcessor = (): InventoryProcessorReturn => {
     }
   }, []);
 
-  const updatePendingInventory = useCallback(
-    async (
-      sku: number,
-      quantity: number,
-      metadata: { productLineId: number; setId: number; productId: number }
-    ) => {
-      try {
-        const response = await fetch("/api/pending-inventory", {
+  const sendPendingMutation = useCallback(
+    async (body: Record<string, unknown>) => {
+      const send = () =>
+        fetch("/api/pending-inventory", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            method: "PUT",
-            sku,
-            quantity,
-            productLineId: metadata.productLineId,
-            setId: metadata.setId,
-            productId: metadata.productId,
-          }),
+          body: JSON.stringify(body),
         });
-
-        if (!response.ok) throw new Error("Failed to update pending inventory");
-
-        // Reload pending inventory to get the latest state
-        await loadPendingInventory();
-      } catch (error) {
-        baseProcessor.setError(`Failed to update pending inventory: ${error}`);
+      let response: Response;
+      try {
+        response = await send();
+      } catch {
+        response = await send();
       }
+      const payload = (await response.json()) as {
+        quantity?: number;
+        error?: string;
+      };
+      if (!response.ok) {
+        throw new Error(payload.error ?? "Failed to update pending inventory");
+      }
+      return payload;
     },
-    [loadPendingInventory]
+    [],
   );
 
-  const clearPendingInventory = useCallback(async () => {
-    try {
-      const response = await fetch("/api/pending-inventory", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ method: "DELETE" }),
+  const queuePendingMutation = useCallback(
+    <T,>(work: () => Promise<T>): Promise<T> => {
+      inventoryMutationState.current.started();
+      const run = async () => {
+        try {
+          return await work();
+        } finally {
+          if (inventoryMutationState.current.finished()) {
+            await loadPendingInventory();
+          }
+        }
+      };
+      const queued = inventoryMutationQueue.current.then(run, run);
+      inventoryMutationQueue.current = queued.catch(() => undefined);
+      return queued;
+    },
+    [loadPendingInventory],
+  );
+
+  const updateLocalPendingQuantity = useCallback(
+    (
+      sku: number,
+      quantity: number,
+      metadata: { productLineId: number; setId: number; productId: number },
+    ) => {
+      setState((prev) => {
+        const existing = prev.pendingInventory.find((entry) => entry.sku === sku);
+        const withoutSku = prev.pendingInventory.filter((entry) => entry.sku !== sku);
+        if (quantity <= 0) {
+          return { ...prev, pendingInventory: withoutSku };
+        }
+        const now = new Date();
+        return {
+          ...prev,
+          pendingInventory: [
+            ...withoutSku,
+            {
+              sku,
+              quantity,
+              ...metadata,
+              createdAt: existing?.createdAt ?? now,
+              updatedAt: now,
+            },
+          ],
+        };
+      });
+    },
+    [],
+  );
+
+  const adjustPendingInventory = useCallback(
+    async (
+      sku: number,
+      quantityDelta: number,
+      metadata: { productLineId: number; setId: number; productId: number }
+    ) => {
+      if (quantityDelta === 0) return;
+      const requestId = crypto.randomUUID();
+      const mutationToken = inventoryMutationState.current.beginSku(sku);
+      setState((prev) => {
+        const current = prev.pendingInventory.find((entry) => entry.sku === sku)?.quantity ?? 0;
+        const next = Math.max(0, current + quantityDelta);
+        const existing = prev.pendingInventory.find((entry) => entry.sku === sku);
+        const withoutSku = prev.pendingInventory.filter((entry) => entry.sku !== sku);
+        if (next === 0) return { ...prev, pendingInventory: withoutSku };
+        const now = new Date();
+        return {
+          ...prev,
+          pendingInventory: [...withoutSku, {
+            sku, quantity: next, ...metadata,
+            createdAt: existing?.createdAt ?? now, updatedAt: now,
+          }],
+        };
       });
 
-      if (!response.ok) throw new Error("Failed to clear pending inventory");
+      void queuePendingMutation(async () => {
+        try {
+          const payload = await sendPendingMutation({
+            operation: quantityDelta > 0 ? "add" : "remove",
+            requestId,
+            sku,
+            quantity: Math.abs(quantityDelta),
+            ...metadata,
+          });
+          if (inventoryMutationState.current.canApplySku(mutationToken)) {
+            updateLocalPendingQuantity(sku, payload.quantity ?? 0, metadata);
+          }
+        } catch (error) {
+          baseProcessor.setError(`Failed to update pending inventory: ${error}`);
+          inventoryMutationState.current.failed();
+        }
+      });
+    },
+    [loadPendingInventory, queuePendingMutation, sendPendingMutation, updateLocalPendingQuantity],
+  );
 
-      // Update local state
-      setState((prev) => ({ ...prev, pendingInventory: [] }));
-    } catch (error) {
-      baseProcessor.setError(`Failed to clear pending inventory: ${error}`);
-    }
-  }, []);
-  const createBatchFromPendingInventory = useCallback(async () => {
+  const setPendingInventory = useCallback(
+    (
+      sku: number,
+      quantity: number,
+      expectedQuantity: number,
+      metadata: { productLineId: number; setId: number; productId: number },
+    ) => {
+      const requestId = crypto.randomUUID();
+      const mutationToken = inventoryMutationState.current.beginSku(sku);
+      updateLocalPendingQuantity(sku, quantity, metadata);
+      void queuePendingMutation(async () => {
+        try {
+          const payload = await sendPendingMutation({
+            operation: "set",
+            requestId,
+            sku,
+            quantity,
+            expectedQuantity,
+            ...metadata,
+          });
+          if (inventoryMutationState.current.canApplySku(mutationToken)) {
+            updateLocalPendingQuantity(sku, payload.quantity ?? 0, metadata);
+          }
+        } catch (error) {
+          baseProcessor.setError(`Failed to update pending inventory: ${error}`);
+          inventoryMutationState.current.failed();
+        }
+      });
+    },
+    [loadPendingInventory, queuePendingMutation, sendPendingMutation, updateLocalPendingQuantity],
+  );
+
+  const clearPendingInventory = useCallback(() => {
+    const requestId = crypto.randomUUID();
+    inventoryMutationState.current.beginBarrier();
+    setState((prev) => ({ ...prev, pendingInventory: [] }));
+    void queuePendingMutation(async () => {
+      try {
+        await sendPendingMutation({ operation: "clear", requestId });
+      } catch (error) {
+        baseProcessor.setError(`Failed to clear pending inventory: ${error}`);
+        inventoryMutationState.current.failed();
+      }
+    });
+  }, [loadPendingInventory, queuePendingMutation, sendPendingMutation]);
+  const createBatchFromPendingInventory = useCallback(() => {
+    const requestId = crypto.randomUUID();
+    const barrierVersion = inventoryMutationState.current.beginBarrier();
+    return queuePendingMutation(async () => {
     const response = await fetch("/api/inventory-batches", {
       method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ requestId }),
     });
     const payload = (await response.json()) as InventoryBatch | { error?: string };
 
@@ -341,9 +475,12 @@ export const useInventoryProcessor = (): InventoryProcessorReturn => {
       );
     }
 
-    setState((prev) => ({ ...prev, pendingInventory: [] }));
+    if (inventoryMutationState.current.canApplyBarrier(barrierVersion)) {
+      setState((prev) => ({ ...prev, pendingInventory: [] }));
+    }
     return payload as InventoryBatch;
-  }, []);
+    });
+  }, [queuePendingMutation]);
 
   const toggleSealedFilter = useCallback(
     (sealedFilter: "all" | "sealed" | "unsealed") => {
@@ -433,7 +570,8 @@ export const useInventoryProcessor = (): InventoryProcessorReturn => {
     setSearchScope,
     loadCurrentInventory,
     loadPendingInventory,
-    updatePendingInventory,
+    adjustPendingInventory,
+    setPendingInventory,
     clearPendingInventory,
     createBatchFromPendingInventory,
     toggleSealedFilter,

--- a/app/features/inventory-management/hooks/useInventoryProcessor.ts
+++ b/app/features/inventory-management/hooks/useInventoryProcessor.ts
@@ -471,7 +471,7 @@ export const useInventoryProcessor = (): InventoryProcessorReturn => {
         const batch = await createPendingInventoryBatch(requestId);
         pendingBatchRequestId.current = null;
         if (inventoryMutationState.current.canApplyBarrier(barrierVersion)) {
-          setState((prev) => ({ ...prev, pendingInventory: [] }));
+          await loadPendingInventory();
         }
         return batch;
       } catch (error) {
@@ -488,7 +488,7 @@ export const useInventoryProcessor = (): InventoryProcessorReturn => {
         throw error;
       }
     });
-  }, [queuePendingMutation]);
+  }, [loadPendingInventory, queuePendingMutation]);
 
   const toggleSealedFilter = useCallback(
     (sealedFilter: "all" | "sealed" | "unsealed") => {

--- a/app/features/inventory-management/hooks/useInventoryProcessor.ts
+++ b/app/features/inventory-management/hooks/useInventoryProcessor.ts
@@ -12,6 +12,10 @@ import {
   type InventorySelectableCondition,
 } from "../../../core/utils/conditionOrder";
 import { InventoryMutationState } from "../services/inventoryMutationState";
+import {
+  createPendingInventoryBatch,
+  PendingBatchRequestError,
+} from "../services/createPendingInventoryBatch";
 
 // Extended interface for SKUs with display information
 interface SkuWithDisplayInfo extends Sku {
@@ -88,6 +92,7 @@ export const useInventoryProcessor = (): InventoryProcessorReturn => {
   const baseProcessor = useProcessorBase();
   const inventoryMutationQueue = useRef<Promise<unknown>>(Promise.resolve());
   const inventoryMutationState = useRef(new InventoryMutationState());
+  const pendingBatchRequestId = useRef<string | null>(null);
   const [state, setState] = useState<InventoryProcessorState>({
     productLines: [],
     sets: [],
@@ -457,28 +462,31 @@ export const useInventoryProcessor = (): InventoryProcessorReturn => {
     });
   }, [loadPendingInventory, queuePendingMutation, sendPendingMutation]);
   const createBatchFromPendingInventory = useCallback(() => {
-    const requestId = crypto.randomUUID();
+    const requestId = pendingBatchRequestId.current ?? crypto.randomUUID();
+    pendingBatchRequestId.current = requestId;
     const barrierVersion = inventoryMutationState.current.beginBarrier();
     return queuePendingMutation(async () => {
-    const response = await fetch("/api/inventory-batches", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ requestId }),
-    });
-    const payload = (await response.json()) as InventoryBatch | { error?: string };
-
-    if (!response.ok) {
-      throw new Error(
-        "error" in payload && payload.error
-          ? payload.error
-          : "Failed to create inventory batch",
-      );
-    }
-
-    if (inventoryMutationState.current.canApplyBarrier(barrierVersion)) {
-      setState((prev) => ({ ...prev, pendingInventory: [] }));
-    }
-    return payload as InventoryBatch;
+      baseProcessor.setError(null);
+      try {
+        const batch = await createPendingInventoryBatch(requestId);
+        pendingBatchRequestId.current = null;
+        if (inventoryMutationState.current.canApplyBarrier(barrierVersion)) {
+          setState((prev) => ({ ...prev, pendingInventory: [] }));
+        }
+        return batch;
+      } catch (error) {
+        if (
+          error instanceof PendingBatchRequestError &&
+          error.outcome === "definitive"
+        ) {
+          pendingBatchRequestId.current = null;
+        }
+        baseProcessor.setError(
+          `${error instanceof Error ? error.message : String(error)}. ` +
+            "Select Process & Price again to safely recover or retry this batch.",
+        );
+        throw error;
+      }
     });
   }, [queuePendingMutation]);
 

--- a/app/features/inventory-management/routes/inventory-manager.tsx
+++ b/app/features/inventory-management/routes/inventory-manager.tsx
@@ -10,6 +10,7 @@ import {
   Select,
   MenuItem,
   Chip,
+  Alert,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -34,6 +35,7 @@ export default function InventoryManagerRoute() {
     productLines,
     sets,
     pendingInventory,
+    error,
     selectedProductLineId,
     selectedSetId,
     searchScope,
@@ -218,6 +220,12 @@ export default function InventoryManagerRoute() {
         <Typography variant="h4" component="h1" gutterBottom>
           Inventory Manager
         </Typography>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 3 }}>
+            {error}
+          </Alert>
+        )}
 
         <Paper sx={{ p: 3, mb: 3 }} elevation={3}>
           <Typography variant="h6" gutterBottom>

--- a/app/features/inventory-management/routes/inventory-manager.tsx
+++ b/app/features/inventory-management/routes/inventory-manager.tsx
@@ -45,7 +45,8 @@ export default function InventoryManagerRoute() {
     loadSets,
     loadSkusByCardNumber,
     loadPendingInventory,
-    updatePendingInventory,
+    adjustPendingInventory,
+    setPendingInventory,
     clearPendingInventory,
     createBatchFromPendingInventory,
     selectSet,
@@ -317,7 +318,8 @@ export default function InventoryManagerRoute() {
           <InventoryEntryTable
             skus={getFilteredSkus()}
             pendingInventory={pendingInventory}
-            onUpdateQuantity={updatePendingInventory}
+            onAdjustQuantity={adjustPendingInventory}
+            onSetQuantity={setPendingInventory}
             searchScope={searchScope}
             allSetsSearchTerm={allSetsSearchTerm}
             selectedCondition={selectedCondition}

--- a/app/features/inventory-management/services/createPendingInventoryBatch.test.ts
+++ b/app/features/inventory-management/services/createPendingInventoryBatch.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import type { InventoryBatch } from "~/features/pending-inventory/types/inventoryBatch";
+import { createPendingInventoryBatch } from "./createPendingInventoryBatch";
+
+const batches = new Map<string, InventoryBatch>();
+const receivedRequestIds: string[] = [];
+let createdCount = 0;
+let responseDropped = true;
+
+const batch = await createPendingInventoryBatch("batch-request-1", async (_url, init) => {
+  const requestId = JSON.parse(String(init.body)).requestId as string;
+  receivedRequestIds.push(requestId);
+  let saved = batches.get(requestId);
+  if (!saved) {
+    createdCount += 1;
+    saved = { batchNumber: 71 } as InventoryBatch;
+    batches.set(requestId, saved);
+  }
+  if (responseDropped) {
+    responseDropped = false;
+    throw new Error("connection closed after commit");
+  }
+  return {
+    ok: true,
+    status: 201,
+    json: async () => saved,
+  };
+});
+
+assert.equal(batch.batchNumber, 71);
+assert.equal(createdCount, 1);
+assert.deepEqual(receivedRequestIds, ["batch-request-1", "batch-request-1"]);
+
+console.log("PASS a dropped batch response retries one durable request exactly once");

--- a/app/features/inventory-management/services/createPendingInventoryBatch.test.ts
+++ b/app/features/inventory-management/services/createPendingInventoryBatch.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import type { InventoryBatch } from "~/features/pending-inventory/types/inventoryBatch";
-import { createPendingInventoryBatch } from "./createPendingInventoryBatch";
+import {
+  createPendingInventoryBatch,
+  PendingBatchRequestError,
+} from "./createPendingInventoryBatch";
 
 const batches = new Map<string, InventoryBatch>();
 const receivedRequestIds: string[] = [];
@@ -31,4 +34,34 @@ assert.equal(batch.batchNumber, 71);
 assert.equal(createdCount, 1);
 assert.deepEqual(receivedRequestIds, ["batch-request-1", "batch-request-1"]);
 
-console.log("PASS a dropped batch response retries one durable request exactly once");
+let serverErrorCount = 0;
+const serverErrorRequestIds: string[] = [];
+const recovered = await createPendingInventoryBatch("batch-request-2", async (_url, init) => {
+  serverErrorRequestIds.push(JSON.parse(String(init.body)).requestId);
+  serverErrorCount += 1;
+  return serverErrorCount === 1
+    ? { ok: false, status: 500, json: async () => ({ error: "response failed" }) }
+    : { ok: true, status: 201, json: async () => ({ batchNumber: 72 }) };
+});
+assert.equal(recovered.batchNumber, 72);
+assert.equal(serverErrorCount, 2);
+assert.deepEqual(serverErrorRequestIds, ["batch-request-2", "batch-request-2"]);
+
+for (const status of [408, 500]) {
+  let attempts = 0;
+  await assert.rejects(
+    createPendingInventoryBatch(`batch-request-${status}`, async () => {
+      attempts += 1;
+      return {
+        ok: false,
+        status,
+        json: async () => ({ error: "response failed" }),
+      };
+    }),
+    (error: unknown) =>
+      error instanceof PendingBatchRequestError && error.outcome === "uncertain",
+  );
+  assert.equal(attempts, 2);
+}
+
+console.log("PASS uncertain batch responses retry one durable request and remain recoverable");

--- a/app/features/inventory-management/services/createPendingInventoryBatch.ts
+++ b/app/features/inventory-management/services/createPendingInventoryBatch.ts
@@ -1,0 +1,77 @@
+import type { InventoryBatch } from "~/features/pending-inventory/types/inventoryBatch";
+
+type BatchResponse = Pick<Response, "ok" | "status" | "json">;
+type BatchFetch = (
+  input: string,
+  init: RequestInit,
+) => Promise<BatchResponse>;
+
+export class PendingBatchRequestError extends Error {
+  constructor(
+    message: string,
+    readonly outcome: "definitive" | "uncertain",
+  ) {
+    super(message);
+    this.name = "PendingBatchRequestError";
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function createPendingInventoryBatch(
+  requestId: string,
+  send: BatchFetch = fetch,
+): Promise<InventoryBatch> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    let response: BatchResponse;
+    try {
+      response = await send("/api/inventory-batches", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ requestId }),
+      });
+    } catch (error) {
+      if (attempt === 0) continue;
+      throw new PendingBatchRequestError(
+        `The batch response could not be confirmed: ${errorMessage(error)}`,
+        "uncertain",
+      );
+    }
+
+    let payload: InventoryBatch | { error?: string };
+    try {
+      payload = (await response.json()) as InventoryBatch | { error?: string };
+    } catch (error) {
+      if (attempt === 0) continue;
+      throw new PendingBatchRequestError(
+        `The batch response could not be read: ${errorMessage(error)}`,
+        "uncertain",
+      );
+    }
+
+    if (!response.ok) {
+      throw new PendingBatchRequestError(
+        "error" in payload && payload.error
+          ? payload.error
+          : `Batch creation failed with HTTP ${response.status}`,
+        "definitive",
+      );
+    }
+
+    if (!("batchNumber" in payload) || !Number.isInteger(payload.batchNumber)) {
+      if (attempt === 0) continue;
+      throw new PendingBatchRequestError(
+        "The batch response did not identify the created batch",
+        "uncertain",
+      );
+    }
+    return payload;
+  }
+
+  throw new PendingBatchRequestError(
+    "The batch response could not be confirmed",
+    "uncertain",
+  );
+}

--- a/app/features/inventory-management/services/createPendingInventoryBatch.ts
+++ b/app/features/inventory-management/services/createPendingInventoryBatch.ts
@@ -52,11 +52,17 @@ export async function createPendingInventoryBatch(
     }
 
     if (!response.ok) {
+      const uncertainStatus =
+        response.status === 408 ||
+        response.status === 425 ||
+        response.status === 429 ||
+        response.status >= 500;
+      if (uncertainStatus && attempt === 0) continue;
       throw new PendingBatchRequestError(
         "error" in payload && payload.error
           ? payload.error
           : `Batch creation failed with HTTP ${response.status}`,
-        "definitive",
+        uncertainStatus ? "uncertain" : "definitive",
       );
     }
 

--- a/app/features/inventory-management/services/inventoryMutationState.test.ts
+++ b/app/features/inventory-management/services/inventoryMutationState.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { InventoryMutationState } from "./inventoryMutationState";
+
+const state = new InventoryMutationState();
+state.started();
+const skuA = state.beginSku(1);
+state.started();
+const skuB = state.beginSku(2);
+state.failed();
+assert.equal(state.finished(), false);
+assert.equal(state.canApplySku(skuA), true);
+assert.equal(state.canApplySku(skuB), true);
+assert.equal(state.finished(), true, "a failed SKU reloads after the whole queue drains");
+
+const beforeBatch = state.beginSku(1);
+const batch = state.beginBarrier();
+assert.equal(state.canApplySku(beforeBatch), false);
+assert.equal(state.canApplyBarrier(batch), true);
+state.beginBarrier();
+assert.equal(state.canApplyBarrier(batch), false);
+
+console.log("PASS mutation acknowledgements reconcile cross-SKU failures and barriers");

--- a/app/features/inventory-management/services/inventoryMutationState.ts
+++ b/app/features/inventory-management/services/inventoryMutationState.ts
@@ -1,0 +1,51 @@
+export type SkuMutationToken = {
+  sku: number;
+  skuVersion: number;
+  barrierVersion: number;
+};
+
+export class InventoryMutationState {
+  private pendingCount = 0;
+  private needsReload = false;
+  private readonly skuVersions = new Map<number, number>();
+  private barrierVersion = 0;
+
+  started(): void {
+    this.pendingCount += 1;
+  }
+
+  failed(): void {
+    this.needsReload = true;
+  }
+
+  finished(): boolean {
+    this.pendingCount -= 1;
+    if (this.pendingCount === 0 && this.needsReload) {
+      this.needsReload = false;
+      return true;
+    }
+    return false;
+  }
+
+  beginSku(sku: number): SkuMutationToken {
+    const skuVersion = (this.skuVersions.get(sku) ?? 0) + 1;
+    this.skuVersions.set(sku, skuVersion);
+    return { sku, skuVersion, barrierVersion: this.barrierVersion };
+  }
+
+  beginBarrier(): number {
+    this.barrierVersion += 1;
+    return this.barrierVersion;
+  }
+
+  canApplySku(token: SkuMutationToken): boolean {
+    return (
+      this.skuVersions.get(token.sku) === token.skuVersion &&
+      this.barrierVersion === token.barrierVersion
+    );
+  }
+
+  canApplyBarrier(version: number): boolean {
+    return this.barrierVersion === version;
+  }
+}

--- a/app/features/inventory-management/services/inventoryQuantityEdit.test.ts
+++ b/app/features/inventory-management/services/inventoryQuantityEdit.test.ts
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { finishQuantityEdit } from "./inventoryQuantityEdit";
+import {
+  adjustDisplayedQuantity,
+  finishQuantityEdit,
+} from "./inventoryQuantityEdit";
 
 assert.deepEqual(finishQuantityEdit(41, "34", 12, true), {
   displayValue: "34",
@@ -11,5 +14,17 @@ assert.deepEqual(finishQuantityEdit(41, "", 12, true), {
 });
 assert.equal(finishQuantityEdit(41, "12", 12, true).commit, null);
 assert.equal(finishQuantityEdit(41, "99", 12, false).commit, null);
+assert.deepEqual(adjustDisplayedQuantity("0", -1), {
+  displayValue: "0",
+  quantityDelta: 0,
+});
+assert.deepEqual(adjustDisplayedQuantity("3", -1), {
+  displayValue: "2",
+  quantityDelta: -1,
+});
+assert.deepEqual(adjustDisplayedQuantity("", 1), {
+  displayValue: "1",
+  quantityDelta: 1,
+});
 
 console.log("PASS quantity edits produce one normalized commit from their focus baseline");

--- a/app/features/inventory-management/services/inventoryQuantityEdit.test.ts
+++ b/app/features/inventory-management/services/inventoryQuantityEdit.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { finishQuantityEdit } from "./inventoryQuantityEdit";
+
+assert.deepEqual(finishQuantityEdit(41, "34", 12, true), {
+  displayValue: "34",
+  commit: { sku: 41, quantity: 34, expectedQuantity: 12 },
+});
+assert.deepEqual(finishQuantityEdit(41, "", 12, true), {
+  displayValue: "0",
+  commit: { sku: 41, quantity: 0, expectedQuantity: 12 },
+});
+assert.equal(finishQuantityEdit(41, "12", 12, true).commit, null);
+assert.equal(finishQuantityEdit(41, "99", 12, false).commit, null);
+
+console.log("PASS quantity edits produce one normalized commit from their focus baseline");

--- a/app/features/inventory-management/services/inventoryQuantityEdit.ts
+++ b/app/features/inventory-management/services/inventoryQuantityEdit.ts
@@ -1,0 +1,22 @@
+export type QuantityCommit = {
+  sku: number;
+  quantity: number;
+  expectedQuantity: number;
+};
+
+export function finishQuantityEdit(
+  sku: number,
+  displayValue: string,
+  expectedQuantity: number,
+  changed: boolean,
+): { displayValue: string; commit: QuantityCommit | null } {
+  const parsed = Number.parseInt(displayValue, 10);
+  const quantity = Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+  return {
+    displayValue: quantity.toString(),
+    commit:
+      changed && quantity !== expectedQuantity
+        ? { sku, quantity, expectedQuantity }
+        : null,
+  };
+}

--- a/app/features/inventory-management/services/inventoryQuantityEdit.ts
+++ b/app/features/inventory-management/services/inventoryQuantityEdit.ts
@@ -4,6 +4,26 @@ export type QuantityCommit = {
   expectedQuantity: number;
 };
 
+export type QuantityAdjustment = {
+  displayValue: string;
+  quantityDelta: number;
+};
+
+export function adjustDisplayedQuantity(
+  displayValue: string,
+  requestedDelta: number,
+): QuantityAdjustment {
+  const parsed = Number.parseInt(displayValue, 10);
+  const startingQuantity = Number.isFinite(parsed)
+    ? Math.max(0, parsed)
+    : 0;
+  const quantity = Math.max(0, startingQuantity + requestedDelta);
+  return {
+    displayValue: quantity.toString(),
+    quantityDelta: quantity - startingQuantity,
+  };
+}
+
 export function finishQuantityEdit(
   sku: number,
   displayValue: string,

--- a/app/features/pending-inventory/routes/api.inventory-batches.ts
+++ b/app/features/pending-inventory/routes/api.inventory-batches.ts
@@ -1,5 +1,6 @@
 import { data } from "react-router";
 import { inventoryBatchesRepository } from "~/core/db";
+import { InventoryBatchRequestConflictError } from "~/core/db/repositories/inventoryBatches.server";
 
 export async function loader() {
   try {
@@ -19,7 +20,17 @@ export async function action({ request }: { request: Request }) {
       return data({ error: "Method not allowed" }, { status: 405 });
     }
 
-    const batch = await inventoryBatchesRepository.createFromPendingInventory();
+    const body = (await request.json().catch(() => null)) as {
+      requestId?: unknown;
+    } | null;
+    const requestId =
+      typeof body?.requestId === "string" ? body.requestId.trim() : "";
+    if (!requestId || requestId.length > 200) {
+      return data({ error: "requestId is required" }, { status: 400 });
+    }
+
+    const batch =
+      await inventoryBatchesRepository.createFromPendingInventory(requestId);
     if (!batch) {
       return data(
         { error: "No pending inventory items available to batch" },
@@ -29,6 +40,9 @@ export async function action({ request }: { request: Request }) {
 
     return data(batch, { status: 201 });
   } catch (error) {
+    if (error instanceof InventoryBatchRequestConflictError) {
+      return data({ error: error.message }, { status: 409 });
+    }
     return data({ error: String(error) }, { status: 500 });
   }
 }

--- a/app/features/pending-inventory/routes/api.pending-inventory.ts
+++ b/app/features/pending-inventory/routes/api.pending-inventory.ts
@@ -1,10 +1,82 @@
 import { data } from "react-router";
-import { pendingInventoryRepository } from "~/core/db";
+import {
+  PendingInventoryConflictError,
+  pendingInventoryRepository,
+} from "~/core/db/repositories/pendingInventory.server";
+import type {
+  InventoryMarketObservation,
+  PendingInventoryMetadata,
+  PendingInventoryMutation,
+} from "~/features/inventory-history/types/inventoryReceipt";
+import { fetchInventoryIntakeMarketObservation } from "~/integrations/tcgplayer/client/get-price-points.server";
+
+type PendingInventoryRequest = {
+  operation?: unknown;
+  requestId?: unknown;
+  sku?: unknown;
+  quantity?: unknown;
+  expectedQuantity?: unknown;
+  productLineId?: unknown;
+  setId?: unknown;
+  productId?: unknown;
+};
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) >= 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) > 0;
+}
+
+function parseRequestId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const requestId = value.trim();
+  return requestId.length > 0 && requestId.length <= 200 ? requestId : null;
+}
+
+function parseMetadata(body: PendingInventoryRequest): PendingInventoryMetadata | null {
+  if (
+    !isPositiveInteger(body.productLineId) ||
+    !isPositiveInteger(body.setId) ||
+    !isPositiveInteger(body.productId)
+  ) return null;
+  return {
+    productLineId: body.productLineId,
+    setId: body.setId,
+    productId: body.productId,
+  };
+}
+
+function unavailableMarket(): InventoryMarketObservation {
+  return {
+    marketValue: null,
+    observedAt: null,
+    calculatedAt: null,
+    provenance: "tcgplayer_price_points_unavailable",
+  };
+}
+
+async function observeMarket(sku: number): Promise<InventoryMarketObservation> {
+  try {
+    const observation = await fetchInventoryIntakeMarketObservation(sku);
+    if (!observation) return unavailableMarket();
+
+    const calculatedAt = new Date(observation.calculatedAt);
+    return {
+      marketValue: observation.marketPrice,
+      observedAt: new Date(),
+      calculatedAt: Number.isNaN(calculatedAt.getTime()) ? null : calculatedAt,
+      provenance: "tcgplayer_price_points",
+    };
+  } catch {
+    return unavailableMarket();
+  }
+}
 
 export async function loader() {
   try {
-    const pendingInventory = await pendingInventoryRepository.findAll();
-    return data(pendingInventory, { status: 200 });
+    return data(await pendingInventoryRepository.findAll(), { status: 200 });
   } catch (error) {
     return data({ error: String(error) }, { status: 500 });
   }
@@ -12,50 +84,93 @@ export async function loader() {
 
 export async function action({ request }: { request: Request }) {
   try {
-    const formData = await request.json();
-    const { method, sku, quantity, productLineId, setId, productId } = formData;
-
-    if (method === "DELETE") {
-      await pendingInventoryRepository.clearAll();
-      return data({ message: "All pending inventory cleared" }, { status: 200 });
+    if (request.method !== "POST") {
+      return data({ error: "Method not allowed" }, { status: 405 });
     }
 
-    if (method === "PUT") {
-      if (!sku || typeof quantity !== "number") {
-        return data({ error: "SKU and quantity are required" }, { status: 400 });
-      }
+    const body = (await request.json()) as PendingInventoryRequest;
+    const requestId = parseRequestId(body.requestId);
+    if (!requestId) {
+      return data({ error: "requestId is required" }, { status: 400 });
+    }
 
-      if (!productLineId || !setId || !productId) {
+    if (body.operation === "clear") {
+      return data(
+        await pendingInventoryRepository.mutate({ type: "clear", requestId }),
+        { status: 200 },
+      );
+    }
+
+    if (!isPositiveInteger(body.sku)) {
+      return data({ error: "A positive integer SKU is required" }, { status: 400 });
+    }
+    const metadata = parseMetadata(body);
+    if (!metadata) {
+      return data(
+        { error: "productLineId, setId, and productId are required" },
+        { status: 400 },
+      );
+    }
+
+    let mutation: PendingInventoryMutation;
+    if (body.operation === "add") {
+      if (!isPositiveInteger(body.quantity)) {
+        return data({ error: "Add quantity must be positive" }, { status: 400 });
+      }
+      const intakeAt = new Date();
+      mutation = {
+        type: "add",
+        requestId,
+        sku: body.sku,
+        quantity: body.quantity,
+        metadata,
+        intakeAt,
+        market: await observeMarket(body.sku),
+      };
+    } else if (body.operation === "remove") {
+      if (!isPositiveInteger(body.quantity)) {
+        return data({ error: "Remove quantity must be positive" }, { status: 400 });
+      }
+      mutation = {
+        type: "remove",
+        requestId,
+        sku: body.sku,
+        quantity: body.quantity,
+        metadata,
+      };
+    } else if (body.operation === "set") {
+      if (
+        !isNonNegativeInteger(body.quantity) ||
+        !isNonNegativeInteger(body.expectedQuantity)
+      ) {
         return data(
-          { error: "productLineId, setId, and productId are required" },
+          { error: "Set quantity and expectedQuantity must be non-negative integers" },
           { status: 400 },
         );
       }
-
-      if (quantity <= 0) {
-        await pendingInventoryRepository.removeBySku(sku);
-        return data(
-          { message: "Pending inventory entry removed" },
-          { status: 200 },
-        );
-      }
-
-      const now = new Date();
-      await pendingInventoryRepository.upsert({
-        sku,
-        quantity,
-        productLineId,
-        setId,
-        productId,
-        createdAt: now,
-        updatedAt: now,
-      });
-
-      return data({ message: "Pending inventory updated" }, { status: 200 });
+      const intakeAt = new Date();
+      mutation = {
+        type: "set",
+        requestId,
+        sku: body.sku,
+        quantity: body.quantity,
+        expectedQuantity: body.expectedQuantity,
+        metadata,
+        intakeAt,
+        market:
+          body.quantity > body.expectedQuantity
+            ? await observeMarket(body.sku)
+            : unavailableMarket(),
+      };
+    } else {
+      return data({ error: "Invalid operation" }, { status: 400 });
     }
 
-    return data({ error: "Invalid method" }, { status: 400 });
+    return data(await pendingInventoryRepository.mutate(mutation), { status: 200 });
   } catch (error) {
+    if (error instanceof PendingInventoryConflictError) {
+      return data({ error: error.message }, { status: 409 });
+    }
     return data({ error: String(error) }, { status: 500 });
   }
 }

--- a/app/integrations/tcgplayer/client/get-price-points.server.test.ts
+++ b/app/integrations/tcgplayer/client/get-price-points.server.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import {
+  fetchInventoryIntakeMarketObservation,
+  fetchMarketPriceObservationsBySku,
+  type PricePoint,
+} from "./get-price-points.server";
+
+const calculatedAt = "2026-09-07T14:05:00.000Z";
+const observations = await fetchMarketPriceObservationsBySku(
+  [41, 42],
+  async ({ skuIds }) =>
+    skuIds.map(
+      (skuId): PricePoint => ({
+        skuId,
+        marketPrice: skuId === 41 ? 4.25 : 0,
+        lowestPrice: 0,
+        highestPrice: 0,
+        priceCount: 1,
+        calculatedAt,
+      }),
+    ),
+);
+assert.deepEqual(observations.get(41), { marketPrice: 4.25, calculatedAt });
+assert.deepEqual(observations.get(42), { marketPrice: null, calculatedAt });
+
+let aborted = false;
+await assert.rejects(
+  fetchInventoryIntakeMarketObservation(
+    41,
+    async (_request, options) =>
+      new Promise<PricePoint[]>((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () => {
+          aborted = true;
+          reject(new Error("aborted"));
+        });
+      }),
+    10,
+  ),
+  /timed out/,
+);
+assert.equal(aborted, true);
+
+console.log("PASS intake market observations preserve source time and honor their deadline");

--- a/app/integrations/tcgplayer/client/get-price-points.server.ts
+++ b/app/integrations/tcgplayer/client/get-price-points.server.ts
@@ -15,10 +15,12 @@ export interface PricePoint {
 
 export async function getPricePoints(
   requestBody: GetPricePointsRequestBody,
+  options?: { signal?: AbortSignal; retry?: boolean },
 ): Promise<PricePoint[]> {
   return mpGateway.post<PricePoint[]>(
     "/v1/pricepoints/marketprice/skus/search",
     requestBody,
+    options,
   );
 }
 
@@ -26,18 +28,20 @@ const MARKET_PRICE_BATCH_SIZE = 250;
 
 export type PricePointsClient = (
   requestBody: GetPricePointsRequestBody,
+  options?: { signal?: AbortSignal; retry?: boolean },
 ) => Promise<PricePoint[]>;
 
-/**
- * Current market price by SKU, fetched in bounded batches. SKUs without a
- * positive market price are left out of the map.
- */
-export async function fetchMarketPricesBySku(
+export type MarketPriceObservation = {
+  marketPrice: number | null;
+  calculatedAt: string;
+};
+
+export async function fetchMarketPriceObservationsBySku(
   skus: number[],
   pricePointsClient: PricePointsClient = getPricePoints,
-): Promise<Map<number, number>> {
+): Promise<Map<number, MarketPriceObservation>> {
   const uniqueSkus = Array.from(new Set(skus));
-  const marketPrices = new Map<number, number>();
+  const observations = new Map<number, MarketPriceObservation>();
 
   for (
     let offset = 0;
@@ -49,9 +53,71 @@ export async function fetchMarketPricesBySku(
     });
 
     for (const pricePoint of pricePoints) {
-      if (pricePoint.marketPrice > 0) {
-        marketPrices.set(pricePoint.skuId, pricePoint.marketPrice);
-      }
+      observations.set(pricePoint.skuId, {
+        marketPrice:
+          Number.isFinite(pricePoint.marketPrice) && pricePoint.marketPrice > 0
+            ? pricePoint.marketPrice
+            : null,
+        calculatedAt: pricePoint.calculatedAt,
+      });
+    }
+  }
+
+  return observations;
+}
+
+export async function fetchInventoryIntakeMarketObservation(
+  sku: number,
+  pricePointsClient: PricePointsClient = getPricePoints,
+  deadlineMs = 3_000,
+): Promise<MarketPriceObservation | null> {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    const pricePoints = await Promise.race([
+      pricePointsClient(
+        { skuIds: [sku] },
+        { signal: controller.signal, retry: false },
+      ),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => {
+          controller.abort();
+          reject(new Error("Inventory intake market lookup timed out"));
+        }, deadlineMs);
+      }),
+    ]);
+    const pricePoint = pricePoints.find((point) => point.skuId === sku);
+    if (!pricePoint) return null;
+    return {
+      marketPrice:
+        Number.isFinite(pricePoint.marketPrice) && pricePoint.marketPrice > 0
+          ? pricePoint.marketPrice
+          : null,
+      calculatedAt: pricePoint.calculatedAt,
+    };
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+/**
+ * Current market price by SKU, fetched in bounded batches. SKUs without a
+ * positive market price are left out of the map.
+ */
+export async function fetchMarketPricesBySku(
+  skus: number[],
+  pricePointsClient: PricePointsClient = getPricePoints,
+): Promise<Map<number, number>> {
+  const marketPrices = new Map<number, number>();
+
+  const observations = await fetchMarketPriceObservationsBySku(
+    skus,
+    pricePointsClient,
+  );
+  for (const [sku, observation] of observations) {
+    if (observation.marketPrice !== null) {
+      marketPrices.set(sku, observation.marketPrice);
     }
   }
 

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -1,4 +1,6 @@
 import "../core/clients/baseDomainClient.server.test";
+import "../integrations/tcgplayer/client/get-price-points.server.test";
+import "../features/inventory-history/domain/receiptBalances.test";
 import "../features/ebay-slab-pricing/supply/sellerOutcomeCsv.test";
 import "../features/ebay-slab-pricing/maintenance/slabMaintenance.test";
 import "../features/ebay-slab-pricing/publication/slabPublication.test";
@@ -24,6 +26,8 @@ import "../features/inventory-publication/services/inventoryPublicationSettings.
 import "../integrations/tcgplayer/client/update-seller-inventory.server.test";
 import "../integrations/tcgplayer/client/staged-pricing-import.server.test";
 import "../features/inventory-management/components/quantityKeyboard.test";
+import "../features/inventory-management/services/inventoryQuantityEdit.test";
+import "../features/inventory-management/services/inventoryMutationState.test";
 import "../features/inventory-management/services/inventoryConverter.test";
 import "../features/shipping-export/config/shippingExportConfig.server.test";
 import "../features/shipping-export/config/shippingExportConfigFormData.test";

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -28,6 +28,7 @@ import "../integrations/tcgplayer/client/staged-pricing-import.server.test";
 import "../features/inventory-management/components/quantityKeyboard.test";
 import "../features/inventory-management/services/inventoryQuantityEdit.test";
 import "../features/inventory-management/services/inventoryMutationState.test";
+import "../features/inventory-management/services/createPendingInventoryBatch.test";
 import "../features/inventory-management/services/inventoryConverter.test";
 import "../features/shipping-export/config/shippingExportConfig.server.test";
 import "../features/shipping-export/config/shippingExportConfigFormData.test";

--- a/db/migrations/035_add_inventory_receipt_history.sql
+++ b/db/migrations/035_add_inventory_receipt_history.sql
@@ -1,0 +1,181 @@
+CREATE TABLE inventory_pending_mutations (
+  request_id TEXT PRIMARY KEY,
+  mutation_type TEXT NOT NULL CHECK (mutation_type IN ('add', 'remove', 'set', 'clear')),
+  sku INTEGER,
+  requested_quantity INTEGER,
+  expected_quantity INTEGER,
+  product_line_id INTEGER,
+  set_id INTEGER,
+  product_id INTEGER,
+  quantity_delta INTEGER NOT NULL,
+  resulting_quantity INTEGER NOT NULL CHECK (resulting_quantity >= 0),
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CHECK (
+    (mutation_type = 'clear' AND sku IS NULL AND requested_quantity IS NULL AND expected_quantity IS NULL
+      AND product_line_id IS NULL AND set_id IS NULL AND product_id IS NULL)
+    OR
+    (mutation_type <> 'clear' AND sku IS NOT NULL
+      AND product_line_id IS NOT NULL AND set_id IS NOT NULL AND product_id IS NOT NULL)
+  )
+);
+
+CREATE TABLE inventory_receipts (
+  receipt_id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  request_id TEXT NOT NULL UNIQUE REFERENCES inventory_pending_mutations(request_id),
+  sku INTEGER NOT NULL,
+  original_quantity INTEGER NOT NULL CHECK (original_quantity > 0),
+  product_line_id INTEGER NOT NULL,
+  set_id INTEGER NOT NULL,
+  product_id INTEGER NOT NULL,
+  seller_key TEXT,
+  intake_at TIMESTAMPTZ,
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  market_value NUMERIC(12, 4),
+  market_observed_at TIMESTAMPTZ,
+  market_calculated_at TIMESTAMPTZ,
+  market_provenance TEXT NOT NULL,
+  source_evidence JSONB,
+  CHECK (market_value IS NULL OR market_value >= 0),
+  CHECK (seller_key IS NULL OR length(trim(seller_key)) > 0)
+);
+
+CREATE TABLE inventory_receipt_adjustments (
+  adjustment_id INTEGER GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  receipt_id INTEGER NOT NULL REFERENCES inventory_receipts(receipt_id),
+  mutation_request_id TEXT NOT NULL REFERENCES inventory_pending_mutations(request_id),
+  quantity_delta INTEGER NOT NULL CHECK (quantity_delta <> 0),
+  reason TEXT NOT NULL CHECK (reason IN ('correction', 'clear')),
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (mutation_request_id, receipt_id)
+);
+
+-- Deliberately no foreign key to inventory_batches: deleting a pricing batch
+-- must not erase the durable receipt-to-batch evidence or make those units
+-- pending again.
+CREATE TABLE inventory_receipt_batch_links (
+  receipt_id INTEGER NOT NULL REFERENCES inventory_receipts(receipt_id),
+  batch_number INTEGER NOT NULL,
+  linked_quantity INTEGER NOT NULL CHECK (linked_quantity > 0),
+  linked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (receipt_id, batch_number)
+);
+
+CREATE INDEX inventory_receipts_pending_order_idx
+  ON inventory_receipts (sku, intake_at NULLS FIRST, receipt_id);
+CREATE INDEX inventory_receipts_seller_sku_idx
+  ON inventory_receipts (seller_key, sku)
+  WHERE seller_key IS NOT NULL;
+CREATE INDEX inventory_receipt_adjustments_receipt_idx
+  ON inventory_receipt_adjustments (receipt_id);
+CREATE INDEX inventory_receipt_batch_links_batch_idx
+  ON inventory_receipt_batch_links (batch_number, receipt_id);
+
+CREATE FUNCTION preserve_inventory_receipt_evidence()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.request_id IS DISTINCT FROM NEW.request_id
+    OR OLD.sku IS DISTINCT FROM NEW.sku
+    OR OLD.original_quantity IS DISTINCT FROM NEW.original_quantity
+    OR OLD.intake_at IS DISTINCT FROM NEW.intake_at
+    OR OLD.recorded_at IS DISTINCT FROM NEW.recorded_at
+    OR OLD.market_value IS DISTINCT FROM NEW.market_value
+    OR OLD.market_observed_at IS DISTINCT FROM NEW.market_observed_at
+    OR OLD.market_calculated_at IS DISTINCT FROM NEW.market_calculated_at
+    OR OLD.market_provenance IS DISTINCT FROM NEW.market_provenance
+    OR OLD.source_evidence IS DISTINCT FROM NEW.source_evidence
+  THEN
+    RAISE EXCEPTION 'Inventory receipt evidence is immutable';
+  END IF;
+
+  IF OLD.seller_key IS NOT NULL AND OLD.seller_key IS DISTINCT FROM NEW.seller_key THEN
+    RAISE EXCEPTION 'Inventory receipt seller ownership cannot be reassigned';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER inventory_receipt_evidence_is_immutable
+BEFORE UPDATE ON inventory_receipts
+FOR EACH ROW
+EXECUTE FUNCTION preserve_inventory_receipt_evidence();
+
+-- Existing aggregate rows establish quantity only. Their old timestamps are
+-- retained as evidence, but are not promoted to exact intake timestamps.
+INSERT INTO inventory_pending_mutations (
+  request_id,
+  mutation_type,
+  sku,
+  requested_quantity,
+  expected_quantity,
+  product_line_id,
+  set_id,
+  product_id,
+  quantity_delta,
+  resulting_quantity,
+  recorded_at
+)
+SELECT
+  'legacy-pending:' || sku::text,
+  'add',
+  sku,
+  quantity,
+  NULL,
+  product_line_id,
+  set_id,
+  product_id,
+  quantity,
+  quantity,
+  NOW()
+FROM pending_inventory
+WHERE quantity > 0;
+
+INSERT INTO inventory_receipts (
+  request_id,
+  sku,
+  original_quantity,
+  product_line_id,
+  set_id,
+  product_id,
+  intake_at,
+  recorded_at,
+  market_value,
+  market_observed_at,
+  market_calculated_at,
+  market_provenance,
+  source_evidence
+)
+SELECT
+  'legacy-pending:' || sku::text,
+  sku,
+  quantity,
+  product_line_id,
+  set_id,
+  product_id,
+  NULL,
+  NOW(),
+  NULL,
+  NULL,
+  NULL,
+  'legacy_unavailable',
+  jsonb_build_object(
+    'legacyPendingCreatedAt', created_at,
+    'legacyPendingUpdatedAt', updated_at
+  )
+FROM pending_inventory
+WHERE quantity > 0;
+
+ALTER TABLE inventory_batches
+  ADD COLUMN source_request_id TEXT;
+
+CREATE UNIQUE INDEX inventory_batches_source_request_idx
+  ON inventory_batches (source_request_id)
+  WHERE source_request_id IS NOT NULL;
+
+CREATE TABLE inventory_batch_intake_requests (
+  request_id TEXT PRIMARY KEY,
+  batch_number INTEGER NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/docs/inventory-receipt-history.md
+++ b/docs/inventory-receipt-history.md
@@ -1,0 +1,27 @@
+# Inventory receipt history
+
+Inventory Manager keeps `pending_inventory` as its small aggregate queue and
+records every durable change beside it:
+
+- A received positive quantity creates one `inventory_receipts` quantity lot.
+  Its SKU, original quantity, intake time, recorded time, and market evidence
+  cannot be rewritten. A separate later addition creates another lot.
+- A decrease or clear appends `inventory_receipt_adjustments`; it never changes
+  the receipt's original quantity. Corrections consume the newest pending lots
+  first so older intake evidence is not needlessly shortened.
+- A batch appends `inventory_receipt_batch_links` for each contributing lot.
+  Links intentionally survive pricing batch deletion and keep those units out
+  of the pending queue.
+- Every UI mutation and pending-to-batch conversion has a durable request ID.
+  Repeating an identical request is safe. Reusing an ID with different inputs,
+  or retrying a conversion after its batch was deleted, is rejected.
+
+Market value is the unit market quote observed for that intake event. The
+upstream `calculatedAt` and local observation time are separate. Missing and
+failed quotes remain `NULL` with provenance; they do not block receipt capture.
+Legacy pending rows migrate as quantity evidence with `intake_at` and market
+fields unknown. Their old aggregate timestamps remain only in `source_evidence`.
+
+Receipts start with nullable `seller_key`. The publication slice must bind each
+batch's receipts to one seller before activation and query later FIFO holdings
+by both seller and exact SKU. Once set, receipt seller ownership cannot change.


### PR DESCRIPTION
Inventory Manager previously overwrote one aggregate row per SKU, so separate additions lost their intake dates and repricing could not preserve intake market evidence. This adds durable receipt quantity groups beside the existing pending projection, append-only corrections and batch links, immutable market evidence with upstream calculation time, and request identities for every pending mutation and batch conversion.

The existing aggregate screen remains intact. Plus/minus actions now send ordered deltas, typed quantities commit once from their focus baseline, failed market lookups do not block intake, concurrent/retried writes conserve quantity, and deleting a pricing batch retains its receipt links. Existing pending rows migrate with unknown intake/market fields while retaining their former timestamps as source evidence. Seller ownership remains nullable for pending lots and becomes immutable once assigned for the later activation slice.

Validation:

- `npm test`
- `npm run typecheck`
- `npm run build`
- fresh PostgreSQL migrations 001-035 on isolated `tcgplayer_fifo_55_agent_20260907`
- `npx tsx app/core/db/inventoryReceiptMigration.integration.test.ts`
- `npx tsx app/core/db/repositories/pendingInventory.server.integration.test.ts`

Closes #55
