### PR TITLE
Activate confirmed inventory receipt lots

### DIFF
--- a/app/core/db/repositories/inventoryPublicationReceipts.server.integration.test.ts
+++ b/app/core/db/repositories/inventoryPublicationReceipts.server.integration.test.ts
@@ -5,6 +5,18 @@ import { pendingInventoryRepository } from "./pendingInventory.server";
 import { inventoryPublicationsRepository } from "./inventoryPublications.server";
 import { action as publicationAction } from "~/features/pending-inventory/routes/api.inventory-batch-publications";
 
+const testDatabaseUrl = process.env.TEST_DATABASE_URL;
+if (!testDatabaseUrl) {
+  throw new Error("TEST_DATABASE_URL is required for this integration test.");
+}
+const testDatabaseName = new URL(testDatabaseUrl).pathname.replace(/^\/+/, "");
+if (!testDatabaseName.startsWith("tcgplayer_fifo_test_")) {
+  throw new Error(
+    "TEST_DATABASE_URL must name a disposable tcgplayer_fifo_test_* database.",
+  );
+}
+process.env.DATABASE_URL = testDatabaseUrl;
+
 const prefix = `publication-receipts-${Date.now()}`;
 const sellerKey = `${prefix}-seller`;
 const skuA = 9_200_001;
@@ -64,7 +76,7 @@ try {
     batchNumber: batch.batchNumber,
     method: "staged_delta" as const,
     sourceType: "pending_inventory" as const,
-    sellerKey,
+    sellerKey: ` ${sellerKey} `,
     items: [
       publicationItem(batch.batchNumber, skuA, 5),
       publicationItem(batch.batchNumber, skuB, 4),
@@ -73,6 +85,7 @@ try {
   const planned = await inventoryPublicationsRepository.createOrFindPlanned(params);
   const repeated = await inventoryPublicationsRepository.createOrFindPlanned(params);
   assert.equal(repeated.created, false);
+  assert.equal(repeated.publication.sellerKey, sellerKey);
   await assert.rejects(
     inventoryPublicationsRepository.createOrFindPlanned({
       ...params,

--- a/app/core/db/repositories/inventoryPublicationReceipts.server.integration.test.ts
+++ b/app/core/db/repositories/inventoryPublicationReceipts.server.integration.test.ts
@@ -1,0 +1,444 @@
+import assert from "node:assert/strict";
+import { execute, getPool, query, queryOne } from "../database.server";
+import { inventoryBatchesRepository } from "./inventoryBatches.server";
+import { pendingInventoryRepository } from "./pendingInventory.server";
+import { inventoryPublicationsRepository } from "./inventoryPublications.server";
+import { action as publicationAction } from "~/features/pending-inventory/routes/api.inventory-batch-publications";
+
+const prefix = `publication-receipts-${Date.now()}`;
+const sellerKey = `${prefix}-seller`;
+const skuA = 9_200_001;
+const skuB = 9_200_002;
+const metadata = { productLineId: 1, setId: 2, productId: 3 };
+const unavailableMarket = {
+  marketValue: null,
+  observedAt: null,
+  calculatedAt: null,
+  provenance: "tcgplayer_price_points_unavailable" as const,
+};
+
+async function addReceipt(sku: number, quantity: number, suffix: string) {
+  await pendingInventoryRepository.mutate({
+    type: "add",
+    requestId: `${prefix}-${suffix}`,
+    sku,
+    quantity,
+    metadata,
+    intakeAt: new Date("2026-08-01T12:00:00.000Z"),
+    market: unavailableMarket,
+  });
+}
+
+function publicationItem(
+  batchNumber: number,
+  sku: number,
+  quantity: number,
+) {
+  return {
+    candidateKey: `${prefix}-candidate-${batchNumber}-${sku}`,
+    inventoryDeltaKey: `${prefix}-delta-${batchNumber}-${sku}`,
+    batchNumber,
+    sku,
+    productId: metadata.productId,
+    productLine: "Pokemon",
+    setName: "Test Set",
+    productName: `Card ${sku}`,
+    condition: "Near Mint",
+    desiredPrice: 4.25,
+    quantityDelta: quantity,
+    pricedAt: new Date("2026-08-10T11:00:00.000Z"),
+  };
+}
+
+try {
+  await addReceipt(skuA, 2, "aa");
+  await addReceipt(skuA, 3, "bbb");
+  await addReceipt(skuB, 4, "cccc");
+  const batch = await inventoryBatchesRepository.createFromPendingInventory(
+    `${prefix}-batch`,
+  );
+  assert.ok(batch);
+
+  const params = {
+    planningKey: `${prefix}-plan`,
+    batchNumber: batch.batchNumber,
+    method: "staged_delta" as const,
+    sourceType: "pending_inventory" as const,
+    sellerKey,
+    items: [
+      publicationItem(batch.batchNumber, skuA, 5),
+      publicationItem(batch.batchNumber, skuB, 4),
+    ],
+  };
+  const planned = await inventoryPublicationsRepository.createOrFindPlanned(params);
+  const repeated = await inventoryPublicationsRepository.createOrFindPlanned(params);
+  assert.equal(repeated.created, false);
+  await assert.rejects(
+    inventoryPublicationsRepository.createOrFindPlanned({
+      ...params,
+      items: [{ ...params.items[0], desiredPrice: 5 }, params.items[1]],
+    }),
+    /different planning inputs/,
+  );
+
+  const publicationId = Number(planned.publication.id);
+  const itemA = Number(planned.publication.items.find((item) => item.sku === skuA)?.id);
+  const itemB = Number(planned.publication.items.find((item) => item.sku === skuB)?.id);
+  const plannedLinks = await query<{ sku: number; quantity: number; liveAt: Date | null }>(
+    `SELECT receipt.sku, SUM(link.planned_quantity)::int AS quantity,
+      MAX(link.live_at) AS "liveAt"
+    FROM inventory_publication_receipt_links link
+    JOIN inventory_receipts receipt ON receipt.receipt_id = link.receipt_id
+    WHERE link.publication_item_id = ANY($1::bigint[])
+    GROUP BY receipt.sku ORDER BY receipt.sku`,
+    [[itemA, itemB]],
+  );
+  assert.deepEqual(
+    plannedLinks.map((row) => ({ sku: row.sku, quantity: row.quantity, liveAt: row.liveAt })),
+    [
+      { sku: skuA, quantity: 5, liveAt: null },
+      { sku: skuB, quantity: 4, liveAt: null },
+    ],
+  );
+
+  await execute(
+    `UPDATE inventory_publications SET status = 'publishing' WHERE id = $1`,
+    [publicationId],
+  );
+  await execute(`CREATE FUNCTION ${prefix.replaceAll("-", "_")}_fail_activation()
+    RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN
+      RAISE EXCEPTION 'injected activation failure';
+    END $$`);
+  await execute(`CREATE TRIGGER fail_activation
+    BEFORE UPDATE ON inventory_publication_receipt_links
+    FOR EACH ROW EXECUTE FUNCTION ${prefix.replaceAll("-", "_")}_fail_activation()`);
+
+  const confirmedAtA = new Date("2026-08-10T12:00:00.000Z");
+  const outcomes = [
+    {
+      itemId: itemA,
+      status: "published" as const,
+      confirmedAt: confirmedAtA,
+      confirmationEvidence: { source: "test-response", responseId: "one" },
+    },
+    {
+      itemId: itemB,
+      status: "ambiguous" as const,
+      errorCode: "seller_portal_item_warning",
+      errorMessage: "confirmation required",
+    },
+  ];
+  await assert.rejects(
+    inventoryPublicationsRepository.saveItemOutcomes(publicationId, outcomes),
+    /injected activation failure/,
+  );
+  assert.deepEqual(
+    planned.publication.items.map((item) => item.status),
+    ["planned", "planned"],
+  );
+  const unchanged = await inventoryPublicationsRepository.findById(publicationId);
+  assert.deepEqual(unchanged?.items.map((item) => item.status), ["planned", "planned"]);
+
+  await execute(`DROP TRIGGER fail_activation ON inventory_publication_receipt_links`);
+  await execute(`DROP FUNCTION ${prefix.replaceAll("-", "_")}_fail_activation()`);
+  await inventoryPublicationsRepository.saveItemOutcomes(publicationId, outcomes);
+  await execute(
+    `UPDATE inventory_publications SET status = 'ambiguous' WHERE id = $1`,
+    [publicationId],
+  );
+
+  let activation = await query<{
+    sku: number;
+    quantity: number;
+    liveAt: Date | null;
+    sellerKey: string | null;
+  }>(
+    `SELECT receipt.sku, SUM(link.planned_quantity)::int AS quantity,
+      MAX(link.live_at) AS "liveAt", MIN(receipt.seller_key) AS "sellerKey"
+    FROM inventory_publication_receipt_links link
+    JOIN inventory_receipts receipt ON receipt.receipt_id = link.receipt_id
+    WHERE link.publication_item_id = ANY($1::bigint[])
+      AND link.live_at IS NOT NULL
+    GROUP BY receipt.sku ORDER BY receipt.sku`,
+    [[itemA, itemB]],
+  );
+  assert.deepEqual(
+    activation.map((row) => ({
+      sku: row.sku,
+      quantity: row.quantity,
+      liveAt: row.liveAt?.toISOString(),
+      sellerKey: row.sellerKey,
+    })),
+    [{ sku: skuA, quantity: 5, liveAt: confirmedAtA.toISOString(), sellerKey }],
+  );
+
+  const confirmedAtB = new Date("2026-08-10T12:05:00.000Z");
+  const correctionResponse = await publicationAction({
+    params: { batchNumber: String(batch.batchNumber) },
+    request: new Request(
+      `http://localhost/api/inventory-batches/${batch.batchNumber}/publications`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          operation: "confirm-ambiguous-item",
+          publicationId,
+          itemId: itemB,
+          confirmedQuantity: 4,
+          sellerKey,
+          confirmedAt: confirmedAtB.toISOString(),
+          evidence: { source: "operator-confirmation", ticket: "T-1" },
+        }),
+      },
+    ),
+  });
+  assert.equal(correctionResponse.init?.status, 200);
+  const correctedPublication = correctionResponse.data as {
+    id: number;
+    status: string;
+    items: Array<{ id: number }>;
+  };
+  assert.equal(typeof correctedPublication.id, "number");
+  assert.equal(typeof correctedPublication.items[0]?.id, "number");
+  assert.equal(correctedPublication.status, "published");
+  const repeatCorrection = () =>
+    publicationAction({
+      params: { batchNumber: String(batch.batchNumber) },
+      request: new Request(
+        `http://localhost/api/inventory-batches/${batch.batchNumber}/publications`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            operation: "confirm-ambiguous-item",
+            publicationId,
+            itemId: itemB,
+            confirmedQuantity: 4,
+            sellerKey,
+            confirmedAt: confirmedAtB.toISOString(),
+            evidence: { ticket: "T-1", source: "operator-confirmation" },
+          }),
+        },
+      ),
+    });
+  assert.equal((await repeatCorrection()).init?.status, 200);
+  const conflictingCorrection = await publicationAction({
+    params: { batchNumber: String(batch.batchNumber) },
+    request: new Request(
+      `http://localhost/api/inventory-batches/${batch.batchNumber}/publications`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          operation: "confirm-ambiguous-item",
+          publicationId,
+          itemId: itemB,
+          confirmedQuantity: 4,
+          sellerKey,
+          confirmedAt: confirmedAtB.toISOString(),
+          evidence: { source: "different-evidence" },
+        }),
+      },
+    ),
+  });
+  assert.equal(conflictingCorrection.init?.status, 409);
+
+  await inventoryPublicationsRepository.saveItemOutcomes(publicationId, [
+    {
+      itemId: itemA,
+      status: "published",
+      confirmedAt: confirmedAtA,
+      confirmationEvidence: { source: "test-response", responseId: "one" },
+    },
+  ]);
+  await assert.rejects(
+    inventoryPublicationsRepository.saveItemOutcomes(publicationId, [
+      {
+        itemId: itemA,
+        status: "published",
+        confirmedAt: new Date("2026-08-11T12:00:00.000Z"),
+        confirmationEvidence: { source: "conflicting-callback" },
+      },
+    ]),
+    /different confirmation evidence/,
+  );
+  activation = await query(
+    `SELECT receipt.sku, SUM(link.planned_quantity)::int AS quantity,
+      MAX(link.live_at) AS "liveAt", MIN(receipt.seller_key) AS "sellerKey"
+    FROM inventory_publication_receipt_links link
+    JOIN inventory_receipts receipt ON receipt.receipt_id = link.receipt_id
+    WHERE link.publication_item_id = ANY($1::bigint[]) AND link.live_at IS NOT NULL
+    GROUP BY receipt.sku ORDER BY receipt.sku`,
+    [[itemA, itemB]],
+  );
+  assert.deepEqual(
+    activation.map((row) => ({ sku: row.sku, quantity: row.quantity, liveAt: row.liveAt?.toISOString() })),
+    [
+      { sku: skuA, quantity: 5, liveAt: confirmedAtA.toISOString() },
+      { sku: skuB, quantity: 4, liveAt: confirmedAtB.toISOString() },
+    ],
+  );
+
+  const priceOnly = await inventoryPublicationsRepository.createOrFindPlanned({
+    planningKey: `${prefix}-price-only`,
+    method: "staged_delta",
+    sourceType: "continuous",
+    sellerKey,
+    items: [{
+      ...publicationItem(batch.batchNumber, 9_200_010, 0),
+      candidateKey: `${prefix}-price-only-candidate`,
+      inventoryDeltaKey: null,
+      batchNumber: null,
+    }],
+  });
+  await inventoryPublicationsRepository.saveItemOutcomes(Number(priceOnly.publication.id), [
+    { itemId: Number(priceOnly.publication.items[0].id), status: "published" },
+  ]);
+  const priceOnlyLinks = await queryOne<{ count: number }>(
+    `SELECT COUNT(*)::int AS count FROM inventory_publication_receipt_links
+    WHERE publication_item_id = $1`,
+    [priceOnly.publication.items[0].id],
+  );
+  assert.equal(priceOnlyLinks?.count, 0);
+  await execute(
+    `UPDATE inventory_publications
+    SET status = 'publishing', claimed_by = 'active-worker',
+      claim_expires_at = NOW() + INTERVAL '5 minutes'
+    WHERE id = $1`,
+    [priceOnly.publication.id],
+  );
+  assert.equal(
+    await inventoryPublicationsRepository.recoverPublicationsWithSavedOutcomes(),
+    0,
+  );
+  assert.equal(
+    (await inventoryPublicationsRepository.findById(Number(priceOnly.publication.id)))?.status,
+    "publishing",
+  );
+  await execute(
+    `UPDATE inventory_publications SET claim_expires_at = NOW() - INTERVAL '1 minute'
+    WHERE id = $1`,
+    [priceOnly.publication.id],
+  );
+  assert.equal(
+    await inventoryPublicationsRepository.recoverPublicationsWithSavedOutcomes(),
+    1,
+  );
+
+  await addReceipt(9_200_020, 1, "mismatch");
+  const mismatchBatch = await inventoryBatchesRepository.createFromPendingInventory(
+    `${prefix}-mismatch-batch`,
+  );
+  assert.ok(mismatchBatch);
+  await execute(
+    `UPDATE inventory_receipts receipt SET seller_key = 'seller-a'
+    FROM inventory_receipt_batch_links link
+    WHERE link.batch_number = $1 AND link.receipt_id = receipt.receipt_id`,
+    [mismatchBatch.batchNumber],
+  );
+  await assert.rejects(
+    inventoryPublicationsRepository.createOrFindPlanned({
+      planningKey: `${prefix}-mismatch-plan`,
+      batchNumber: mismatchBatch.batchNumber,
+      method: "staged_delta",
+      sourceType: "pending_inventory",
+      sellerKey: "seller-b",
+      items: [publicationItem(mismatchBatch.batchNumber, 9_200_020, 1)],
+    }),
+    /different seller/,
+  );
+  await assert.rejects(
+    inventoryPublicationsRepository.createOrFindPlanned({
+      planningKey: `${prefix}-absolute-plan`,
+      batchNumber: mismatchBatch.batchNumber,
+      method: "direct_absolute",
+      sourceType: "pending_inventory",
+      sellerKey: "seller-a",
+      items: [publicationItem(mismatchBatch.batchNumber, 9_200_020, 1)],
+    }),
+    /only be published with staged quantity deltas/,
+  );
+
+  const recoverySku = 9_200_030;
+  await addReceipt(recoverySku, 2, "lease-recovery");
+  const recoveryBatch = await inventoryBatchesRepository.createFromPendingInventory(
+    `${prefix}-recovery-batch`,
+  );
+  assert.ok(recoveryBatch);
+  const recoveryPlan = await inventoryPublicationsRepository.createOrFindPlanned({
+    planningKey: `${prefix}-recovery-plan`,
+    batchNumber: recoveryBatch.batchNumber,
+    method: "staged_delta",
+    sourceType: "pending_inventory",
+    sellerKey,
+    items: [publicationItem(recoveryBatch.batchNumber, recoverySku, 2)],
+  });
+  const recoveryPublicationId = Number(recoveryPlan.publication.id);
+  const recoveryItemId = Number(recoveryPlan.publication.items[0].id);
+  await execute(
+    `UPDATE inventory_publications
+    SET status = 'publishing', claimed_by = 'lost-worker',
+      claim_expires_at = NOW() - INTERVAL '1 minute'
+    WHERE id = $1`,
+    [recoveryPublicationId],
+  );
+  assert.equal(await inventoryPublicationsRepository.recoverExpiredClaims(), 1);
+  const expired = await inventoryPublicationsRepository.findById(
+    recoveryPublicationId,
+  );
+  assert.equal(expired?.status, "ambiguous");
+  assert.equal(expired?.items[0]?.status, "ambiguous");
+
+  const recoveryConfirmedAt = new Date("2026-08-10T13:00:00.000Z");
+  const recoveryResponse = await publicationAction({
+    params: { batchNumber: String(recoveryBatch.batchNumber) },
+    request: new Request(
+      `http://localhost/api/inventory-batches/${recoveryBatch.batchNumber}/publications`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          operation: "confirm-ambiguous-item",
+          publicationId: recoveryPublicationId,
+          itemId: recoveryItemId,
+          confirmedQuantity: 2,
+          sellerKey,
+          confirmedAt: recoveryConfirmedAt.toISOString(),
+          evidence: { source: "operator-confirmation", ticket: "T-2" },
+        }),
+      },
+    ),
+  });
+  assert.equal(recoveryResponse.init?.status, 200);
+  const recoveredLink = await queryOne<{ liveAt: Date }>(
+    `SELECT live_at AS "liveAt"
+    FROM inventory_publication_receipt_links
+    WHERE publication_item_id = $1`,
+    [recoveryItemId],
+  );
+  assert.equal(recoveredLink?.liveAt.toISOString(), recoveryConfirmedAt.toISOString());
+  const beforeIntakeResponse = await publicationAction({
+    params: { batchNumber: String(recoveryBatch.batchNumber) },
+    request: new Request(
+      `http://localhost/api/inventory-batches/${recoveryBatch.batchNumber}/publications`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          operation: "confirm-ambiguous-item",
+          publicationId: recoveryPublicationId,
+          itemId: recoveryItemId,
+          confirmedQuantity: 2,
+          sellerKey,
+          confirmedAt: "2026-01-01T00:00:00.000Z",
+          evidence: { source: "conflicting-time" },
+        }),
+      },
+    ),
+  });
+  assert.equal(beforeIntakeResponse.init?.status, 409);
+
+  console.log("PASS publication outcomes activate exact receipt lots once with safe recovery");
+} finally {
+  await getPool().end();
+}

--- a/app/core/db/repositories/inventoryPublications.server.ts
+++ b/app/core/db/repositories/inventoryPublications.server.ts
@@ -497,7 +497,7 @@ export const inventoryPublicationsRepository = {
           params.pricingJobId ?? null,
           params.method,
           params.sourceType,
-          params.sellerKey ?? null,
+          params.sellerKey?.trim() || null,
           asJson(params.config ?? {}),
         ],
         client,

--- a/app/core/db/repositories/inventoryPublications.server.ts
+++ b/app/core/db/repositories/inventoryPublications.server.ts
@@ -3,6 +3,7 @@ import type {
   InventoryPublication,
   InventoryPublicationItem,
   InventoryPublicationItemOutcome,
+  InventoryPublicationReceiptLink,
   InventoryPublicationStatus,
 } from "~/features/inventory-publication/types/inventoryPublication";
 import { requireInventoryPublicationTransition } from "~/features/inventory-publication/services/inventoryPublicationState";
@@ -18,6 +19,41 @@ import {
 
 type InventoryPublicationRow = Omit<InventoryPublication, "items">;
 type InventoryPublicationItemRow = InventoryPublicationItem;
+
+function safeDatabaseId(value: number | string | null, name: string): number | null {
+  if (value === null) return null;
+  const id = Number(value);
+  if (!Number.isSafeInteger(id) || id <= 0) {
+    throw new Error(`${name} is outside the supported integer range.`);
+  }
+  return id;
+}
+
+function normalizePublicationRow(
+  row: InventoryPublicationRow,
+): InventoryPublicationRow {
+  return {
+    ...row,
+    id: safeDatabaseId(row.id as number | string, "Publication ID")!,
+    pricingJobId: safeDatabaseId(
+      row.pricingJobId as number | string | null,
+      "Pricing job ID",
+    ),
+  };
+}
+
+function normalizePublicationItem(
+  row: InventoryPublicationItemRow,
+): InventoryPublicationItem {
+  return {
+    ...row,
+    id: safeDatabaseId(row.id as number | string, "Publication item ID")!,
+    publicationId: safeDatabaseId(
+      row.publicationId as number | string,
+      "Publication ID",
+    )!,
+  };
+}
 
 export interface CreateOrFindInventoryPublicationResult {
   publication: InventoryPublication;
@@ -87,6 +123,16 @@ function validateCreateParams(params: CreateInventoryPublication): void {
 
   if (params.items.length === 0) {
     throw new RangeError("items must contain at least one publication item.");
+  }
+
+  if (
+    params.sourceType === "pending_inventory" &&
+    params.items.some((item) => item.quantityDelta > 0) &&
+    params.method !== "staged_delta"
+  ) {
+    throw new RangeError(
+      "Received inventory can only be published with staged quantity deltas.",
+    );
   }
 
   if (
@@ -211,13 +257,14 @@ async function findItems(
   publicationId: number,
   executor?: Queryable,
 ): Promise<InventoryPublicationItem[]> {
-  return query<InventoryPublicationItemRow>(
+  const rows = await query<InventoryPublicationItemRow>(
     `${publicationItemSelect}
     WHERE publication_id = $1
     ORDER BY id`,
     [publicationId],
     executor,
   );
+  return rows.map(normalizePublicationItem);
 }
 
 async function attachItems(
@@ -225,8 +272,11 @@ async function attachItems(
   executor?: Queryable,
 ): Promise<InventoryPublication> {
   return {
-    ...publication,
-    items: await findItems(publication.id, executor),
+    ...normalizePublicationRow(publication),
+    items: await findItems(
+      safeDatabaseId(publication.id as number | string, "Publication ID")!,
+      executor,
+    ),
   };
 }
 
@@ -758,9 +808,10 @@ export const inventoryPublicationsRepository = {
 
     const publication = await queryOne<{
       sourceType: InventoryPublication["sourceType"];
+      method: InventoryPublication["method"];
       sellerKey: string | null;
     }>(
-      `SELECT source_type AS "sourceType", seller_key AS "sellerKey"
+      `SELECT source_type AS "sourceType", method, seller_key AS "sellerKey"
       FROM inventory_publications
       WHERE id = $1
       FOR UPDATE`,
@@ -800,6 +851,7 @@ export const inventoryPublicationsRepository = {
 
       const activatesReceipts =
         publication.sourceType === "pending_inventory" &&
+        publication.method === "staged_delta" &&
         item.quantityDelta > 0 &&
         outcome.status === "published";
       if (
@@ -844,18 +896,35 @@ export const inventoryPublicationsRepository = {
         const linked = await queryOne<{
           plannedQuantity: number;
           mismatchedSellerCount: number;
+          linkCount: number;
+          activatedCount: number;
+          conflictingEvidenceCount: number;
         }>(
           `SELECT
             COALESCE(SUM(link.planned_quantity), 0)::int AS "plannedQuantity",
+            COUNT(*)::int AS "linkCount",
+            COUNT(*) FILTER (WHERE link.live_at IS NOT NULL)::int AS "activatedCount",
             COUNT(*) FILTER (
               WHERE receipt.seller_key IS NOT NULL
                 AND receipt.seller_key <> $2
-            )::int AS "mismatchedSellerCount"
+            )::int AS "mismatchedSellerCount",
+            COUNT(*) FILTER (
+              WHERE link.live_at IS NOT NULL
+                AND (
+                  link.live_at <> $3
+                  OR link.confirmation_evidence IS DISTINCT FROM $4::jsonb
+                )
+            )::int AS "conflictingEvidenceCount"
           FROM inventory_publication_receipt_links link
           JOIN inventory_receipts receipt ON receipt.receipt_id = link.receipt_id
           WHERE link.publication_item_id = $1
             AND link.target_seller_key = $2`,
-          [outcome.itemId, publication.sellerKey],
+          [
+            outcome.itemId,
+            publication.sellerKey,
+            outcome.confirmedAt,
+            asJson(outcome.confirmationEvidence),
+          ],
           executor,
         );
         if ((linked?.mismatchedSellerCount ?? 0) > 0) {
@@ -866,6 +935,16 @@ export const inventoryPublicationsRepository = {
         if ((linked?.plannedQuantity ?? 0) !== item.quantityDelta) {
           throw new Error(
             `Publication item ${outcome.itemId} cannot activate ${item.quantityDelta} units from ${linked?.plannedQuantity ?? 0} linked units.`,
+          );
+        }
+        if (
+          repeated &&
+          ((linked?.activatedCount ?? 0) !== (linked?.linkCount ?? 0) ||
+            (linked?.conflictingEvidenceCount ?? 0) > 0 ||
+            item.publishedAt?.getTime() !== outcome.confirmedAt?.getTime())
+        ) {
+          throw new Error(
+            `Publication item ${outcome.itemId} already has different confirmation evidence.`,
           );
         }
 
@@ -912,7 +991,17 @@ export const inventoryPublicationsRepository = {
           claimed_by = NULL,
           claim_expires_at = NULL,
           updated_at = NOW()
-      WHERE publication.status IN ('publishing', 'ambiguous')
+      WHERE (
+          publication.status = 'ambiguous'
+          OR (
+            publication.status = 'publishing'
+            AND (
+              publication.claimed_by IS NULL
+              OR publication.claim_expires_at IS NULL
+              OR publication.claim_expires_at < NOW()
+            )
+          )
+        )
         AND EXISTS (
           SELECT 1 FROM inventory_publication_items item
           WHERE item.publication_id = publication.id
@@ -926,6 +1015,29 @@ export const inventoryPublicationsRepository = {
       RETURNING publication.id`,
     );
     return recovered.length;
+  },
+
+  async findReceiptLinks(
+    publicationItemId: number,
+    executor?: Queryable,
+  ): Promise<InventoryPublicationReceiptLink[]> {
+    return query<InventoryPublicationReceiptLink>(
+      `SELECT
+        link.publication_item_id AS "publicationItemId",
+        link.receipt_id AS "receiptId",
+        link.planned_quantity AS "plannedQuantity",
+        link.target_seller_key AS "targetSellerKey",
+        link.live_at AS "liveAt",
+        link.activated_at AS "activatedAt",
+        link.confirmation_evidence AS "confirmationEvidence",
+        receipt.intake_at AS "intakeAt"
+      FROM inventory_publication_receipt_links link
+      JOIN inventory_receipts receipt ON receipt.receipt_id = link.receipt_id
+      WHERE link.publication_item_id = $1
+      ORDER BY receipt.intake_at NULLS FIRST, receipt.receipt_id`,
+      [publicationItemId],
+      executor,
+    );
   },
 
   async markPlannedItems(
@@ -980,8 +1092,9 @@ export const inventoryPublicationsRepository = {
     };
   },
   async recoverExpiredClaims(): Promise<number> {
-    const recovered = await query<{ id: number }>(
-      `UPDATE inventory_publications
+    return withTransaction(async (client) => {
+      const recovered = await query<{ id: number }>(
+        `UPDATE inventory_publications
       SET status = CASE
             WHEN status = 'publishing' THEN 'ambiguous'
             WHEN staged_pricing_upload_id IS NOT NULL THEN 'ambiguous'
@@ -1006,8 +1119,26 @@ export const inventoryPublicationsRepository = {
         AND claim_expires_at IS NOT NULL
         AND claim_expires_at < NOW()
       RETURNING id`,
-    );
-
-    return recovered.length;
+        [],
+        client,
+      );
+      if (recovered.length > 0) {
+        await execute(
+          `UPDATE inventory_publication_items item
+          SET status = 'ambiguous',
+              error_code = 'worker_lease_expired',
+              error_message = 'Worker lease expired after Seller Portal state may have changed.',
+              updated_at = NOW()
+          FROM inventory_publications publication
+          WHERE item.publication_id = publication.id
+            AND publication.id = ANY($1::bigint[])
+            AND publication.status = 'ambiguous'
+            AND item.status = 'planned'`,
+          [recovered.map((row) => row.id)],
+          client,
+        );
+      }
+      return recovered.length;
+    });
   },
 };

--- a/app/core/db/repositories/inventoryPublications.server.ts
+++ b/app/core/db/repositories/inventoryPublications.server.ts
@@ -89,6 +89,16 @@ function validateCreateParams(params: CreateInventoryPublication): void {
     throw new RangeError("items must contain at least one publication item.");
   }
 
+  if (
+    params.sourceType === "pending_inventory" &&
+    params.items.some((item) => item.quantityDelta > 0) &&
+    !params.sellerKey?.trim()
+  ) {
+    throw new RangeError(
+      "sellerKey is required for received inventory publication.",
+    );
+  }
+
   params.items.forEach((item, index) => {
     const prefix = `items[${index}]`;
     requireNonEmptyText(item.candidateKey, `${prefix}.candidateKey`);
@@ -122,6 +132,79 @@ function validateCreateParams(params: CreateInventoryPublication): void {
       );
     }
   });
+}
+
+async function linkPendingInventoryReceipts(
+  publicationId: number,
+  sellerKey: string,
+  executor: Queryable,
+): Promise<void> {
+  const items = await query<{
+    itemId: number;
+    batchNumber: number | null;
+    sku: number;
+    quantityDelta: number;
+  }>(
+    `SELECT
+      id AS "itemId",
+      batch_number AS "batchNumber",
+      sku,
+      quantity_delta AS "quantityDelta"
+    FROM inventory_publication_items
+    WHERE publication_id = $1 AND quantity_delta > 0`,
+    [publicationId],
+    executor,
+  );
+
+  for (const item of items) {
+    if (!item.batchNumber) {
+      throw new Error(
+        `Publication item ${item.itemId} cannot link receipts without a batch.`,
+      );
+    }
+
+    const receiptSummary = await queryOne<{
+      linkedQuantity: number;
+      mismatchedSellerCount: number;
+    }>(
+      `SELECT
+        COALESCE(SUM(link.linked_quantity), 0)::int AS "linkedQuantity",
+        COUNT(*) FILTER (
+          WHERE receipt.seller_key IS NOT NULL
+            AND receipt.seller_key <> $3
+        )::int AS "mismatchedSellerCount"
+      FROM inventory_receipt_batch_links link
+      JOIN inventory_receipts receipt ON receipt.receipt_id = link.receipt_id
+      WHERE link.batch_number = $1 AND receipt.sku = $2`,
+      [item.batchNumber, item.sku, sellerKey],
+      executor,
+    );
+    if ((receiptSummary?.mismatchedSellerCount ?? 0) > 0) {
+      throw new Error(
+        `SKU ${item.sku} has receipt lots assigned to a different seller.`,
+      );
+    }
+    if ((receiptSummary?.linkedQuantity ?? 0) !== item.quantityDelta) {
+      throw new Error(
+        `SKU ${item.sku} publication quantity ${item.quantityDelta} does not match linked receipt quantity ${receiptSummary?.linkedQuantity ?? 0}.`,
+      );
+    }
+
+    await execute(
+      `INSERT INTO inventory_publication_receipt_links (
+        publication_item_id,
+        receipt_id,
+        planned_quantity,
+        target_seller_key
+      )
+      SELECT $1, link.receipt_id, link.linked_quantity, $4
+      FROM inventory_receipt_batch_links link
+      JOIN inventory_receipts receipt ON receipt.receipt_id = link.receipt_id
+      WHERE link.batch_number = $2 AND receipt.sku = $3`,
+      [item.itemId, item.batchNumber, item.sku, sellerKey],
+      executor,
+    );
+  }
 }
 
 async function findItems(
@@ -159,6 +242,66 @@ async function findByPlanningKey(
   );
 
   return publication ? attachItems(publication, executor) : null;
+}
+
+function plannedPublicationIdentity(
+  publication: InventoryPublication,
+): string {
+  return JSON.stringify({
+    batchNumber: publication.batchNumber,
+    pricingJobId: publication.pricingJobId,
+    method: publication.method,
+    sourceType: publication.sourceType,
+    sellerKey: publication.sellerKey,
+    items: publication.items.map((item) => ({
+      candidateKey: item.candidateKey,
+      inventoryDeltaKey: item.inventoryDeltaKey,
+      batchNumber: item.batchNumber,
+      sku: item.sku,
+      productId: item.productId,
+      productLine: item.productLine,
+      setName: item.setName,
+      productName: item.productName,
+      condition: item.condition,
+      previousPrice: item.previousPrice,
+      desiredPrice: item.desiredPrice,
+      quantityDelta: item.quantityDelta,
+      observedQuantity: item.observedQuantity,
+      desiredAbsoluteQuantity: item.desiredAbsoluteQuantity,
+      pricedAt: item.pricedAt.toISOString(),
+      eligibilityReasons: item.eligibilityReasons,
+    })),
+  });
+}
+
+function requestedPublicationIdentity(
+  params: CreateInventoryPublication,
+): string {
+  return JSON.stringify({
+    batchNumber: params.batchNumber ?? null,
+    pricingJobId: params.pricingJobId ?? null,
+    method: params.method,
+    sourceType: params.sourceType,
+    sellerKey: params.sellerKey?.trim() || null,
+    items: params.items.map((item) => ({
+      candidateKey: item.candidateKey,
+      inventoryDeltaKey: item.inventoryDeltaKey?.trim() || null,
+      batchNumber: item.batchNumber ?? params.batchNumber ?? null,
+      sku: item.sku,
+      productId: item.productId,
+      productLine: item.productLine,
+      setName: item.setName,
+      productName: item.productName,
+      condition: item.condition,
+      previousPrice: item.previousPrice ?? null,
+      desiredPrice: item.desiredPrice,
+      quantityDelta: item.quantityDelta,
+      observedQuantity: item.observedQuantity ?? null,
+      desiredAbsoluteQuantity: item.desiredAbsoluteQuantity ?? null,
+      pricedAt: item.pricedAt.toISOString(),
+      eligibilityReasons: item.eligibilityReasons ?? [],
+    })),
+  });
 }
 
 export const inventoryPublicationsRepository = {
@@ -318,6 +461,15 @@ export const inventoryPublicationsRepository = {
           );
         }
 
+        if (
+          plannedPublicationIdentity(existing) !==
+          requestedPublicationIdentity(params)
+        ) {
+          throw new Error(
+            `Inventory publication ${params.planningKey} already exists with different planning inputs.`,
+          );
+        }
+
         return { publication: existing, created: false };
       }
 
@@ -367,6 +519,17 @@ export const inventoryPublicationsRepository = {
         values,
         client,
       );
+
+      if (
+        params.sourceType === "pending_inventory" &&
+        params.items.some((item) => item.quantityDelta > 0)
+      ) {
+        await linkPendingInventoryReceipts(
+          inserted.id,
+          params.sellerKey!.trim(),
+          client,
+        );
+      }
 
       return {
         publication: await attachItems(inserted, client),
@@ -593,36 +756,176 @@ export const inventoryPublicationsRepository = {
       return;
     }
 
+    const publication = await queryOne<{
+      sourceType: InventoryPublication["sourceType"];
+      sellerKey: string | null;
+    }>(
+      `SELECT source_type AS "sourceType", seller_key AS "sellerKey"
+      FROM inventory_publications
+      WHERE id = $1
+      FOR UPDATE`,
+      [publicationId],
+      executor,
+    );
+    if (!publication) {
+      throw new Error(`Inventory publication ${publicationId} not found.`);
+    }
+
     for (const outcome of outcomes) {
-      const updated = await execute(
+      const item = await queryOne<{
+        status: InventoryPublicationItem["status"];
+        quantityDelta: number;
+        publishedAt: Date | null;
+      }>(
+        `SELECT
+          status,
+          quantity_delta AS "quantityDelta",
+          published_at AS "publishedAt"
+        FROM inventory_publication_items
+        WHERE id = $1 AND publication_id = $2
+        FOR UPDATE`,
+        [outcome.itemId, publicationId],
+        executor,
+      );
+      if (!item) {
+        throw new Error(`Publication item ${outcome.itemId} not found.`);
+      }
+      const correction = item.status === "ambiguous" && outcome.status === "published";
+      const repeated = item.status === outcome.status;
+      if (item.status !== "planned" && !repeated && !correction) {
+        throw new Error(
+          `Publication item ${outcome.itemId} cannot change from ${item.status} to ${outcome.status}.`,
+        );
+      }
+
+      const activatesReceipts =
+        publication.sourceType === "pending_inventory" &&
+        item.quantityDelta > 0 &&
+        outcome.status === "published";
+      if (
+        activatesReceipts &&
+        (!publication.sellerKey ||
+          !outcome.confirmedAt ||
+          !outcome.confirmationEvidence)
+      ) {
+        throw new Error(
+          `Publication item ${outcome.itemId} requires seller, confirmation time, and evidence before receipt activation.`,
+        );
+      }
+
+      await execute(
         `UPDATE inventory_publication_items
         SET status = $3,
             error_code = $4,
             error_message = $5,
             published_at = CASE
-              WHEN $3 = 'published' THEN NOW()
+              WHEN $3 = 'published' THEN COALESCE(published_at, $6)
               ELSE published_at
             END,
             updated_at = NOW()
         WHERE id = $1
           AND publication_id = $2
-          AND status = 'planned'`,
+          AND status = ANY($7::text[])`,
         [
           outcome.itemId,
           publicationId,
           outcome.status,
           outcome.errorCode ?? null,
           outcome.errorMessage ?? null,
+          outcome.confirmedAt ?? new Date(),
+          correction
+            ? ["planned", "ambiguous", "published"]
+            : ["planned", outcome.status],
         ],
         executor,
       );
 
-      if (updated !== 1) {
-        throw new Error(
-          `Publication item ${outcome.itemId} could not record ${outcome.status}.`,
+      if (activatesReceipts) {
+        const linked = await queryOne<{
+          plannedQuantity: number;
+          mismatchedSellerCount: number;
+        }>(
+          `SELECT
+            COALESCE(SUM(link.planned_quantity), 0)::int AS "plannedQuantity",
+            COUNT(*) FILTER (
+              WHERE receipt.seller_key IS NOT NULL
+                AND receipt.seller_key <> $2
+            )::int AS "mismatchedSellerCount"
+          FROM inventory_publication_receipt_links link
+          JOIN inventory_receipts receipt ON receipt.receipt_id = link.receipt_id
+          WHERE link.publication_item_id = $1
+            AND link.target_seller_key = $2`,
+          [outcome.itemId, publication.sellerKey],
+          executor,
+        );
+        if ((linked?.mismatchedSellerCount ?? 0) > 0) {
+          throw new Error(
+            `Publication item ${outcome.itemId} has receipts assigned to another seller.`,
+          );
+        }
+        if ((linked?.plannedQuantity ?? 0) !== item.quantityDelta) {
+          throw new Error(
+            `Publication item ${outcome.itemId} cannot activate ${item.quantityDelta} units from ${linked?.plannedQuantity ?? 0} linked units.`,
+          );
+        }
+
+        await execute(
+          `UPDATE inventory_receipts receipt
+          SET seller_key = $2
+          FROM inventory_publication_receipt_links link
+          WHERE link.publication_item_id = $1
+            AND link.receipt_id = receipt.receipt_id
+            AND receipt.seller_key IS NULL`,
+          [outcome.itemId, publication.sellerKey],
+          executor,
+        );
+        await execute(
+          `UPDATE inventory_publication_receipt_links
+          SET live_at = COALESCE(live_at, $2),
+              activated_at = COALESCE(activated_at, NOW()),
+              confirmation_evidence = COALESCE(confirmation_evidence, $3::jsonb)
+          WHERE publication_item_id = $1`,
+          [
+            outcome.itemId,
+            outcome.confirmedAt,
+            asJson(outcome.confirmationEvidence),
+          ],
+          executor,
         );
       }
     }
+  },
+
+  async recoverPublicationsWithSavedOutcomes(): Promise<number> {
+    const recovered = await query<{ id: number }>(
+      `UPDATE inventory_publications publication
+      SET status = 'published',
+          published_at = COALESCE(
+            publication.published_at,
+            (SELECT MAX(item.published_at)
+             FROM inventory_publication_items item
+             WHERE item.publication_id = publication.id)
+          ),
+          completed_at = COALESCE(publication.completed_at, NOW()),
+          error_code = NULL,
+          error_message = NULL,
+          claimed_by = NULL,
+          claim_expires_at = NULL,
+          updated_at = NOW()
+      WHERE publication.status IN ('publishing', 'ambiguous')
+        AND EXISTS (
+          SELECT 1 FROM inventory_publication_items item
+          WHERE item.publication_id = publication.id
+            AND item.status = 'published'
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM inventory_publication_items item
+          WHERE item.publication_id = publication.id
+            AND item.status IN ('planned', 'ambiguous')
+        )
+      RETURNING publication.id`,
+    );
+    return recovered.length;
   },
 
   async markPlannedItems(

--- a/app/features/inventory-publication/services/inventoryBatchPublication.server.test.ts
+++ b/app/features/inventory-publication/services/inventoryBatchPublication.server.test.ts
@@ -367,6 +367,7 @@ const testCases: TestCase[] = [
         dependencies,
         now: NOW,
         selectedSkus: [5199433, 5199433],
+        targetSellerKey: "test-seller",
       });
 
       assert.match(
@@ -456,6 +457,18 @@ const testCases: TestCase[] = [
           selectedSkus: [],
         }),
         /Select at least one valid SKU/,
+      );
+    },
+  },
+  {
+    name: "received inventory requires a target seller before planning",
+    run: async () => {
+      await assert.rejects(
+        planInventoryBatchPublication(90, {
+          dependencies: createDependencies().dependencies,
+          now: NOW,
+        }),
+        /Select a target seller/,
       );
     },
   },

--- a/app/features/inventory-publication/services/inventoryBatchPublication.server.ts
+++ b/app/features/inventory-publication/services/inventoryBatchPublication.server.ts
@@ -212,6 +212,16 @@ function createPublicationParams(
 ): CreateInventoryPublication {
   const sellerKey = targetSellerKey?.trim() || undefined;
 
+  if (
+    preview.sourceType === "pending_inventory" &&
+    items.some((item) => item.quantityDelta > 0) &&
+    !sellerKey
+  ) {
+    throw new Error(
+      "Select a target seller before publishing received inventory.",
+    );
+  }
+
   return {
     planningKey: createSelectedPlanningKey(preview.pricingJobId, selectedSkus),
     batchNumber: preview.batchNumber,

--- a/app/features/inventory-publication/services/inventoryPublicationWorker.server.ts
+++ b/app/features/inventory-publication/services/inventoryPublicationWorker.server.ts
@@ -373,6 +373,10 @@ function responseItemsBySku(
 export function buildMoveToLiveOutcomes(
   items: InventoryPublicationItem[],
   response: MoveStagedPricingImportResponse,
+  confirmation?: {
+    confirmedAt: Date;
+    evidence: Record<string, unknown>;
+  },
 ): InventoryPublicationItemOutcome[] {
   const confirmed = responseItemsBySku([
     ...response.Success,
@@ -406,6 +410,8 @@ export function buildMoveToLiveOutcomes(
       return {
         itemId: item.id,
         status: "published",
+        confirmedAt: confirmation?.confirmedAt,
+        confirmationEvidence: confirmation?.evidence,
       };
     }
     return {
@@ -416,6 +422,20 @@ export function buildMoveToLiveOutcomes(
         "TCGplayer did not return a move-to-live outcome for this item.",
     };
   });
+}
+
+async function saveConfirmedOutcomes(
+  dependencies: InventoryPublicationWorkerDependencies,
+  publicationId: number,
+  outcomes: InventoryPublicationItemOutcome[],
+): Promise<void> {
+  try {
+    await dependencies.saveItemOutcomes(publicationId, outcomes);
+  } catch {
+    // The Seller Portal response is already in memory. Retry only the local,
+    // idempotent transaction; never repeat move-to-live here.
+    await dependencies.saveItemOutcomes(publicationId, outcomes);
+  }
 }
 
 async function failBeforeMove(
@@ -603,8 +623,19 @@ export async function executeClaimedStagedPublication(
       productDetailMismatchSkus,
     );
     const response = await dependencies.move({ uploadId });
-    const acceptedOutcomes = buildMoveToLiveOutcomes(acceptedItems, response);
-    await dependencies.saveItemOutcomes(publication.id, acceptedOutcomes);
+    const confirmedAt = new Date();
+    const acceptedOutcomes = buildMoveToLiveOutcomes(acceptedItems, response, {
+      confirmedAt,
+      evidence: {
+        source: "seller_portal_move_to_live",
+        stagedPricingUploadId: uploadId,
+      },
+    });
+    await saveConfirmedOutcomes(
+      dependencies,
+      publication.id,
+      acceptedOutcomes,
+    );
     const allOutcomes = [...rejectedOutcomes, ...acceptedOutcomes];
 
     const hasAmbiguousItems = allOutcomes.some(
@@ -694,6 +725,7 @@ async function tick(state: WorkerState): Promise<void> {
   state.running = true;
 
   try {
+    await inventoryPublicationsRepository.recoverPublicationsWithSavedOutcomes();
     await inventoryPublicationsRepository.recoverExpiredClaims();
     const configuration = await inventoryPublicationSettingsRepository.get();
     if (

--- a/app/features/inventory-publication/services/inventoryPublicationWorker.test.ts
+++ b/app/features/inventory-publication/services/inventoryPublicationWorker.test.ts
@@ -90,6 +90,8 @@ function createDependencies(
       ReturnType<InventoryPublicationWorkerDependencies["move"]>
     >;
     moveError?: Error;
+    saveFailures?: number;
+    completionTransitionFailures?: number;
   } = {},
 ): {
   dependencies: InventoryPublicationWorkerDependencies;
@@ -102,6 +104,9 @@ function createDependencies(
   const outcomes: InventoryPublicationItemOutcome[] = [];
   const markedItems: Array<{ status: string; errorCode: string }> = [];
   const projectedPublications: InventoryPublication[] = [];
+  let saveFailures = overrides.saveFailures ?? 0;
+  let completionTransitionFailures =
+    overrides.completionTransitionFailures ?? 0;
 
   return {
     calls,
@@ -154,6 +159,14 @@ function createDependencies(
       },
       transition: async (_publicationId, expectedStatus, nextStatus) => {
         calls.push(`transition:${expectedStatus}:${nextStatus}`);
+        if (
+          expectedStatus === "publishing" &&
+          nextStatus === "published" &&
+          completionTransitionFailures > 0
+        ) {
+          completionTransitionFailures -= 1;
+          throw new Error("local completion failed");
+        }
         return createPublication({
           status: nextStatus,
           items:
@@ -164,6 +177,10 @@ function createDependencies(
       },
       saveItemOutcomes: async (_publicationId, nextOutcomes) => {
         calls.push("save-outcomes");
+        if (saveFailures > 0) {
+          saveFailures -= 1;
+          throw new Error("local transaction failed");
+        }
         outcomes.push(...nextOutcomes);
       },
       markPlannedItems: async (_publicationId, status, errorCode) => {
@@ -202,7 +219,25 @@ const testCases: TestCase[] = [
         "save-outcomes",
         "transition:publishing:published",
       ]);
-      assert.deepEqual(outcomes, [{ itemId: 11, status: "published" }]);
+      assert.deepEqual(
+        outcomes.map((outcome) => ({
+          itemId: outcome.itemId,
+          status: outcome.status,
+          evidence: outcome.confirmationEvidence,
+          hasConfirmedAt: outcome.confirmedAt instanceof Date,
+        })),
+        [
+          {
+            itemId: 11,
+            status: "published",
+            evidence: {
+              source: "seller_portal_move_to_live",
+              stagedPricingUploadId: 16104570,
+            },
+            hasConfirmedAt: true,
+          },
+        ],
+      );
       assert.equal(projectedPublications.length, 1);
       assert.equal(projectedPublications[0]?.items[0]?.status, "published");
       assert.equal(
@@ -233,6 +268,38 @@ const testCases: TestCase[] = [
           errorCode: "staged_publication_rolled_back",
         },
       ]);
+    },
+  },
+  {
+    name: "a local outcome failure retries persistence without moving live twice",
+    run: async () => {
+      const { dependencies, calls, outcomes } = createDependencies({
+        saveFailures: 1,
+      });
+      await executeClaimedStagedPublication(
+        createPublication(),
+        "test-worker",
+        dependencies,
+      );
+      assert.equal(calls.filter((call) => call === "move").length, 1);
+      assert.equal(calls.filter((call) => call === "save-outcomes").length, 2);
+      assert.equal(outcomes[0]?.status, "published");
+    },
+  },
+  {
+    name: "saved outcomes survive a parent completion transition failure",
+    run: async () => {
+      const { dependencies, calls, outcomes } = createDependencies({
+        completionTransitionFailures: 1,
+      });
+      await executeClaimedStagedPublication(
+        createPublication(),
+        "test-worker",
+        dependencies,
+      );
+      assert.equal(calls.filter((call) => call === "move").length, 1);
+      assert.equal(outcomes[0]?.status, "published");
+      assert.ok(calls.includes("transition:publishing:ambiguous"));
     },
   },
   {

--- a/app/features/inventory-publication/types/inventoryPublication.ts
+++ b/app/features/inventory-publication/types/inventoryPublication.ts
@@ -208,6 +208,7 @@ export interface InventoryPublicationReceiptLink {
   liveAt: Date | null;
   activatedAt: Date | null;
   confirmationEvidence: Record<string, unknown> | null;
+  intakeAt: Date | null;
 }
 
 export interface InventoryBatchPublicationPreviewItem {

--- a/app/features/inventory-publication/types/inventoryPublication.ts
+++ b/app/features/inventory-publication/types/inventoryPublication.ts
@@ -196,6 +196,18 @@ export interface InventoryPublicationItemOutcome {
   >;
   errorCode?: string | null;
   errorMessage?: string | null;
+  confirmedAt?: Date;
+  confirmationEvidence?: Record<string, unknown>;
+}
+
+export interface InventoryPublicationReceiptLink {
+  publicationItemId: number;
+  receiptId: number;
+  plannedQuantity: number;
+  targetSellerKey: string;
+  liveAt: Date | null;
+  activatedAt: Date | null;
+  confirmationEvidence: Record<string, unknown> | null;
 }
 
 export interface InventoryBatchPublicationPreviewItem {

--- a/app/features/pending-inventory/routes/api.inventory-batch-publications.ts
+++ b/app/features/pending-inventory/routes/api.inventory-batch-publications.ts
@@ -57,6 +57,73 @@ export async function action({
     if (!batchNumber) {
       return data({ error: "Invalid batch number" }, { status: 400 });
     }
+    if (request.method === "PATCH") {
+      const body = (await request.json()) as Record<string, unknown>;
+      const publicationId = Number(body.publicationId);
+      const itemId = Number(body.itemId);
+      const confirmedQuantity = Number(body.confirmedQuantity);
+      const sellerKey =
+        typeof body.sellerKey === "string" ? body.sellerKey.trim() : "";
+      const confirmedAt =
+        typeof body.confirmedAt === "string"
+          ? new Date(body.confirmedAt)
+          : new Date(Number.NaN);
+      const evidence = body.evidence;
+      if (
+        body.operation !== "confirm-ambiguous-item" ||
+        !Number.isSafeInteger(publicationId) ||
+        publicationId <= 0 ||
+        !Number.isSafeInteger(itemId) ||
+        itemId <= 0 ||
+        !Number.isInteger(confirmedQuantity) ||
+        confirmedQuantity <= 0 ||
+        !sellerKey ||
+        Number.isNaN(confirmedAt.getTime()) ||
+        confirmedAt > new Date() ||
+        !evidence ||
+        typeof evidence !== "object" ||
+        Array.isArray(evidence) ||
+        Object.keys(evidence).length === 0
+      ) {
+        return data(
+          { error: "A valid ambiguous confirmation is required" },
+          { status: 400 },
+        );
+      }
+
+      const publication =
+        await inventoryPublicationsRepository.findById(publicationId);
+      const item = publication?.items.find((candidate) => candidate.id === itemId);
+      if (
+        !publication ||
+        publication.batchNumber !== batchNumber ||
+        publication.sourceType !== "pending_inventory" ||
+        publication.sellerKey !== sellerKey ||
+        !item ||
+        item.status !== "ambiguous" ||
+        item.quantityDelta !== confirmedQuantity
+      ) {
+        return data(
+          { error: "Confirmation does not match the ambiguous publication item" },
+          { status: 409 },
+        );
+      }
+
+      await inventoryPublicationsRepository.saveItemOutcomes(publicationId, [
+        {
+          itemId,
+          status: "published",
+          confirmedAt,
+          confirmationEvidence: evidence as Record<string, unknown>,
+        },
+      ]);
+      await inventoryPublicationsRepository.recoverPublicationsWithSavedOutcomes();
+      return data(
+        await inventoryPublicationsRepository.findById(publicationId),
+        { status: 200 },
+      );
+    }
+
     if (request.method !== "POST") {
       return data({ error: "Method not allowed" }, { status: 405 });
     }

--- a/app/features/pending-inventory/routes/api.inventory-batch-publications.ts
+++ b/app/features/pending-inventory/routes/api.inventory-batch-publications.ts
@@ -15,6 +15,19 @@ function parseBatchNumber(rawValue: string | undefined): number | null {
   return Number.isInteger(batchNumber) && batchNumber > 0 ? batchNumber : null;
 }
 
+function canonicalEvidence(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalEvidence).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${canonicalEvidence(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "undefined";
+}
+
 export async function loader({ params }: { params: { batchNumber?: string } }) {
   try {
     const batchNumber = parseBatchNumber(params.batchNumber);
@@ -100,12 +113,52 @@ export async function action({
         publication.sourceType !== "pending_inventory" ||
         publication.sellerKey !== sellerKey ||
         !item ||
-        item.status !== "ambiguous" ||
+        !["ambiguous", "published"].includes(item.status) ||
         item.quantityDelta !== confirmedQuantity
       ) {
         return data(
           { error: "Confirmation does not match the ambiguous publication item" },
           { status: 409 },
+        );
+      }
+
+      const receiptLinks =
+        await inventoryPublicationsRepository.findReceiptLinks(itemId);
+      const latestKnownIntake = receiptLinks.reduce<Date | null>(
+        (latest, link) =>
+          link.intakeAt && (!latest || link.intakeAt > latest)
+            ? link.intakeAt
+            : latest,
+        null,
+      );
+      if (
+        receiptLinks.length === 0 ||
+        (latestKnownIntake && confirmedAt < latestKnownIntake) ||
+        (publication.publishingAt && confirmedAt < publication.publishingAt)
+      ) {
+        return data(
+          { error: "Confirmation time precedes the publication or receipt evidence" },
+          { status: 409 },
+        );
+      }
+
+      if (item.status === "published") {
+        const exactReplay = receiptLinks.every(
+          (link) =>
+            link.liveAt?.getTime() === confirmedAt.getTime() &&
+            canonicalEvidence(link.confirmationEvidence) ===
+              canonicalEvidence(evidence),
+        );
+        if (!exactReplay) {
+          return data(
+            { error: "Confirmation conflicts with saved publication evidence" },
+            { status: 409 },
+          );
+        }
+        await inventoryPublicationsRepository.recoverPublicationsWithSavedOutcomes();
+        return data(
+          await inventoryPublicationsRepository.findById(publicationId),
+          { status: 200 },
         );
       }
 

--- a/db/migrations/036_activate_published_inventory_receipts.sql
+++ b/db/migrations/036_activate_published_inventory_receipts.sql
@@ -1,0 +1,116 @@
+CREATE TABLE inventory_publication_receipt_links (
+  publication_item_id BIGINT NOT NULL
+    REFERENCES inventory_publication_items(id) ON DELETE RESTRICT,
+  receipt_id INTEGER NOT NULL
+    REFERENCES inventory_receipts(receipt_id) ON DELETE RESTRICT,
+  planned_quantity INTEGER NOT NULL CHECK (planned_quantity > 0),
+  target_seller_key TEXT NOT NULL CHECK (length(trim(target_seller_key)) > 0),
+  live_at TIMESTAMPTZ,
+  activated_at TIMESTAMPTZ,
+  confirmation_evidence JSONB,
+  PRIMARY KEY (publication_item_id, receipt_id),
+  UNIQUE (receipt_id),
+  CHECK (
+    (live_at IS NULL AND activated_at IS NULL AND confirmation_evidence IS NULL)
+    OR
+    (live_at IS NOT NULL AND activated_at IS NOT NULL AND confirmation_evidence IS NOT NULL)
+  )
+);
+
+CREATE INDEX inventory_publication_receipt_links_seller_live_idx
+  ON inventory_publication_receipt_links (target_seller_key, live_at)
+  WHERE live_at IS NOT NULL;
+
+-- If receipt capture was deployed before this migration, preserve any already
+-- confirmed publication whose exact batch/SKU receipt quantity and seller are
+-- still provable. Rows without complete evidence remain deliberately unlinked.
+WITH valid_items AS (
+  SELECT item.id AS publication_item_id, publication.seller_key
+  FROM inventory_publication_items item
+  JOIN inventory_publications publication ON publication.id = item.publication_id
+  JOIN inventory_receipt_batch_links batch_link
+    ON batch_link.batch_number = item.batch_number
+  JOIN inventory_receipts receipt
+    ON receipt.receipt_id = batch_link.receipt_id AND receipt.sku = item.sku
+  WHERE item.status = 'published'
+    AND item.quantity_delta > 0
+    AND item.published_at IS NOT NULL
+    AND publication.source_type = 'pending_inventory'
+    AND publication.seller_key IS NOT NULL
+  GROUP BY item.id, item.quantity_delta, publication.seller_key
+  HAVING SUM(batch_link.linked_quantity) = item.quantity_delta
+    AND BOOL_AND(
+      receipt.seller_key IS NULL OR receipt.seller_key = publication.seller_key
+    )
+)
+UPDATE inventory_receipts receipt
+SET seller_key = valid.seller_key
+FROM valid_items valid
+JOIN inventory_publication_items item ON item.id = valid.publication_item_id
+JOIN inventory_receipt_batch_links batch_link
+  ON batch_link.batch_number = item.batch_number
+WHERE receipt.receipt_id = batch_link.receipt_id
+  AND receipt.sku = item.sku
+  AND receipt.seller_key IS NULL;
+
+WITH valid_items AS (
+  SELECT
+    item.id AS publication_item_id,
+    item.sku,
+    item.batch_number,
+    item.quantity_delta,
+    item.status,
+    item.published_at,
+    publication.seller_key
+  FROM inventory_publication_items item
+  JOIN inventory_publications publication ON publication.id = item.publication_id
+  JOIN inventory_receipt_batch_links batch_link
+    ON batch_link.batch_number = item.batch_number
+  JOIN inventory_receipts receipt
+    ON receipt.receipt_id = batch_link.receipt_id AND receipt.sku = item.sku
+  WHERE item.quantity_delta > 0
+    AND publication.source_type = 'pending_inventory'
+    AND publication.seller_key IS NOT NULL
+    AND (item.status <> 'published' OR item.published_at IS NOT NULL)
+  GROUP BY
+    item.id,
+    item.sku,
+    item.batch_number,
+    item.quantity_delta,
+    item.status,
+    item.published_at,
+    publication.seller_key
+  HAVING SUM(batch_link.linked_quantity) = item.quantity_delta
+    AND BOOL_AND(
+      receipt.seller_key IS NULL OR receipt.seller_key = publication.seller_key
+    )
+)
+INSERT INTO inventory_publication_receipt_links (
+  publication_item_id,
+  receipt_id,
+  planned_quantity,
+  target_seller_key,
+  live_at,
+  activated_at,
+  confirmation_evidence
+)
+SELECT
+  valid.publication_item_id,
+  batch_link.receipt_id,
+  batch_link.linked_quantity,
+  valid.seller_key,
+  CASE WHEN valid.status = 'published' THEN valid.published_at ELSE NULL END,
+  CASE WHEN valid.status = 'published' THEN NOW() ELSE NULL END,
+  CASE
+    WHEN valid.status = 'published' THEN jsonb_build_object(
+      'source', 'migration_036_confirmed_publication',
+      'publicationItemId', valid.publication_item_id
+    )
+    ELSE NULL
+  END
+FROM valid_items valid
+JOIN inventory_receipt_batch_links batch_link
+  ON batch_link.batch_number = valid.batch_number
+JOIN inventory_receipts receipt
+  ON receipt.receipt_id = batch_link.receipt_id AND receipt.sku = valid.sku
+ON CONFLICT DO NOTHING;

--- a/db/migrations/036_activate_published_inventory_receipts.sql
+++ b/db/migrations/036_activate_published_inventory_receipts.sql
@@ -36,6 +36,7 @@ WITH valid_items AS (
     AND item.quantity_delta > 0
     AND item.published_at IS NOT NULL
     AND publication.source_type = 'pending_inventory'
+    AND publication.method = 'staged_delta'
     AND publication.seller_key IS NOT NULL
   GROUP BY item.id, item.quantity_delta, publication.seller_key
   HAVING SUM(batch_link.linked_quantity) = item.quantity_delta
@@ -70,6 +71,7 @@ WITH valid_items AS (
     ON receipt.receipt_id = batch_link.receipt_id AND receipt.sku = item.sku
   WHERE item.quantity_delta > 0
     AND publication.source_type = 'pending_inventory'
+    AND publication.method = 'staged_delta'
     AND publication.seller_key IS NOT NULL
     AND (item.status <> 'published' OR item.published_at IS NOT NULL)
   GROUP BY

--- a/docs/inventory-receipt-history.md
+++ b/docs/inventory-receipt-history.md
@@ -59,3 +59,18 @@ sending `PATCH` to `/api/inventory-batches/{batchNumber}/publications`:
 
 The batch, seller, quantity, receipt chronology, and evidence must match. An
 exact retry is idempotent; conflicting time or evidence is rejected.
+
+Run the publication receipt integration test only against a disposable database
+whose name starts with `tcgplayer_fifo_test_`:
+
+```powershell
+$testDatabaseUrl='postgresql://postgres:postgres@localhost:5433/tcgplayer_fifo_test_publication'
+$env:TEST_DATABASE_URL=$testDatabaseUrl
+$env:DATABASE_URL=$testDatabaseUrl
+npm run db:migrate
+npx tsx app/core/db/repositories/inventoryPublicationReceipts.server.integration.test.ts
+```
+
+Set `DATABASE_URL` to the same disposable URL while applying migrations. The
+test refuses to run without the guarded `TEST_DATABASE_URL` because batch
+creation intentionally consumes the database's complete pending queue.

--- a/docs/inventory-receipt-history.md
+++ b/docs/inventory-receipt-history.md
@@ -25,3 +25,37 @@ fields unknown. Their old aggregate timestamps remain only in `source_evidence`.
 Receipts start with nullable `seller_key`. The publication slice must bind each
 batch's receipts to one seller before activation and query later FIFO holdings
 by both seller and exact SKU. Once set, receipt seller ownership cannot change.
+
+## Publication activation and recovery
+
+Positive Inventory Manager deltas plan exact links from a publication item to
+every contributing receipt lot. Planning requires one target seller and rejects
+incomplete quantity or seller evidence before Seller Portal work. Only a
+confirmed staged move-to-live result sets `live_at`; price-only changes,
+current-holdings imports, warnings, failures, and unknown outcomes do not make
+receipt stock eligible.
+
+The app validates the configured seller consistently across the plan, receipts,
+and saved result. Seller Portal uses shared credentials and does not separately
+return authenticated account identity, so this proves target consistency rather
+than the identity of the remote session.
+
+If a worker lease expires after remote state may have changed, the publication
+and remaining items become ambiguous and are never sent remotely again. After
+an operator verifies Seller Portal evidence, local history can be repaired by
+sending `PATCH` to `/api/inventory-batches/{batchNumber}/publications`:
+
+```json
+{
+  "operation": "confirm-ambiguous-item",
+  "publicationId": 123,
+  "itemId": 456,
+  "confirmedQuantity": 2,
+  "sellerKey": "target-seller",
+  "confirmedAt": "2026-08-10T12:00:00.000Z",
+  "evidence": { "source": "operator-confirmation", "ticket": "T-123" }
+}
+```
+
+The batch, seller, quantity, receipt chronology, and evidence must match. An
+exact retry is idempotent; conflicting time or evidence is rejected.


### PR DESCRIPTION
Confirmed positive Inventory Manager publication deltas now activate the exact receipt lots that supplied their batch/SKU, with a separately recorded Seller Portal confirmation time and seller. Price-only publication, seller/CSV holdings, failures, and ambiguous outcomes do not activate receipt stock.

Planning persists receipt links and validates method, quantity, seller, and replay identity before remote work. Outcome persistence atomically records item results and activates confirmed lots, supports exact callbacks, and preserves the first confirmation evidence. The worker retries only the local transaction after a successful remote response; saved outcomes recover an expired parent transition without repeating move-to-live, while active worker leases remain untouched. Unknown external outcomes become ambiguous.

A bounded PATCH reconciliation path confirms an ambiguous item only when batch, seller, quantity, publication/receipt chronology, timestamp, and evidence match. Exact recovery retries are safe and conflicting evidence is rejected. Migration 036 conservatively backfills only publication links supported by exact existing receipt evidence.

Validation:

- `npm test`
- `npm run typecheck`
- `npm run build`
- fresh PostgreSQL migrations 001-036 on disposable `tcgplayer_fifo_test_56_agent`
- guarded `inventoryPublicationReceipts.server.integration.test.ts`
- independent repository-to-route recovery harness

The integration test refuses to run unless `TEST_DATABASE_URL` names a disposable `tcgplayer_fifo_test_*` database.

Closes #56
