### PR TITLE
Establish reconciled inventory opening balances

### DIFF
--- a/app/core/db/index.server.ts
+++ b/app/core/db/index.server.ts
@@ -10,6 +10,7 @@ export { categorySetsRepository } from "./repositories/categorySets.server";
 export { continuousPricingRepository } from "./repositories/continuousPricing.server";
 export { httpConfigRepository } from "./repositories/httpConfig.server";
 export { inventoryBatchesRepository } from "./repositories/inventoryBatches.server";
+export { inventoryOpeningBalancesRepository } from "./repositories/inventoryOpeningBalances.server";
 export { inventoryBatchPricingJobsRepository } from "./repositories/inventoryBatchPricingJobs.server";
 export { inventoryPublicationsRepository } from "./repositories/inventoryPublications.server";
 export { inventoryPublicationSettingsRepository } from "./repositories/inventoryPublicationSettings.server";

--- a/app/core/db/repositories/inventoryBatches.server.ts
+++ b/app/core/db/repositories/inventoryBatches.server.ts
@@ -585,7 +585,8 @@ export const inventoryBatchesRepository = {
           JOIN pending_inventory pending ON pending.sku = receipt.sku
           LEFT JOIN inventory_receipt_adjustments adjustment
             ON adjustment.receipt_id = receipt.receipt_id
-          WHERE NOT EXISTS (
+          WHERE receipt.receipt_kind = 'received'
+            AND NOT EXISTS (
             SELECT 1 FROM inventory_receipt_batch_links existing_link
             WHERE existing_link.receipt_id = receipt.receipt_id
           )

--- a/app/core/db/repositories/inventoryOpeningBalances.server.integration.test.ts
+++ b/app/core/db/repositories/inventoryOpeningBalances.server.integration.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import {quantityFingerprint} from "~/features/inventory-opening-balance/domain/inventoryObservation";
+const testUrl=process.env.TEST_DATABASE_URL;
+if(!testUrl) throw new Error("TEST_DATABASE_URL is required.");
+const name=new URL(testUrl).pathname.replace(/^\/+/,"");
+if(!name.startsWith("tcgplayer_fifo_test_")) throw new Error("A tcgplayer_fifo_test_* database is required.");
+if(process.env.DATABASE_URL!==testUrl) throw new Error("DATABASE_URL must match TEST_DATABASE_URL.");
+const {getPool}=await import("../database.server");
+const {inventoryOpeningBalancesRepository:repo}=await import("./inventoryOpeningBalances.server");
+const {inventoryBatchesRepository}=await import("./inventoryBatches.server");
+const pool=getPool();
+const seller=`opening-${Date.now()}`;
+const started=new Date("2026-09-07T12:00:00Z");
+const cutoff=new Date("2026-09-07T12:01:00Z");
+try{
+  await pool.query(`INSERT INTO products (product_id,product_type_name,rarity_name,sealed,product_name,set_id,set_code,set_name,product_line_id,product_status_id,product_line_name)
+    VALUES (9001,'Card','Rare',false,'Card',90,'S','Set',9,1,'Game'),
+      (9002,'Card','Rare',false,'Other',90,'S','Set',9,1,'Game')`);
+  await pool.query(`INSERT INTO skus (sku,condition,variant,language,product_type_name,rarity_name,sealed,product_name,set_id,set_code,product_id,set_name,product_line_id,product_status_id,product_line_name)
+    VALUES (99001,'Near Mint','','English','Card','Rare',false,'Card',90,'S',9001,'Set',9,1,'Game')`);
+  const claim=await repo.beginObservationCapture({requestId:`${seller}-obs`,sellerKey:seller});
+  assert.equal(claim.state,"claimed");
+  if(claim.state!=="claimed") throw new Error("Expected observation claim.");
+  const firstItems=[{sku:99001,quantity:5,productLine:"Game",setName:"Set",productName:"Card",condition:"Near Mint",variant:""}];
+  const observation=await repo.recordObservation({requestId:`${seller}-obs`,sellerKey:seller,claimToken:claim.claimToken,
+    beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"complete",startedAt:started,cutoffAt:cutoff,
+    quantityFingerprint:quantityFingerprint(firstItems),firstContentFingerprint:"raw-a",secondContentFingerprint:"raw-b",
+    items:firstItems});
+  const observationReplay=await repo.beginObservationCapture({requestId:`${seller}-obs`,sellerKey:seller});
+  assert.equal(observationReplay.state,"complete");
+  await assert.rejects(()=>repo.beginObservationCapture({requestId:`${seller}-obs`,sellerKey:`${seller}-other`}),/different seller/);
+  const withoutCoverage=await repo.preview({requestId:`${seller}-preview-no-coverage`,sellerKey:seller,observationId:observation.id});
+  assert.equal(withoutCoverage.status,"blocked");
+  assert.match(withoutCoverage.unresolved.join(" "),/order coverage/);
+  await pool.query(`INSERT INTO seller_order_sync_runs (seller_key,source,status,search_range,started_at,finished_at,next_offset,expected_total,pages_completed,orders_observed,details_recorded)
+    VALUES ($1,'tcgplayer_api','complete','LastThreeMonths',$2,$3,0,0,1,0,0)`,[seller,cutoff,new Date("2026-09-07T12:02:00Z")]);
+  await pool.query(`INSERT INTO seller_orders
+    (seller_key,order_number,order_time,lifecycle,provider_status,gross_item_proceeds,source_fingerprint,
+     first_observed_at,last_observed_at,detail_observed_at,latest_source)
+    VALUES ($1,'interval-order',$2,'ready_to_ship','Ready to Ship',1.00,'interval-fp',$3,$3,$3,'tcgplayer_api')`,
+    [seller,new Date("2026-09-07T12:00:30Z"),new Date("2026-09-07T12:02:00Z")]);
+  const intervalPreview=await repo.preview({requestId:`${seller}-preview-interval`,sellerKey:seller,observationId:observation.id});
+  assert.equal(intervalPreview.status,"blocked");
+  assert.match(intervalPreview.unresolved.join(" "),/order occurred/);
+  await pool.query(`DELETE FROM seller_orders WHERE seller_key=$1`,[seller]);
+  const preview=await repo.preview({requestId:`${seller}-preview`,sellerKey:seller,observationId:observation.id});
+  assert.equal(preview.status,"previewed");
+  await assert.rejects(()=>repo.preview({requestId:`${seller}-preview`,sellerKey:`${seller}-other`,observationId:observation.id}),/different inputs/);
+  await pool.query(`UPDATE skus SET product_id=9002 WHERE sku=99001`);
+  await assert.rejects(()=>repo.apply(preview.id,preview.evidenceFingerprint,seller),/evidence changed/);
+  await pool.query(`UPDATE skus SET product_id=9001 WHERE sku=99001`);
+  const applied=await repo.apply(preview.id,preview.evidenceFingerprint,seller);
+  assert.equal(applied.status,"applied");
+  assert.equal((await repo.apply(preview.id,preview.evidenceFingerprint,seller)).status,"applied");
+  await assert.rejects(()=>repo.apply(preview.id,preview.evidenceFingerprint,`${seller}-other`),/not found/);
+  const opening=await pool.query(`SELECT original_quantity,product_id,receipt_kind,fifo_precedence,intake_at,market_value FROM inventory_receipts WHERE opening_balance_run_id=$1`,[preview.id]);
+  assert.deepEqual(opening.rows,[{original_quantity:5,product_id:9001,receipt_kind:"opening_balance",fifo_precedence:0,intake_at:null,market_value:null}]);
+
+  await pool.query(`INSERT INTO pending_inventory (sku,quantity,product_line_id,set_id,product_id,created_at,updated_at) VALUES (99001,2,9,90,9001,NOW(),NOW())`);
+  await pool.query(`INSERT INTO inventory_pending_mutations (request_id,mutation_type,sku,requested_quantity,product_line_id,set_id,product_id,quantity_delta,resulting_quantity)
+    VALUES ($1,'add',99001,2,9,90,9001,2,2)`,[`${seller}-pending`]);
+  await pool.query(`INSERT INTO inventory_receipts (request_id,sku,original_quantity,product_line_id,set_id,product_id,intake_at,market_provenance)
+    VALUES ($1,99001,2,9,90,9001,NOW(),'unavailable')`,[`${seller}-pending`]);
+  const batch=await inventoryBatchesRepository.createFromPendingInventory(`${seller}-batch`);
+  const linked=await pool.query(`SELECT receipt.receipt_kind,SUM(link.linked_quantity)::int quantity FROM inventory_receipt_batch_links link JOIN inventory_receipts receipt USING(receipt_id) WHERE link.batch_number=$1 GROUP BY receipt.receipt_kind`,[batch?.batchNumber]);
+  assert.deepEqual(linked.rows,[{receipt_kind:"received",quantity:2}]);
+  const openingUnlinked=await pool.query(`SELECT COUNT(*)::int count FROM inventory_receipt_batch_links link JOIN inventory_receipts receipt USING(receipt_id) WHERE receipt.receipt_kind='opening_balance'`);
+  assert.equal(openingUnlinked.rows[0]?.count,0);
+
+  const nextClaim=await repo.beginObservationCapture({requestId:`${seller}-obs-next`,sellerKey:seller});
+  if(nextClaim.state!=="claimed") throw new Error("Expected next observation claim.");
+  const nextItems=[{sku:99001,quantity:4,productLine:"Game",setName:"Set",productName:"Card",condition:"Near Mint",variant:""}];
+  const nextObservation=await repo.recordObservation({requestId:`${seller}-obs-next`,sellerKey:seller,claimToken:nextClaim.claimToken,
+    beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"complete",
+    startedAt:new Date("2026-09-07T13:00:00Z"),cutoffAt:new Date("2026-09-07T13:01:00Z"),
+    quantityFingerprint:quantityFingerprint(nextItems),firstContentFingerprint:"raw-c",secondContentFingerprint:"raw-d",
+    items:nextItems});
+  const difference=await pool.query(`SELECT id::text AS id,status,previous_quantity,observed_quantity,quantity_delta
+    FROM inventory_observation_differences WHERE observation_id=$1`,[nextObservation.id]);
+  assert.deepEqual(difference.rows.map(({status,previous_quantity,observed_quantity,quantity_delta})=>({status,previous_quantity,observed_quantity,quantity_delta})),
+    [{status:"unresolved",previous_quantity:5,observed_quantity:4,quantity_delta:-1}]);
+  const acknowledgement={requestId:`${seller}-ack`,id:difference.rows[0].id,sellerKey:seller,note:"Count checked; cause remains unknown."};
+  await repo.acknowledgeDifference(acknowledgement);
+  await repo.acknowledgeDifference(acknowledgement);
+  await assert.rejects(()=>repo.acknowledgeDifference({...acknowledgement,note:"Different evidence"}),/conflicts/);
+  console.log("PASS opening balance applies once with unknown evidence and cannot enter pending batches");
+}finally{
+  await pool.query(`DELETE FROM inventory_batch_intake_requests WHERE request_id LIKE $1`,[`${seller}%`]);
+  await pool.query(`DELETE FROM inventory_receipt_batch_links WHERE receipt_id IN (SELECT receipt_id FROM inventory_receipts WHERE request_id LIKE $1)`,[`${seller}%`]);
+  await pool.query(`DELETE FROM inventory_opening_balance_items WHERE run_id IN (SELECT id FROM inventory_opening_balance_runs WHERE seller_key=$1)`,[seller]);
+  await pool.query(`DELETE FROM inventory_receipts WHERE request_id LIKE $1 OR opening_balance_run_id IN (SELECT id FROM inventory_opening_balance_runs WHERE seller_key=$2)`,[`${seller}%`,seller]);
+  await pool.query(`DELETE FROM inventory_pending_mutations WHERE request_id LIKE $1 OR request_id IN (
+    SELECT 'opening:'||run.id::text||':'||item.sku::text FROM inventory_opening_balance_runs run
+    JOIN inventory_complete_observation_items item ON item.observation_id=run.observation_id WHERE run.seller_key=$2)`,[`${seller}%`,seller]);
+  await pool.query(`DELETE FROM inventory_batches WHERE source_request_id LIKE $1`,[`${seller}%`]);
+  await pool.query(`DELETE FROM inventory_opening_balance_runs WHERE seller_key=$1`,[seller]);
+  await pool.query(`DELETE FROM inventory_observation_differences WHERE seller_key=$1`,[seller]);
+  await pool.query(`DELETE FROM inventory_complete_observation_items WHERE observation_id IN (SELECT id FROM inventory_complete_observations WHERE seller_key=$1)`,[seller]);
+  await pool.query(`DELETE FROM inventory_complete_observation_requests WHERE seller_key=$1`,[seller]);
+  await pool.query(`DELETE FROM inventory_complete_observations WHERE seller_key=$1`,[seller]);
+  await pool.query(`DELETE FROM seller_orders WHERE seller_key=$1`,[seller]);
+  await pool.query(`DELETE FROM seller_order_sync_runs WHERE seller_key=$1`,[seller]);
+  await pool.query(`DELETE FROM skus WHERE sku=99001`);await pool.query(`DELETE FROM products WHERE product_id IN (9001,9002)`);
+  await pool.end();
+}

--- a/app/core/db/repositories/inventoryOpeningBalances.server.integration.test.ts
+++ b/app/core/db/repositories/inventoryOpeningBalances.server.integration.test.ts
@@ -95,6 +95,23 @@ try{
   const staleApplyInput={runId:preview.id,expectedFingerprint:preview.evidenceFingerprint,sellerKey:seller,
     requestId:`${seller}-apply`,validationObservationId:validation.id};
   await assert.rejects(()=>repo.apply(staleApplyInput),/newer seller inventory observation/);
+  const driftClaim=await repo.beginObservationCapture({requestId:`${seller}-hidden-drift`,sellerKey:seller});
+  if(driftClaim.state!=="claimed") throw new Error("Expected drift claim.");
+  const driftItems=[{...firstItems[0]!,quantity:6},firstItems[1]!];
+  const driftCutoff=new Date(validationCutoff.getTime()+15_000);
+  await repo.recordObservation({requestId:`${seller}-hidden-drift`,sellerKey:seller,claimToken:driftClaim.claimToken,
+    beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"complete",
+    startedAt:new Date(driftCutoff.getTime()-2_000),cutoffAt:driftCutoff,
+    quantityFingerprint:quantityFingerprint(driftItems),supportedQuantityFingerprint:supportedQuantityFingerprint(driftItems),
+    firstContentFingerprint:"drift-a",secondContentFingerprint:"drift-b",items:driftItems});
+  const restoreClaim=await repo.beginObservationCapture({requestId:`${seller}-hidden-restore`,sellerKey:seller});
+  if(restoreClaim.state!=="claimed") throw new Error("Expected restore claim.");
+  const restoreCutoff=new Date(validationCutoff.getTime()+20_000);
+  await repo.recordObservation({requestId:`${seller}-hidden-restore`,sellerKey:seller,claimToken:restoreClaim.claimToken,
+    beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"complete",
+    startedAt:new Date(restoreCutoff.getTime()-2_000),cutoffAt:restoreCutoff,
+    quantityFingerprint:quantityFingerprint(firstItems),supportedQuantityFingerprint:supportedQuantityFingerprint(firstItems),
+    firstContentFingerprint:"restore-a",secondContentFingerprint:"restore-b",items:firstItems});
   const currentClaim=await repo.beginObservationCapture({requestId:`${seller}-validation-current`,sellerKey:seller});
   if(currentClaim.state!=="claimed") throw new Error("Expected current validation claim.");
   const currentCutoff=new Date();
@@ -109,6 +126,16 @@ try{
     [seller,currentCutoff,new Date(currentCutoff.getTime()+1_000)]);
   const applyInput={runId:preview.id,expectedFingerprint:preview.evidenceFingerprint,sellerKey:seller,
     requestId:`${seller}-apply`,validationObservationId:currentValidation.id};
+  await assert.rejects(()=>repo.apply(applyInput),/differences must be acknowledged/);
+  const applicationDifferences=await repo.listApplicationDifferences({sellerKey:seller,runId:preview.id,
+    validationObservationId:currentValidation.id,limit:10});
+  assert.equal(applicationDifferences.length,2);
+  assert.equal((await repo.listApplicationDifferences({sellerKey:`${seller}-other`,runId:preview.id,
+    validationObservationId:currentValidation.id})).length,0);
+  for(const difference of applicationDifferences){
+    await repo.acknowledgeDifference({requestId:`${seller}-apply-ack-${difference.id}`,id:difference.id,
+      sellerKey:seller,note:"Reviewed intermediate standard-SKU observation."});
+  }
   await pool.query(`UPDATE skus SET product_id=9002 WHERE sku=99001`);
   await assert.rejects(()=>repo.apply(applyInput),/evidence changed/);
   await pool.query(`UPDATE skus SET product_id=9001 WHERE sku=99001`);
@@ -157,6 +184,18 @@ try{
   await repo.acknowledgeDifference(acknowledgement);
   await repo.acknowledgeDifference(acknowledgement);
   await assert.rejects(()=>repo.acknowledgeDifference({...acknowledgement,note:"Different evidence"}),/conflicts/);
+  for(let index=1;index<=3;index++){
+    const laterClaim=await repo.beginObservationCapture({requestId:`${seller}-later-${index}`,sellerKey:seller});
+    if(laterClaim.state!=="claimed") throw new Error("Expected later observation claim.");
+    const laterCutoff=new Date(Date.now()+3_000+index*1_000);
+    await repo.recordObservation({requestId:`${seller}-later-${index}`,sellerKey:seller,claimToken:laterClaim.claimToken,
+      beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"complete",
+      startedAt:new Date(laterCutoff.getTime()-500),cutoffAt:laterCutoff,
+      quantityFingerprint:quantityFingerprint(nextItems),supportedQuantityFingerprint:supportedQuantityFingerprint(nextItems),
+      firstContentFingerprint:`later-${index}-a`,secondContentFingerprint:`later-${index}-b`,items:nextItems});
+  }
+  assert.deepEqual(await repo.listObservationItems({sellerKey:seller,observationId:currentValidation.id,unsupportedOnly:true}),
+    [{inventoryKey:"C-3967723",identityKind:"unsupported",sku:null,quantity:2}]);
   console.log("PASS opening balance applies once with unknown evidence and cannot enter pending batches");
 }finally{
   await pool.query(`DELETE FROM inventory_batch_intake_requests WHERE request_id LIKE $1`,[`${seller}%`]);

--- a/app/core/db/repositories/inventoryOpeningBalances.server.integration.test.ts
+++ b/app/core/db/repositories/inventoryOpeningBalances.server.integration.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import {quantityFingerprint} from "~/features/inventory-opening-balance/domain/inventoryObservation";
+import {quantityFingerprint,supportedQuantityFingerprint} from "~/features/inventory-opening-balance/domain/inventoryObservation";
 const testUrl=process.env.TEST_DATABASE_URL;
 if(!testUrl) throw new Error("TEST_DATABASE_URL is required.");
 const name=new URL(testUrl).pathname.replace(/^\/+/,"");
@@ -8,6 +8,7 @@ if(process.env.DATABASE_URL!==testUrl) throw new Error("DATABASE_URL must match 
 const {getPool}=await import("../database.server");
 const {inventoryOpeningBalancesRepository:repo}=await import("./inventoryOpeningBalances.server");
 const {inventoryBatchesRepository}=await import("./inventoryBatches.server");
+const {pendingInventoryRepository}=await import("./pendingInventory.server");
 const pool=getPool();
 const seller=`opening-${Date.now()}`;
 const started=new Date("2026-09-07T12:00:00Z");
@@ -21,17 +22,38 @@ try{
   const claim=await repo.beginObservationCapture({requestId:`${seller}-obs`,sellerKey:seller});
   assert.equal(claim.state,"claimed");
   if(claim.state!=="claimed") throw new Error("Expected observation claim.");
-  const firstItems=[{sku:99001,quantity:5,productLine:"Game",setName:"Set",productName:"Card",condition:"Near Mint",variant:""}];
+  const firstItems=[{inventoryKey:"99001",identityKind:"standard_sku" as const,sku:99001,quantity:5,productLine:"Game",setName:"Set",productName:"Card",condition:"Near Mint",variant:""},
+    {inventoryKey:"C-3967723",identityKind:"unsupported" as const,sku:null,quantity:1,productLine:"Game",setName:"Set",productName:"Custom",condition:"Near Mint",variant:""}];
   const observation=await repo.recordObservation({requestId:`${seller}-obs`,sellerKey:seller,claimToken:claim.claimToken,
     beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"complete",startedAt:started,cutoffAt:cutoff,
-    quantityFingerprint:quantityFingerprint(firstItems),firstContentFingerprint:"raw-a",secondContentFingerprint:"raw-b",
+    quantityFingerprint:quantityFingerprint(firstItems),supportedQuantityFingerprint:supportedQuantityFingerprint(firstItems),firstContentFingerprint:"raw-a",secondContentFingerprint:"raw-b",
     items:firstItems});
   const observationReplay=await repo.beginObservationCapture({requestId:`${seller}-obs`,sellerKey:seller});
   assert.equal(observationReplay.state,"complete");
+  await assert.rejects(()=>repo.beginObservationCapture({requestId:`${seller}-obs`,sellerKey:seller,
+    purposeEvidence:{kind:"opening_apply"}}),/different purpose/);
   await assert.rejects(()=>repo.beginObservationCapture({requestId:`${seller}-obs`,sellerKey:`${seller}-other`}),/different seller/);
+  for(let index=1;index<=3;index++){
+    const unstableClaim=await repo.beginObservationCapture({requestId:`${seller}-unstable-${index}`,sellerKey:seller});
+    if(unstableClaim.state!=="claimed") throw new Error("Expected unstable observation claim.");
+    const unstableItems=[{...firstItems[0]!,quantity:5+index}];
+    await repo.recordObservation({requestId:`${seller}-unstable-${index}`,sellerKey:seller,claimToken:unstableClaim.claimToken,
+      beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"unstable",
+      startedAt:new Date(`2026-09-07T12:01:${index}0Z`),cutoffAt:new Date(`2026-09-07T12:01:${index}5Z`),
+      quantityFingerprint:quantityFingerprint(unstableItems),supportedQuantityFingerprint:supportedQuantityFingerprint(unstableItems),firstContentFingerprint:`unstable-${index}-a`,
+      secondContentFingerprint:`unstable-${index}-b`,items:unstableItems,error:"quantities changed"});
+  }
   const withoutCoverage=await repo.preview({requestId:`${seller}-preview-no-coverage`,sellerKey:seller,observationId:observation.id});
   assert.equal(withoutCoverage.status,"blocked");
   assert.match(withoutCoverage.unresolved.join(" "),/order coverage/);
+  assert.equal(withoutCoverage.positiveSkuCount,1);
+  assert.equal(withoutCoverage.totalQuantity,5);
+  assert.equal(withoutCoverage.unsupportedPositiveItemCount,1);
+  assert.equal(withoutCoverage.unsupportedPositiveQuantity,1);
+  assert.match(withoutCoverage.limitations.join(" "),/unsupported positive inventory/);
+  assert.deepEqual(await repo.listObservationItems({sellerKey:seller,observationId:observation.id,unsupportedOnly:true}),
+    [{inventoryKey:"C-3967723",identityKind:"unsupported",sku:null,quantity:1}]);
+  assert.equal((await repo.listObservationItems({sellerKey:`${seller}-other`,observationId:observation.id})).length,0);
   await pool.query(`INSERT INTO seller_order_sync_runs (seller_key,source,status,search_range,started_at,finished_at,next_offset,expected_total,pages_completed,orders_observed,details_recorded)
     VALUES ($1,'tcgplayer_api','complete','LastThreeMonths',$2,$3,0,0,1,0,0)`,[seller,cutoff,new Date("2026-09-07T12:02:00Z")]);
   await pool.query(`INSERT INTO seller_orders
@@ -45,16 +67,59 @@ try{
   await pool.query(`DELETE FROM seller_orders WHERE seller_key=$1`,[seller]);
   const preview=await repo.preview({requestId:`${seller}-preview`,sellerKey:seller,observationId:observation.id});
   assert.equal(preview.status,"previewed");
+  assert.equal((await repo.listPreviewItems({sellerKey:seller,runId:preview.id,limit:1}))[0]?.openingQuantity,5);
+  assert.equal((await repo.listPreviewItems({sellerKey:`${seller}-other`,runId:preview.id})).length,0);
+  await assert.rejects(()=>repo.listPreviewItems({sellerKey:seller,runId:preview.id,limit:201}),/between 1 and 200/);
   await assert.rejects(()=>repo.preview({requestId:`${seller}-preview`,sellerKey:`${seller}-other`,observationId:observation.id}),/different inputs/);
+  const validationClaim=await repo.beginObservationCapture({requestId:`${seller}-validation`,sellerKey:seller});
+  if(validationClaim.state!=="claimed") throw new Error("Expected validation observation claim.");
+  const validationCutoff=new Date(Date.now()-30_000);
+  const validationStarted=new Date(validationCutoff.getTime()-30_000);
+  const validation=await repo.recordObservation({requestId:`${seller}-validation`,sellerKey:seller,claimToken:validationClaim.claimToken,
+    beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"complete",
+    startedAt:validationStarted,cutoffAt:validationCutoff,
+    quantityFingerprint:quantityFingerprint(firstItems),supportedQuantityFingerprint:supportedQuantityFingerprint(firstItems),firstContentFingerprint:"raw-validation-a",secondContentFingerprint:"raw-validation-b",
+    items:firstItems});
+  await pool.query(`INSERT INTO seller_order_sync_runs (seller_key,source,status,search_range,started_at,finished_at,next_offset,expected_total,pages_completed,orders_observed,details_recorded)
+    VALUES ($1,'tcgplayer_api','complete','LastThreeMonths',$2,$3,0,0,1,0,0)`,
+    [seller,validationCutoff,new Date()]);
+  const lateUnstableClaim=await repo.beginObservationCapture({requestId:`${seller}-late-unstable`,sellerKey:seller});
+  if(lateUnstableClaim.state!=="claimed") throw new Error("Expected late unstable claim.");
+  const lateUnstableItems=[{...firstItems[0]!,quantity:6}];
+  const lateUnstableCutoff=new Date(validationCutoff.getTime()+10_000);
+  await repo.recordObservation({requestId:`${seller}-late-unstable`,sellerKey:seller,claimToken:lateUnstableClaim.claimToken,
+    beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"unstable",
+    startedAt:new Date(validationCutoff.getTime()+5_000),cutoffAt:lateUnstableCutoff,
+    quantityFingerprint:quantityFingerprint(lateUnstableItems),supportedQuantityFingerprint:supportedQuantityFingerprint(lateUnstableItems),firstContentFingerprint:"late-unstable-a",
+    secondContentFingerprint:"late-unstable-b",items:lateUnstableItems,error:"quantities changed"});
+  const staleApplyInput={runId:preview.id,expectedFingerprint:preview.evidenceFingerprint,sellerKey:seller,
+    requestId:`${seller}-apply`,validationObservationId:validation.id};
+  await assert.rejects(()=>repo.apply(staleApplyInput),/newer seller inventory observation/);
+  const currentClaim=await repo.beginObservationCapture({requestId:`${seller}-validation-current`,sellerKey:seller});
+  if(currentClaim.state!=="claimed") throw new Error("Expected current validation claim.");
+  const currentCutoff=new Date();
+  const currentValidation=await repo.recordObservation({requestId:`${seller}-validation-current`,sellerKey:seller,
+    claimToken:currentClaim.claimToken,beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"complete",
+    startedAt:new Date(currentCutoff.getTime()-5_000),cutoffAt:currentCutoff,
+    quantityFingerprint:quantityFingerprint(firstItems),supportedQuantityFingerprint:supportedQuantityFingerprint(firstItems),firstContentFingerprint:"raw-current-a",secondContentFingerprint:"raw-current-b",
+    items:firstItems});
+  await pool.query(`INSERT INTO seller_order_sync_runs (seller_key,source,status,search_range,started_at,finished_at,next_offset,expected_total,pages_completed,orders_observed,details_recorded)
+    VALUES ($1,'tcgplayer_api','complete','LastThreeMonths',$2,$3,0,0,1,0,0)`,
+    [seller,currentCutoff,new Date(currentCutoff.getTime()+1_000)]);
+  const applyInput={runId:preview.id,expectedFingerprint:preview.evidenceFingerprint,sellerKey:seller,
+    requestId:`${seller}-apply`,validationObservationId:currentValidation.id};
   await pool.query(`UPDATE skus SET product_id=9002 WHERE sku=99001`);
-  await assert.rejects(()=>repo.apply(preview.id,preview.evidenceFingerprint,seller),/evidence changed/);
+  await assert.rejects(()=>repo.apply(applyInput),/evidence changed/);
   await pool.query(`UPDATE skus SET product_id=9001 WHERE sku=99001`);
-  const applied=await repo.apply(preview.id,preview.evidenceFingerprint,seller);
+  const applied=await repo.apply(applyInput);
   assert.equal(applied.status,"applied");
-  assert.equal((await repo.apply(preview.id,preview.evidenceFingerprint,seller)).status,"applied");
-  await assert.rejects(()=>repo.apply(preview.id,preview.evidenceFingerprint,`${seller}-other`),/not found/);
+  assert.equal((await repo.apply(applyInput)).status,"applied");
+  await assert.rejects(()=>repo.apply({...applyInput,sellerKey:`${seller}-other`}),/not found/);
   const opening=await pool.query(`SELECT original_quantity,product_id,receipt_kind,fifo_precedence,intake_at,market_value FROM inventory_receipts WHERE opening_balance_run_id=$1`,[preview.id]);
   assert.deepEqual(opening.rows,[{original_quantity:5,product_id:9001,receipt_kind:"opening_balance",fifo_precedence:0,intake_at:null,market_value:null}]);
+  await pendingInventoryRepository.updateSetIdByProduct(9001,9,91);
+  const frozenOpening=await pool.query(`SELECT set_id FROM inventory_receipts WHERE opening_balance_run_id=$1`,[preview.id]);
+  assert.equal(frozenOpening.rows[0]?.set_id,90);
 
   await pool.query(`INSERT INTO pending_inventory (sku,quantity,product_line_id,set_id,product_id,created_at,updated_at) VALUES (99001,2,9,90,9001,NOW(),NOW())`);
   await pool.query(`INSERT INTO inventory_pending_mutations (request_id,mutation_type,sku,requested_quantity,product_line_id,set_id,product_id,quantity_delta,resulting_quantity)
@@ -69,16 +134,18 @@ try{
 
   const nextClaim=await repo.beginObservationCapture({requestId:`${seller}-obs-next`,sellerKey:seller});
   if(nextClaim.state!=="claimed") throw new Error("Expected next observation claim.");
-  const nextItems=[{sku:99001,quantity:4,productLine:"Game",setName:"Set",productName:"Card",condition:"Near Mint",variant:""}];
+  const nextItems=[{...firstItems[0]!,quantity:4},firstItems[1]!];
   const nextObservation=await repo.recordObservation({requestId:`${seller}-obs-next`,sellerKey:seller,claimToken:nextClaim.claimToken,
     beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"complete",
-    startedAt:new Date("2026-09-07T13:00:00Z"),cutoffAt:new Date("2026-09-07T13:01:00Z"),
-    quantityFingerprint:quantityFingerprint(nextItems),firstContentFingerprint:"raw-c",secondContentFingerprint:"raw-d",
+    startedAt:new Date(Date.now()+1_000),cutoffAt:new Date(Date.now()+2_000),
+    quantityFingerprint:quantityFingerprint(nextItems),supportedQuantityFingerprint:supportedQuantityFingerprint(nextItems),firstContentFingerprint:"raw-c",secondContentFingerprint:"raw-d",
     items:nextItems});
   const difference=await pool.query(`SELECT id::text AS id,status,previous_quantity,observed_quantity,quantity_delta
     FROM inventory_observation_differences WHERE observation_id=$1`,[nextObservation.id]);
   assert.deepEqual(difference.rows.map(({status,previous_quantity,observed_quantity,quantity_delta})=>({status,previous_quantity,observed_quantity,quantity_delta})),
     [{status:"unresolved",previous_quantity:5,observed_quantity:4,quantity_delta:-1}]);
+  assert.equal((await repo.listDifferences({sellerKey:seller,observationId:nextObservation.id,limit:1})).length,1);
+  assert.equal((await repo.listDifferences({sellerKey:`${seller}-other`,observationId:nextObservation.id})).length,0);
   const acknowledgement={requestId:`${seller}-ack`,id:difference.rows[0].id,sellerKey:seller,note:"Count checked; cause remains unknown."};
   await repo.acknowledgeDifference(acknowledgement);
   await repo.acknowledgeDifference(acknowledgement);

--- a/app/core/db/repositories/inventoryOpeningBalances.server.integration.test.ts
+++ b/app/core/db/repositories/inventoryOpeningBalances.server.integration.test.ts
@@ -147,7 +147,10 @@ try{
     requestId:applyInput.requestId,expectedFingerprint:preview.evidenceFingerprint});
   assert.equal(appliedReplay?.validationObservationId,currentValidation.id);
   assert.equal(appliedReplay?.unsupportedPositiveQuantity,2);
-  assert.equal((await repo.apply(applyInput)).status,"applied");
+  const directReplay=await repo.apply(applyInput);
+  assert.equal(directReplay.status,"applied");
+  assert.equal(directReplay.validationObservationId,currentValidation.id);
+  assert.equal(directReplay.unsupportedPositiveQuantity,2);
   await assert.rejects(()=>repo.apply({...applyInput,sellerKey:`${seller}-other`}),/not found/);
   const opening=await pool.query(`SELECT original_quantity,product_id,receipt_kind,fifo_precedence,intake_at,market_value FROM inventory_receipts WHERE opening_balance_run_id=$1`,[preview.id]);
   assert.deepEqual(opening.rows,[{original_quantity:5,product_id:9001,receipt_kind:"opening_balance",fifo_precedence:0,intake_at:null,market_value:null}]);

--- a/app/core/db/repositories/inventoryOpeningBalances.server.integration.test.ts
+++ b/app/core/db/repositories/inventoryOpeningBalances.server.integration.test.ts
@@ -98,11 +98,12 @@ try{
   const currentClaim=await repo.beginObservationCapture({requestId:`${seller}-validation-current`,sellerKey:seller});
   if(currentClaim.state!=="claimed") throw new Error("Expected current validation claim.");
   const currentCutoff=new Date();
+  const currentItems=[firstItems[0]!,{...firstItems[1]!,quantity:2}];
   const currentValidation=await repo.recordObservation({requestId:`${seller}-validation-current`,sellerKey:seller,
     claimToken:currentClaim.claimToken,beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"complete",
     startedAt:new Date(currentCutoff.getTime()-5_000),cutoffAt:currentCutoff,
-    quantityFingerprint:quantityFingerprint(firstItems),supportedQuantityFingerprint:supportedQuantityFingerprint(firstItems),firstContentFingerprint:"raw-current-a",secondContentFingerprint:"raw-current-b",
-    items:firstItems});
+    quantityFingerprint:quantityFingerprint(currentItems),supportedQuantityFingerprint:supportedQuantityFingerprint(currentItems),firstContentFingerprint:"raw-current-a",secondContentFingerprint:"raw-current-b",
+    items:currentItems});
   await pool.query(`INSERT INTO seller_order_sync_runs (seller_key,source,status,search_range,started_at,finished_at,next_offset,expected_total,pages_completed,orders_observed,details_recorded)
     VALUES ($1,'tcgplayer_api','complete','LastThreeMonths',$2,$3,0,0,1,0,0)`,
     [seller,currentCutoff,new Date(currentCutoff.getTime()+1_000)]);
@@ -113,6 +114,12 @@ try{
   await pool.query(`UPDATE skus SET product_id=9001 WHERE sku=99001`);
   const applied=await repo.apply(applyInput);
   assert.equal(applied.status,"applied");
+  assert.equal(applied.validationObservationId,currentValidation.id);
+  assert.equal(applied.unsupportedPositiveQuantity,2);
+  const appliedReplay=await repo.findApplicationReplay({runId:preview.id,sellerKey:seller,
+    requestId:applyInput.requestId,expectedFingerprint:preview.evidenceFingerprint});
+  assert.equal(appliedReplay?.validationObservationId,currentValidation.id);
+  assert.equal(appliedReplay?.unsupportedPositiveQuantity,2);
   assert.equal((await repo.apply(applyInput)).status,"applied");
   await assert.rejects(()=>repo.apply({...applyInput,sellerKey:`${seller}-other`}),/not found/);
   const opening=await pool.query(`SELECT original_quantity,product_id,receipt_kind,fifo_precedence,intake_at,market_value FROM inventory_receipts WHERE opening_balance_run_id=$1`,[preview.id]);
@@ -134,7 +141,7 @@ try{
 
   const nextClaim=await repo.beginObservationCapture({requestId:`${seller}-obs-next`,sellerKey:seller});
   if(nextClaim.state!=="claimed") throw new Error("Expected next observation claim.");
-  const nextItems=[{...firstItems[0]!,quantity:4},firstItems[1]!];
+  const nextItems=[{...firstItems[0]!,quantity:4},currentItems[1]!];
   const nextObservation=await repo.recordObservation({requestId:`${seller}-obs-next`,sellerKey:seller,claimToken:nextClaim.claimToken,
     beforeIdentityDeclarationCount:2,afterIdentityDeclarationCount:2,status:"complete",
     startedAt:new Date(Date.now()+1_000),cutoffAt:new Date(Date.now()+2_000),

--- a/app/core/db/repositories/inventoryOpeningBalances.server.ts
+++ b/app/core/db/repositories/inventoryOpeningBalances.server.ts
@@ -429,10 +429,15 @@ export const inventoryOpeningBalancesRepository = {
   }) {
     return withTransaction(async (db) => {
       const run = await queryOne<any>(
-        `SELECT id::text AS id,seller_key AS "sellerKey",cutoff_at AS "cutoffAt",status,
-          evidence_fingerprint AS "evidenceFingerprint",observation_id::text AS "observationId",
-          apply_request_id AS "applyRequestId"
-         FROM inventory_opening_balance_runs WHERE id=$1 AND seller_key=$2 FOR UPDATE`,[input.runId,input.sellerKey.trim()],db);
+        `SELECT run.id::text AS id,run.seller_key AS "sellerKey",run.cutoff_at AS "cutoffAt",run.status,
+          run.evidence_fingerprint AS "evidenceFingerprint",run.observation_id::text AS "observationId",
+          run.apply_request_id AS "applyRequestId",
+          run.validation_observation_id::text AS "validationObservationId",
+          validation.unsupported_positive_item_count AS "unsupportedPositiveItemCount",
+          validation.unsupported_positive_quantity AS "unsupportedPositiveQuantity"
+         FROM inventory_opening_balance_runs run
+         LEFT JOIN inventory_complete_observations validation ON validation.id=run.validation_observation_id
+         WHERE run.id=$1 AND run.seller_key=$2 FOR UPDATE OF run`,[input.runId,input.sellerKey.trim()],db);
       if (!run) throw new Error("Opening balance preview was not found.");
       if (run.status === "applied") {
         if (run.evidenceFingerprint !== input.expectedFingerprint || run.applyRequestId !== input.requestId.trim()) {

--- a/app/core/db/repositories/inventoryOpeningBalances.server.ts
+++ b/app/core/db/repositories/inventoryOpeningBalances.server.ts
@@ -92,9 +92,14 @@ export const inventoryOpeningBalancesRepository = {
   },
 
   async findApplicationReplay(input: {runId:string;sellerKey:string;requestId:string;expectedFingerprint:string}) {
-    const run=await queryOne<any>(`SELECT id::text AS id,status,evidence_fingerprint AS "evidenceFingerprint",
-      apply_request_id AS "applyRequestId" FROM inventory_opening_balance_runs
-      WHERE id=$1 AND seller_key=$2`,[input.runId,input.sellerKey.trim()]);
+    const run=await queryOne<any>(`SELECT run.id::text AS id,run.status,
+      run.evidence_fingerprint AS "evidenceFingerprint",run.apply_request_id AS "applyRequestId",
+      run.validation_observation_id::text AS "validationObservationId",
+      validation.unsupported_positive_item_count AS "unsupportedPositiveItemCount",
+      validation.unsupported_positive_quantity AS "unsupportedPositiveQuantity"
+      FROM inventory_opening_balance_runs run
+      LEFT JOIN inventory_complete_observations validation ON validation.id=run.validation_observation_id
+      WHERE run.id=$1 AND run.seller_key=$2`,[input.runId,input.sellerKey.trim()]);
     if(!run) throw new Error("Opening balance preview was not found.");
     if(run.status!=="applied") {
       if(run.status!=="previewed" || run.evidenceFingerprint!==input.expectedFingerprint) {
@@ -453,8 +458,10 @@ export const inventoryOpeningBalancesRepository = {
         WHERE seller_key=$1 ORDER BY cutoff_at DESC,id DESC LIMIT 1`,[run.sellerKey],db);
       if(latest?.id!==validation.id) throw new Error("A newer seller inventory observation must be reconciled first.");
       const validationDifferences=await queryOne<{count:number}>(`SELECT COUNT(*)::int AS count
-        FROM inventory_observation_differences
-        WHERE observation_id=$1 AND status='unresolved' AND sku IS NOT NULL`,[validation.id],db);
+        FROM inventory_observation_differences difference
+        JOIN inventory_complete_observations observation ON observation.id=difference.observation_id
+        WHERE observation.seller_key=$1 AND observation.cutoff_at>$2 AND observation.cutoff_at<=$3
+          AND difference.status='unresolved' AND difference.sku IS NOT NULL`,[run.sellerKey,run.cutoffAt,validation.cutoffAt],db);
       if((validationDifferences?.count??0)>0) throw new Error("Current seller inventory differences must be acknowledged before apply.");
       const validationCoverage=await queryOne<any>(`SELECT id::text AS id,finished_at AS "finishedAt",
           observed_from AS "observedFrom",observed_through AS "observedThrough",
@@ -508,7 +515,11 @@ export const inventoryOpeningBalancesRepository = {
       await execute(`UPDATE inventory_opening_balance_runs SET status='applied',apply_request_id=$2,
         validation_observation_id=$3,validation_order_coverage_evidence=$4::jsonb,applied_at=NOW()
         WHERE id=$1`,[input.runId,input.requestId.trim(),validation.id,asJson(validationCoverage)],db);
-      return { ...run, status:"applied" };
+      return {
+        ...run,status:"applied",validationObservationId:validation.id,
+        unsupportedPositiveItemCount:validation.unsupportedPositiveItemCount,
+        unsupportedPositiveQuantity:validation.unsupportedPositiveQuantity,
+      };
     });
   },
 

--- a/app/core/db/repositories/inventoryOpeningBalances.server.ts
+++ b/app/core/db/repositories/inventoryOpeningBalances.server.ts
@@ -1,0 +1,331 @@
+import { createHash, randomUUID } from "node:crypto";
+import { asJson, execute, query, queryOne, withTransaction, type Queryable } from "../database.server";
+import { quantityFingerprint, type InventoryObservationItem } from "~/features/inventory-opening-balance/domain/inventoryObservation";
+
+type ObservationInput = {
+  requestId: string; sellerKey: string; status: "complete" | "unstable";
+  claimToken: string; beforeIdentityDeclarationCount: number; afterIdentityDeclarationCount: number;
+  startedAt: Date; cutoffAt: Date; quantityFingerprint: string;
+  firstContentFingerprint: string; secondContentFingerprint: string;
+  items: InventoryObservationItem[]; error?: string;
+};
+
+async function evidence(sellerKey: string, cutoffAt: Date, observationId: string, db?: Queryable) {
+  const orders = await query<{ id: string; revision: number }>(
+    `SELECT id::text AS id, source_revision AS revision FROM seller_orders
+     WHERE seller_key=$1 AND order_time < $2 ORDER BY id`, [sellerKey, cutoffAt], db);
+  const receipts = await query<{ receiptId: number; liveAt: Date; quantity: number }>(
+    `SELECT link.receipt_id AS "receiptId", link.live_at AS "liveAt",link.planned_quantity AS quantity
+     FROM inventory_publication_receipt_links link
+     WHERE link.target_seller_key=$1 AND link.live_at < $2 ORDER BY link.receipt_id`,
+    [sellerKey, cutoffAt], db);
+  const catalog = await query<{ sku: number; productLineId: number | null; setId: number | null; productId: number | null }>(
+    `SELECT item.sku, skus.product_line_id AS "productLineId", skus.set_id AS "setId",
+      skus.product_id AS "productId"
+     FROM inventory_complete_observation_items item
+     LEFT JOIN skus ON skus.sku=item.sku
+     WHERE item.observation_id=$1 AND item.quantity>0
+     ORDER BY item.sku`, [observationId], db);
+  return createHash("sha256").update(JSON.stringify({
+    orders: orders.map((row) => [row.id, row.revision]),
+    receipts: receipts.map((row) => [row.receiptId, row.quantity, row.liveAt.toISOString()]),
+    catalog: catalog.map((row) => [row.sku, row.productLineId, row.setId, row.productId]),
+  })).digest("hex");
+}
+
+export const inventoryOpeningBalancesRepository = {
+  async beginObservationCapture(input: { requestId: string; sellerKey: string }) {
+    return withTransaction(async (db) => {
+      await db.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [`opening-capture:${input.requestId}`]);
+      const existing = await queryOne<{
+        sellerKey: string; status: string; claimExpiresAt: Date | null; observationId: string | null;
+      }>(`SELECT seller_key AS "sellerKey",status,claim_expires_at AS "claimExpiresAt",
+          observation_id::text AS "observationId"
+         FROM inventory_complete_observation_requests WHERE request_id=$1 FOR UPDATE`,[input.requestId],db);
+      if (existing?.sellerKey !== undefined && existing.sellerKey !== input.sellerKey) {
+        throw new Error("Observation request ID was reused for a different seller.");
+      }
+      if (existing?.status === "complete" && existing.observationId) {
+        const observation = await queryOne<any>(
+          `SELECT id::text AS id,seller_key AS "sellerKey",status,
+            quantity_fingerprint AS "quantityFingerprint",sku_count AS "skuCount",
+            positive_sku_count AS "positiveSkuCount",total_quantity AS "totalQuantity",
+            cutoff_at AS "cutoffAt"
+           FROM inventory_complete_observations WHERE id=$1`,[existing.observationId],db);
+        if (!observation) throw new Error("Completed inventory observation evidence is missing.");
+        return { state: "complete" as const, observation };
+      }
+      if (existing?.status === "capturing" && existing.claimExpiresAt && existing.claimExpiresAt.getTime() > Date.now()) {
+        throw new Error("This inventory observation capture is already in progress.");
+      }
+      const claimToken=randomUUID();
+      if (existing) {
+        await execute(`UPDATE inventory_complete_observation_requests
+          SET status='capturing',claim_token=$2,claim_expires_at=NOW()+INTERVAL '3 minutes',
+            observation_id=NULL,error=NULL,updated_at=NOW() WHERE request_id=$1`,[input.requestId,claimToken],db);
+      } else {
+        await execute(`INSERT INTO inventory_complete_observation_requests
+          (request_id,seller_key,status,claim_token,claim_expires_at)
+          VALUES ($1,$2,'capturing',$3,NOW()+INTERVAL '3 minutes')`,[input.requestId,input.sellerKey,claimToken],db);
+      }
+      return { state: "claimed" as const, claimToken };
+    });
+  },
+
+  async failObservationCapture(requestId: string, claimToken: string, error: string) {
+    await execute(`UPDATE inventory_complete_observation_requests
+      SET status='failed',claim_token=NULL,claim_expires_at=NULL,error=$3,updated_at=NOW()
+      WHERE request_id=$1 AND status='capturing' AND claim_token=$2`,[requestId,claimToken,error.slice(0,500)]);
+  },
+
+  async recordObservation(input: ObservationInput) {
+    return withTransaction(async (db) => {
+      const totalQuantity=input.items.reduce((sum,item)=>sum+item.quantity,0);
+      if (!input.requestId.trim() || !input.sellerKey.trim() || input.beforeIdentityDeclarationCount < 2 ||
+          input.afterIdentityDeclarationCount < 2 || input.items.length > 50_000 ||
+          input.items.some((item)=>!Number.isInteger(item.sku)||item.sku<=0||item.sku>2_147_483_647||
+            !Number.isInteger(item.quantity)||item.quantity<0||item.quantity>2_147_483_647) ||
+          !Number.isSafeInteger(totalQuantity)||totalQuantity>2_147_483_647 ||
+          quantityFingerprint(input.items)!==input.quantityFingerprint) {
+        throw new Error("Inventory observation evidence is invalid.");
+      }
+      const request=await queryOne<{sellerKey:string;status:string;claimToken:string|null}>(
+        `SELECT seller_key AS "sellerKey",status,claim_token AS "claimToken"
+         FROM inventory_complete_observation_requests WHERE request_id=$1 FOR UPDATE`,[input.requestId],db);
+      if (!request || request.sellerKey !== input.sellerKey || request.status !== "capturing" || request.claimToken !== input.claimToken) {
+        throw new Error("Inventory observation capture claim was lost.");
+      }
+      await db.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [`opening-observation:${input.sellerKey}`]);
+      if (input.startedAt.getTime() > input.cutoffAt.getTime()) throw new Error("Inventory observation cutoff precedes its start.");
+      const positive = input.items.filter((item) => item.quantity > 0);
+      const previous = await queryOne<{ id: string; cutoffAt: Date }>(
+        `SELECT id::text AS id,cutoff_at AS "cutoffAt" FROM inventory_complete_observations
+         WHERE seller_key=$1 AND status='complete' ORDER BY cutoff_at DESC,id DESC LIMIT 1`,
+        [input.sellerKey],db);
+      if (previous && previous.cutoffAt.getTime() >= input.cutoffAt.getTime()) {
+        throw new Error("Inventory observations must advance the seller cutoff.");
+      }
+      const row = await queryOne<{ id: string }>(
+        `INSERT INTO inventory_complete_observations (
+          request_id,seller_key,source,status,quantity_semantics,started_at,cutoff_at,
+          quantity_fingerprint,first_content_fingerprint,second_content_fingerprint,
+          sku_count,positive_sku_count,total_quantity,identity_evidence,error
+        ) VALUES ($1,$2,'seller_portal_live_export',$3,'sellable_excludes_reserved',$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb,$13)
+        RETURNING id::text AS id`,
+        [input.requestId,input.sellerKey,input.status,input.startedAt,input.cutoffAt,
+          input.quantityFingerprint,input.firstContentFingerprint,input.secondContentFingerprint,
+          input.items.length,positive.length,totalQuantity,
+          asJson({
+            sellerKey: input.sellerKey, checkedBeforeAndAfter: true,
+            beforeDeclarationCount: input.beforeIdentityDeclarationCount,
+            afterDeclarationCount: input.afterIdentityDeclarationCount,
+          }),input.error??null],db);
+      if (!row) throw new Error("Failed to record inventory observation.");
+      await execute(
+        `INSERT INTO inventory_complete_observation_items (observation_id,sku,quantity)
+         SELECT $1,x.sku,x.quantity
+         FROM jsonb_to_recordset($2::jsonb) AS x(sku integer,quantity integer)`,
+        [row.id,asJson(input.items.map(({sku,quantity})=>({sku,quantity})))],db);
+      if (previous && input.status === "complete") await execute(
+        `INSERT INTO inventory_observation_differences
+          (seller_key,previous_observation_id,observation_id,sku,quantity_delta,previous_quantity,observed_quantity)
+         SELECT $1,$2,$3,COALESCE(old.sku,current.sku),COALESCE(current.quantity,0)-COALESCE(old.quantity,0),
+           COALESCE(old.quantity,0),COALESCE(current.quantity,0)
+         FROM (SELECT sku,quantity FROM inventory_complete_observation_items WHERE observation_id=$2) old
+         FULL JOIN (SELECT sku,quantity FROM inventory_complete_observation_items WHERE observation_id=$3) current
+           USING (sku)
+         WHERE COALESCE(current.quantity,0)<>COALESCE(old.quantity,0)`,
+        [input.sellerKey,previous.id,row.id],db);
+      await execute(`DELETE FROM inventory_complete_observation_items item
+        WHERE item.observation_id IN (
+          SELECT old.id FROM inventory_complete_observations old
+          WHERE old.seller_key=$1
+            AND old.id NOT IN (
+              SELECT recent.id FROM inventory_complete_observations recent
+              WHERE recent.seller_key=$1 ORDER BY recent.cutoff_at DESC,recent.id DESC LIMIT 3
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM inventory_opening_balance_runs run
+              WHERE run.observation_id=old.id AND run.status='previewed'
+            )
+        )`,[input.sellerKey],db);
+      await execute(`UPDATE inventory_complete_observation_requests
+        SET status='complete',claim_token=NULL,claim_expires_at=NULL,observation_id=$2,updated_at=NOW()
+        WHERE request_id=$1`,[input.requestId,row.id],db);
+      return {
+        id: row.id, sellerKey: input.sellerKey, status: input.status,
+        quantityFingerprint: input.quantityFingerprint, skuCount: input.items.length,
+        positiveSkuCount: positive.length,
+        totalQuantity,
+      };
+    });
+  },
+
+  async preview(input: { requestId: string; sellerKey: string; observationId: string }) {
+    return withTransaction(async (db) => {
+      await db.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [`opening:${input.sellerKey}`]);
+      const existing = await queryOne<any>(
+        `SELECT run.id::text AS id,run.seller_key AS "sellerKey",run.observation_id::text AS "observationId",
+          run.cutoff_at AS "cutoffAt",run.status,run.evidence_fingerprint AS "evidenceFingerprint",run.unresolved,
+          observation.sku_count AS "skuCount",observation.positive_sku_count AS "positiveSkuCount",
+          observation.total_quantity AS "totalQuantity"
+         FROM inventory_opening_balance_runs run
+         JOIN inventory_complete_observations observation ON observation.id=run.observation_id
+         WHERE run.request_id=$1`,[input.requestId],db);
+      if (existing) {
+        if (existing.sellerKey !== input.sellerKey || existing.observationId !== input.observationId) {
+          throw new Error("Opening preview request ID was reused with different inputs.");
+        }
+        return existing;
+      }
+      const observation = await queryOne<any>(
+        `SELECT id::text AS id,seller_key AS "sellerKey",status,cutoff_at AS "cutoffAt",
+          started_at AS "startedAt", quantity_fingerprint AS "quantityFingerprint",
+          sku_count AS "skuCount",positive_sku_count AS "positiveSkuCount",total_quantity AS "totalQuantity"
+         FROM inventory_complete_observations WHERE id=$1`,
+        [input.observationId],db);
+      if (!observation || observation.sellerKey !== input.sellerKey) throw new Error("Complete inventory observation does not match seller.");
+      await db.query(
+        `SELECT skus.sku FROM skus
+         JOIN inventory_complete_observation_items item ON item.sku=skus.sku
+         WHERE item.observation_id=$1 AND item.quantity>0 FOR SHARE OF skus`,[input.observationId]);
+      const coverage = await queryOne<any>(
+        `SELECT id::text AS id,finished_at AS "finishedAt",observed_from AS "observedFrom",
+          observed_through AS "observedThrough",orders_observed AS "ordersObserved",
+          details_recorded AS "detailsRecorded" FROM seller_order_sync_runs
+         WHERE seller_key=$1 AND source='tcgplayer_api' AND status='complete' AND finished_at >= $2
+         ORDER BY finished_at ASC LIMIT 1`,[input.sellerKey,observation.cutoffAt],db);
+      const missing = await query<{ sku: number }>(
+        `SELECT item.sku FROM inventory_complete_observation_items item
+         LEFT JOIN skus ON skus.sku=item.sku
+         WHERE item.observation_id=$1 AND item.quantity>0
+           AND (skus.sku IS NULL OR skus.product_line_id IS NULL OR skus.set_id IS NULL OR skus.product_id IS NULL)`,[input.observationId],db);
+      const intervalOrders = await queryOne<{ count: number }>(
+        `SELECT COUNT(*)::int AS count FROM seller_orders
+         WHERE seller_key=$1 AND order_time >= $2 AND order_time < $3`,
+        [input.sellerKey,observation.startedAt,observation.cutoffAt],db);
+      const intervalPublications = await queryOne<{ count: number }>(
+        `SELECT COUNT(*)::int AS count FROM inventory_publication_receipt_links
+         WHERE target_seller_key=$1 AND live_at >= $2 AND live_at < $3`,
+        [input.sellerKey,observation.startedAt,observation.cutoffAt],db);
+      const unresolvedDifferences = await queryOne<{ count: number }>(
+        `SELECT COUNT(*)::int AS count FROM inventory_observation_differences
+         WHERE observation_id=$1 AND status='unresolved'`, [input.observationId], db);
+      const appliedOpening = await queryOne<{ count: number }>(
+        `SELECT COUNT(*)::int AS count FROM inventory_opening_balance_runs
+         WHERE seller_key=$1 AND status='applied'`,[input.sellerKey],db);
+      const unresolved = [
+        ...(observation.status !== "complete" ? ["Inventory quantities changed during observation."] : []),
+        ...(!coverage ? ["Complete seller order coverage through the cutoff is required."] : []),
+        ...(missing.length ? [`${missing.length} positive inventory SKUs lack catalog identity.`] : []),
+        ...((intervalOrders?.count ?? 0) > 0 ? ["An order occurred during the inventory observation interval."] : []),
+        ...((intervalPublications?.count ?? 0) > 0 ? ["A publication became live during the inventory observation interval."] : []),
+        ...((unresolvedDifferences?.count ?? 0) > 0 ? [`${unresolvedDifferences?.count} inventory changes require review.`] : []),
+        ...((appliedOpening?.count ?? 0) > 0 ? ["This seller already has an applied opening balance."] : []),
+      ];
+      const sourceEvidence = await evidence(input.sellerKey, observation.cutoffAt, input.observationId, db);
+      const fingerprint = createHash("sha256").update(JSON.stringify({
+        observation: observation.quantityFingerprint, orderCoverage: coverage?.id ?? null, sourceEvidence,
+      })).digest("hex");
+      const run = await queryOne<{ id: string; status: string }>(
+        `INSERT INTO inventory_opening_balance_runs
+          (request_id,seller_key,observation_id,order_coverage_run_id,order_coverage_evidence,cutoff_at,status,evidence_fingerprint,unresolved)
+         VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8,$9::jsonb) RETURNING id::text AS id,status`,
+        [input.requestId,input.sellerKey,input.observationId,coverage?.id??null,asJson(coverage),
+          observation.cutoffAt,unresolved.length?"blocked":"previewed",fingerprint,asJson(unresolved)],db);
+      if (!run) throw new Error("Failed to create opening preview.");
+      await execute(
+        `INSERT INTO inventory_opening_balance_items
+          (run_id,sku,opening_quantity,product_line_id,set_id,product_id)
+         SELECT $1,item.sku,item.quantity,
+           CASE WHEN skus.product_line_id IS NULL OR skus.set_id IS NULL OR skus.product_id IS NULL THEN NULL ELSE skus.product_line_id END,
+           CASE WHEN skus.product_line_id IS NULL OR skus.set_id IS NULL OR skus.product_id IS NULL THEN NULL ELSE skus.set_id END,
+           CASE WHEN skus.product_line_id IS NULL OR skus.set_id IS NULL OR skus.product_id IS NULL THEN NULL ELSE skus.product_id END
+         FROM inventory_complete_observation_items item
+         LEFT JOIN skus ON skus.sku=item.sku
+         WHERE item.observation_id=$2 AND item.quantity>0`,
+        [run.id,input.observationId],db);
+      return {
+        ...run, cutoffAt: observation.cutoffAt, evidenceFingerprint: fingerprint, unresolved,
+        skuCount: observation.skuCount, positiveSkuCount: observation.positiveSkuCount,
+        totalQuantity: observation.totalQuantity,
+      };
+    });
+  },
+
+  async apply(runId: string, expectedFingerprint: string, expectedSellerKey: string) {
+    return withTransaction(async (db) => {
+      const run = await queryOne<any>(
+        `SELECT id::text AS id,seller_key AS "sellerKey",cutoff_at AS "cutoffAt",status,
+          evidence_fingerprint AS "evidenceFingerprint",observation_id AS "observationId"
+         FROM inventory_opening_balance_runs WHERE id=$1 AND seller_key=$2 FOR UPDATE`,[runId,expectedSellerKey.trim()],db);
+      if (!run) throw new Error("Opening balance preview was not found.");
+      if (run.status === "applied") {
+        if (run.evidenceFingerprint !== expectedFingerprint) throw new Error("Opening balance evidence conflict.");
+        return run;
+      }
+      if (run.status !== "previewed" || run.evidenceFingerprint !== expectedFingerprint) throw new Error("Opening balance preview is blocked or stale.");
+      await db.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [`opening:${run.sellerKey}`]);
+      const currentEvidence = await evidence(run.sellerKey, run.cutoffAt, run.observationId, db);
+      const coverage = await queryOne<{ id: string }>(`SELECT order_coverage_run_id::text AS id FROM inventory_opening_balance_runs WHERE id=$1`,[runId],db);
+      const observation = await queryOne<{ fp: string }>(`SELECT quantity_fingerprint AS fp FROM inventory_complete_observations WHERE id=$1`,[run.observationId],db);
+      const recomputed = createHash("sha256").update(JSON.stringify({ observation: observation?.fp, orderCoverage: coverage?.id, sourceEvidence: currentEvidence })).digest("hex");
+      if (recomputed !== expectedFingerprint) throw new Error("Opening balance evidence changed; create a new preview.");
+      const positive=await queryOne<{count:number}>(`SELECT COUNT(*)::int AS count FROM inventory_opening_balance_items
+        WHERE run_id=$1 AND opening_quantity>0`,[runId],db);
+      const expectedCount=positive?.count??0;
+      const mutations=await execute(`INSERT INTO inventory_pending_mutations
+          (request_id,mutation_type,sku,requested_quantity,product_line_id,set_id,product_id,quantity_delta,resulting_quantity)
+        SELECT 'opening:'||$1::text||':'||item.sku::text,'opening',item.sku,item.opening_quantity,
+          item.product_line_id,item.set_id,item.product_id,item.opening_quantity,item.opening_quantity
+        FROM inventory_opening_balance_items item
+        WHERE item.run_id=$1::bigint AND item.opening_quantity>0
+          AND item.product_line_id IS NOT NULL AND item.set_id IS NOT NULL AND item.product_id IS NOT NULL`,[runId],db);
+      if(mutations!==expectedCount) throw new Error("Opening balance catalog evidence is incomplete.");
+      const receipts=await execute(`WITH inserted AS (INSERT INTO inventory_receipts
+          (request_id,sku,original_quantity,product_line_id,set_id,product_id,seller_key,intake_at,
+           market_value,market_observed_at,market_calculated_at,market_provenance,source_evidence,
+           receipt_kind,opening_balance_run_id,fifo_precedence)
+          SELECT 'opening:'||$1::text||':'||item.sku::text,item.sku,item.opening_quantity,
+            item.product_line_id,item.set_id,item.product_id,$2,NULL,NULL,NULL,NULL,
+            'opening_balance_unknown',jsonb_build_object('observationId',$3::bigint,'cutoffAt',$4::timestamptz),
+            'opening_balance',$1::bigint,0
+          FROM inventory_opening_balance_items item
+          WHERE item.run_id=$1::bigint AND item.opening_quantity>0
+            AND item.product_line_id IS NOT NULL AND item.set_id IS NOT NULL AND item.product_id IS NOT NULL
+          RETURNING receipt_id,sku)
+        UPDATE inventory_opening_balance_items item SET receipt_id=inserted.receipt_id
+        FROM inserted WHERE item.run_id=$1::bigint AND item.sku=inserted.sku`,
+        [runId,run.sellerKey,run.observationId,run.cutoffAt],db);
+      if(receipts!==expectedCount) throw new Error("Opening balance receipt conservation failed.");
+      await execute(`UPDATE inventory_opening_balance_runs SET status='applied',applied_at=NOW() WHERE id=$1`,[runId],db);
+      return { ...run, status:"applied" };
+    });
+  },
+
+  async acknowledgeDifference(input: { requestId: string; id: string; sellerKey: string; note: string }) {
+    if (!input.requestId.trim() || !input.note.trim()) throw new Error("An acknowledgement request ID and note are required.");
+    return withTransaction(async (db) => {
+      const replay=await queryOne<{id:string;sellerKey:string;note:string|null}>(
+        `SELECT id::text AS id,seller_key AS "sellerKey",acknowledgement_note AS note
+         FROM inventory_observation_differences WHERE acknowledgement_request_id=$1 FOR UPDATE`,[input.requestId],db);
+      if(replay){
+        if(replay.id!==input.id || replay.sellerKey!==input.sellerKey.trim() || replay.note!==input.note.trim()) {
+          throw new Error("Inventory difference acknowledgement request conflicts.");
+        }
+        return {id:replay.id};
+      }
+      const existing=await queryOne<{id:string;sellerKey:string;status:string}>(
+        `SELECT id::text AS id,seller_key AS "sellerKey",status
+         FROM inventory_observation_differences WHERE id=$1 AND seller_key=$2 FOR UPDATE`,[input.id,input.sellerKey.trim()],db);
+      if (!existing) {
+        throw new Error("Unresolved inventory difference was not found for seller.");
+      }
+      const row=await queryOne<{id:string}>(`UPDATE inventory_observation_differences
+        SET status='acknowledged',acknowledgement_request_id=$2,acknowledgement_note=$3,acknowledged_at=NOW()
+        WHERE id=$1 AND status='unresolved' RETURNING id::text AS id`,[input.id,input.requestId.trim(),input.note.trim()],db);
+      if (!row) throw new Error("Unresolved inventory difference was not found.");
+      return row;
+    });
+  },
+};

--- a/app/core/db/repositories/inventoryOpeningBalances.server.ts
+++ b/app/core/db/repositories/inventoryOpeningBalances.server.ts
@@ -1,14 +1,33 @@
 import { createHash, randomUUID } from "node:crypto";
 import { asJson, execute, query, queryOne, withTransaction, type Queryable } from "../database.server";
-import { quantityFingerprint, type InventoryObservationItem } from "~/features/inventory-opening-balance/domain/inventoryObservation";
+import { quantityFingerprint, supportedQuantityFingerprint, type InventoryObservationItem } from "~/features/inventory-opening-balance/domain/inventoryObservation";
 
 type ObservationInput = {
   requestId: string; sellerKey: string; status: "complete" | "unstable";
   claimToken: string; beforeIdentityDeclarationCount: number; afterIdentityDeclarationCount: number;
   startedAt: Date; cutoffAt: Date; quantityFingerprint: string;
+  supportedQuantityFingerprint: string;
   firstContentFingerprint: string; secondContentFingerprint: string;
   items: InventoryObservationItem[]; error?: string;
 };
+
+async function observationItemsEvidence(observationId: string, db?: Queryable) {
+  const items=await query<{inventoryKey:string;sku:number|null;quantity:number}>(`SELECT inventory_key AS "inventoryKey",sku,quantity
+    FROM inventory_complete_observation_items WHERE observation_id=$1 ORDER BY inventory_key COLLATE "C"`,[observationId],db);
+  const supported=items.filter((item)=>item.sku!==null);
+  return {
+    itemCount:items.length,
+    positiveItemCount:items.filter((item)=>item.quantity>0).length,
+    totalQuantity:items.reduce((sum,item)=>sum+item.quantity,0),
+    positiveSkuCount:supported.filter((item)=>item.quantity>0).length,
+    supportedTotalQuantity:supported.reduce((sum,item)=>sum+item.quantity,0),
+    unsupportedPositiveItemCount:items.filter((item)=>item.sku===null&&item.quantity>0).length,
+    unsupportedPositiveQuantity:items.filter((item)=>item.sku===null).reduce((sum,item)=>sum+item.quantity,0),
+    quantityFingerprint:createHash("sha256").update(JSON.stringify(items.map(({inventoryKey,quantity})=>[inventoryKey,quantity]))).digest("hex"),
+    supportedQuantityFingerprint:createHash("sha256").update(JSON.stringify(supported
+      .sort((a,b)=>(a.sku??0)-(b.sku??0)).map(({sku,quantity})=>[sku,quantity]))).digest("hex"),
+  };
+}
 
 async function evidence(sellerKey: string, cutoffAt: Date, observationId: string, db?: Queryable) {
   const orders = await query<{ id: string; revision: number }>(
@@ -24,7 +43,7 @@ async function evidence(sellerKey: string, cutoffAt: Date, observationId: string
       skus.product_id AS "productId"
      FROM inventory_complete_observation_items item
      LEFT JOIN skus ON skus.sku=item.sku
-     WHERE item.observation_id=$1 AND item.quantity>0
+     WHERE item.observation_id=$1 AND item.sku IS NOT NULL AND item.quantity>0
      ORDER BY item.sku`, [observationId], db);
   return createHash("sha256").update(JSON.stringify({
     orders: orders.map((row) => [row.id, row.revision]),
@@ -34,22 +53,86 @@ async function evidence(sellerKey: string, cutoffAt: Date, observationId: string
 }
 
 export const inventoryOpeningBalancesRepository = {
-  async beginObservationCapture(input: { requestId: string; sellerKey: string }) {
+  async listDifferences(input: {sellerKey:string;observationId:string;afterId?:string;limit?:number}) {
+    const limit=input.limit??100;
+    if(!Number.isInteger(limit)||limit<1||limit>200) throw new Error("Difference page limit must be between 1 and 200.");
+    return query(`SELECT id::text AS id,inventory_key AS "inventoryKey",sku,previous_quantity AS "previousQuantity",
+      observed_quantity AS "observedQuantity",quantity_delta AS "quantityDelta",status,
+      acknowledgement_note AS "acknowledgementNote",acknowledged_at AS "acknowledgedAt"
+      FROM inventory_observation_differences
+      WHERE seller_key=$1 AND observation_id=$2 AND id>$3::bigint
+      ORDER BY id LIMIT $4`,[input.sellerKey.trim(),input.observationId,input.afterId??"0",limit]);
+  },
+
+  async listObservationItems(input: {
+    sellerKey:string;observationId:string;afterInventoryKey?:string;limit?:number;unsupportedOnly?:boolean;
+  }) {
+    const limit=input.limit??100;
+    if(!Number.isInteger(limit)||limit<1||limit>200) throw new Error("Observation item page limit must be between 1 and 200.");
+    return query(`SELECT item.inventory_key AS "inventoryKey",item.identity_kind AS "identityKind",
+      item.sku,item.quantity
+      FROM inventory_complete_observation_items item
+      JOIN inventory_complete_observations observation ON observation.id=item.observation_id
+      WHERE observation.id=$1 AND observation.seller_key=$2
+        AND item.inventory_key COLLATE "C">$3 COLLATE "C"
+        AND (NOT $4::boolean OR item.identity_kind='unsupported')
+      ORDER BY item.inventory_key COLLATE "C" LIMIT $5`,
+      [input.observationId,input.sellerKey.trim(),input.afterInventoryKey??"",input.unsupportedOnly??false,limit]);
+  },
+
+  async listPreviewItems(input: {sellerKey:string;runId:string;afterSku?:number;limit?:number}) {
+    const limit=input.limit??100;
+    if(!Number.isInteger(limit)||limit<1||limit>200) throw new Error("Preview item page limit must be between 1 and 200.");
+    return query(`SELECT item.sku,item.opening_quantity AS "openingQuantity",
+      item.product_line_id AS "productLineId",item.set_id AS "setId",item.product_id AS "productId"
+      FROM inventory_opening_balance_items item
+      JOIN inventory_opening_balance_runs run ON run.id=item.run_id
+      WHERE run.id=$1 AND run.seller_key=$2 AND item.sku>$3
+      ORDER BY item.sku LIMIT $4`,[input.runId,input.sellerKey.trim(),input.afterSku??0,limit]);
+  },
+
+  async findApplicationReplay(input: {runId:string;sellerKey:string;requestId:string;expectedFingerprint:string}) {
+    const run=await queryOne<any>(`SELECT id::text AS id,status,evidence_fingerprint AS "evidenceFingerprint",
+      apply_request_id AS "applyRequestId" FROM inventory_opening_balance_runs
+      WHERE id=$1 AND seller_key=$2`,[input.runId,input.sellerKey.trim()]);
+    if(!run) throw new Error("Opening balance preview was not found.");
+    if(run.status!=="applied") {
+      if(run.status!=="previewed" || run.evidenceFingerprint!==input.expectedFingerprint) {
+        throw new Error("Opening balance preview is blocked or stale.");
+      }
+      return null;
+    }
+    if(run.applyRequestId!==input.requestId.trim() || run.evidenceFingerprint!==input.expectedFingerprint) {
+      throw new Error("Opening balance application evidence conflicts.");
+    }
+    return run;
+  },
+
+  async beginObservationCapture(input: { requestId: string; sellerKey: string; purposeEvidence?: Record<string,unknown> }) {
     return withTransaction(async (db) => {
+      const purposeEvidence=input.purposeEvidence??{kind:"opening_observation"};
       await db.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [`opening-capture:${input.requestId}`]);
       const existing = await queryOne<{
         sellerKey: string; status: string; claimExpiresAt: Date | null; observationId: string | null;
+        purposeMatches: boolean;
       }>(`SELECT seller_key AS "sellerKey",status,claim_expires_at AS "claimExpiresAt",
-          observation_id::text AS "observationId"
-         FROM inventory_complete_observation_requests WHERE request_id=$1 FOR UPDATE`,[input.requestId],db);
+          observation_id::text AS "observationId",purpose_evidence=$2::jsonb AS "purposeMatches"
+         FROM inventory_complete_observation_requests WHERE request_id=$1 FOR UPDATE`,
+        [input.requestId,asJson(purposeEvidence)],db);
       if (existing?.sellerKey !== undefined && existing.sellerKey !== input.sellerKey) {
         throw new Error("Observation request ID was reused for a different seller.");
+      }
+      if(existing && !existing.purposeMatches) {
+        throw new Error("Observation request ID was reused for a different purpose.");
       }
       if (existing?.status === "complete" && existing.observationId) {
         const observation = await queryOne<any>(
           `SELECT id::text AS id,seller_key AS "sellerKey",status,
-            quantity_fingerprint AS "quantityFingerprint",sku_count AS "skuCount",
-            positive_sku_count AS "positiveSkuCount",total_quantity AS "totalQuantity",
+            quantity_fingerprint AS "quantityFingerprint",supported_quantity_fingerprint AS "supportedQuantityFingerprint",
+            item_count AS "itemCount",positive_item_count AS "positiveItemCount",total_quantity AS "observedTotalQuantity",
+            supported_positive_sku_count AS "positiveSkuCount",supported_total_quantity AS "totalQuantity",
+            unsupported_positive_item_count AS "unsupportedPositiveItemCount",
+            unsupported_positive_quantity AS "unsupportedPositiveQuantity",
             cutoff_at AS "cutoffAt"
            FROM inventory_complete_observations WHERE id=$1`,[existing.observationId],db);
         if (!observation) throw new Error("Completed inventory observation evidence is missing.");
@@ -65,8 +148,9 @@ export const inventoryOpeningBalancesRepository = {
             observation_id=NULL,error=NULL,updated_at=NOW() WHERE request_id=$1`,[input.requestId,claimToken],db);
       } else {
         await execute(`INSERT INTO inventory_complete_observation_requests
-          (request_id,seller_key,status,claim_token,claim_expires_at)
-          VALUES ($1,$2,'capturing',$3,NOW()+INTERVAL '3 minutes')`,[input.requestId,input.sellerKey,claimToken],db);
+          (request_id,seller_key,purpose_evidence,status,claim_token,claim_expires_at)
+          VALUES ($1,$2,$3::jsonb,'capturing',$4,NOW()+INTERVAL '3 minutes')`,
+          [input.requestId,input.sellerKey,asJson(purposeEvidence),claimToken],db);
       }
       return { state: "claimed" as const, claimToken };
     });
@@ -81,12 +165,23 @@ export const inventoryOpeningBalancesRepository = {
   async recordObservation(input: ObservationInput) {
     return withTransaction(async (db) => {
       const totalQuantity=input.items.reduce((sum,item)=>sum+item.quantity,0);
+      const supportedItems=input.items.filter((item)=>item.sku!==null);
+      const supportedTotalQuantity=supportedItems.reduce((sum,item)=>sum+item.quantity,0);
+      const unsupportedPositiveItems=input.items.filter((item)=>item.sku===null&&item.quantity>0);
+      const inventoryKeys=new Set(input.items.map((item)=>item.inventoryKey));
+      const numericSkus=new Set(supportedItems.map((item)=>item.sku));
       if (!input.requestId.trim() || !input.sellerKey.trim() || input.beforeIdentityDeclarationCount < 2 ||
           input.afterIdentityDeclarationCount < 2 || input.items.length > 50_000 ||
-          input.items.some((item)=>!Number.isInteger(item.sku)||item.sku<=0||item.sku>2_147_483_647||
+          inventoryKeys.size!==input.items.length || numericSkus.size!==supportedItems.length ||
+          input.items.some((item)=>!/^[\x21-\x7e]{1,100}$/.test(item.inventoryKey) ||
+            !["standard_sku","unsupported"].includes(item.identityKind) ||
+            (item.sku===null)!==(item.identityKind==="unsupported") ||
+            (item.sku!==null&&(!Number.isInteger(item.sku)||item.sku<=0||item.sku>2_147_483_647))||
             !Number.isInteger(item.quantity)||item.quantity<0||item.quantity>2_147_483_647) ||
           !Number.isSafeInteger(totalQuantity)||totalQuantity>2_147_483_647 ||
-          quantityFingerprint(input.items)!==input.quantityFingerprint) {
+          !Number.isSafeInteger(supportedTotalQuantity)||supportedTotalQuantity>2_147_483_647 ||
+          quantityFingerprint(input.items)!==input.quantityFingerprint ||
+          supportedQuantityFingerprint(input.items)!==input.supportedQuantityFingerprint) {
         throw new Error("Inventory observation evidence is invalid.");
       }
       const request=await queryOne<{sellerKey:string;status:string;claimToken:string|null}>(
@@ -98,23 +193,29 @@ export const inventoryOpeningBalancesRepository = {
       await db.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [`opening-observation:${input.sellerKey}`]);
       if (input.startedAt.getTime() > input.cutoffAt.getTime()) throw new Error("Inventory observation cutoff precedes its start.");
       const positive = input.items.filter((item) => item.quantity > 0);
+      const latestObservation = await queryOne<{ cutoffAt: Date }>(
+        `SELECT cutoff_at AS "cutoffAt" FROM inventory_complete_observations
+         WHERE seller_key=$1 ORDER BY cutoff_at DESC,id DESC LIMIT 1`,[input.sellerKey],db);
+      if (latestObservation && latestObservation.cutoffAt.getTime() >= input.cutoffAt.getTime()) {
+        throw new Error("Inventory observations must advance the seller cutoff.");
+      }
       const previous = await queryOne<{ id: string; cutoffAt: Date }>(
         `SELECT id::text AS id,cutoff_at AS "cutoffAt" FROM inventory_complete_observations
          WHERE seller_key=$1 AND status='complete' ORDER BY cutoff_at DESC,id DESC LIMIT 1`,
         [input.sellerKey],db);
-      if (previous && previous.cutoffAt.getTime() >= input.cutoffAt.getTime()) {
-        throw new Error("Inventory observations must advance the seller cutoff.");
-      }
       const row = await queryOne<{ id: string }>(
         `INSERT INTO inventory_complete_observations (
           request_id,seller_key,source,status,quantity_semantics,started_at,cutoff_at,
-          quantity_fingerprint,first_content_fingerprint,second_content_fingerprint,
-          sku_count,positive_sku_count,total_quantity,identity_evidence,error
-        ) VALUES ($1,$2,'seller_portal_live_export',$3,'sellable_excludes_reserved',$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb,$13)
+          quantity_fingerprint,supported_quantity_fingerprint,first_content_fingerprint,second_content_fingerprint,
+          item_count,positive_item_count,total_quantity,supported_positive_sku_count,supported_total_quantity,
+          unsupported_positive_item_count,unsupported_positive_quantity,identity_evidence,error
+        ) VALUES ($1,$2,'seller_portal_live_export',$3,'sellable_excludes_reserved',$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17::jsonb,$18)
         RETURNING id::text AS id`,
         [input.requestId,input.sellerKey,input.status,input.startedAt,input.cutoffAt,
-          input.quantityFingerprint,input.firstContentFingerprint,input.secondContentFingerprint,
-          input.items.length,positive.length,totalQuantity,
+          input.quantityFingerprint,input.supportedQuantityFingerprint,input.firstContentFingerprint,input.secondContentFingerprint,
+          input.items.length,positive.length,totalQuantity,supportedItems.filter((item)=>item.quantity>0).length,
+          supportedTotalQuantity,unsupportedPositiveItems.length,
+          unsupportedPositiveItems.reduce((sum,item)=>sum+item.quantity,0),
           asJson({
             sellerKey: input.sellerKey, checkedBeforeAndAfter: true,
             beforeDeclarationCount: input.beforeIdentityDeclarationCount,
@@ -122,18 +223,19 @@ export const inventoryOpeningBalancesRepository = {
           }),input.error??null],db);
       if (!row) throw new Error("Failed to record inventory observation.");
       await execute(
-        `INSERT INTO inventory_complete_observation_items (observation_id,sku,quantity)
-         SELECT $1,x.sku,x.quantity
-         FROM jsonb_to_recordset($2::jsonb) AS x(sku integer,quantity integer)`,
-        [row.id,asJson(input.items.map(({sku,quantity})=>({sku,quantity})))],db);
+        `INSERT INTO inventory_complete_observation_items (observation_id,inventory_key,identity_kind,sku,quantity)
+         SELECT $1,x."inventoryKey",x."identityKind",x.sku,x.quantity
+         FROM jsonb_to_recordset($2::jsonb) AS x("inventoryKey" text,"identityKind" text,sku integer,quantity integer)`,
+        [row.id,asJson(input.items.map(({inventoryKey,identityKind,sku,quantity})=>({inventoryKey,identityKind,sku,quantity})))],db);
       if (previous && input.status === "complete") await execute(
         `INSERT INTO inventory_observation_differences
-          (seller_key,previous_observation_id,observation_id,sku,quantity_delta,previous_quantity,observed_quantity)
-         SELECT $1,$2,$3,COALESCE(old.sku,current.sku),COALESCE(current.quantity,0)-COALESCE(old.quantity,0),
+          (seller_key,previous_observation_id,observation_id,inventory_key,sku,quantity_delta,previous_quantity,observed_quantity)
+         SELECT $1,$2,$3,COALESCE(old.inventory_key,current.inventory_key),COALESCE(old.sku,current.sku),
+           COALESCE(current.quantity,0)-COALESCE(old.quantity,0),
            COALESCE(old.quantity,0),COALESCE(current.quantity,0)
-         FROM (SELECT sku,quantity FROM inventory_complete_observation_items WHERE observation_id=$2) old
-         FULL JOIN (SELECT sku,quantity FROM inventory_complete_observation_items WHERE observation_id=$3) current
-           USING (sku)
+         FROM (SELECT inventory_key,sku,quantity FROM inventory_complete_observation_items WHERE observation_id=$2) old
+         FULL JOIN (SELECT inventory_key,sku,quantity FROM inventory_complete_observation_items WHERE observation_id=$3) current
+           USING (inventory_key)
          WHERE COALESCE(current.quantity,0)<>COALESCE(old.quantity,0)`,
         [input.sellerKey,previous.id,row.id],db);
       await execute(`DELETE FROM inventory_complete_observation_items item
@@ -146,17 +248,24 @@ export const inventoryOpeningBalancesRepository = {
             )
             AND NOT EXISTS (
               SELECT 1 FROM inventory_opening_balance_runs run
-              WHERE run.observation_id=old.id AND run.status='previewed'
+              WHERE run.observation_id=old.id
             )
+            AND old.id <> COALESCE((
+              SELECT latest.id FROM inventory_complete_observations latest
+              WHERE latest.seller_key=$1 AND latest.status='complete'
+              ORDER BY latest.cutoff_at DESC,latest.id DESC LIMIT 1
+            ),-1)
         )`,[input.sellerKey],db);
       await execute(`UPDATE inventory_complete_observation_requests
         SET status='complete',claim_token=NULL,claim_expires_at=NULL,observation_id=$2,updated_at=NOW()
         WHERE request_id=$1`,[input.requestId,row.id],db);
       return {
         id: row.id, sellerKey: input.sellerKey, status: input.status,
-        quantityFingerprint: input.quantityFingerprint, skuCount: input.items.length,
-        positiveSkuCount: positive.length,
-        totalQuantity,
+        quantityFingerprint: input.quantityFingerprint,supportedQuantityFingerprint:input.supportedQuantityFingerprint,
+        itemCount:input.items.length,positiveItemCount:positive.length,observedTotalQuantity:totalQuantity,
+        positiveSkuCount:supportedItems.filter((item)=>item.quantity>0).length,totalQuantity:supportedTotalQuantity,
+        unsupportedPositiveItemCount:unsupportedPositiveItems.length,
+        unsupportedPositiveQuantity:unsupportedPositiveItems.reduce((sum,item)=>sum+item.quantity,0),
       };
     });
   },
@@ -166,9 +275,13 @@ export const inventoryOpeningBalancesRepository = {
       await db.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [`opening:${input.sellerKey}`]);
       const existing = await queryOne<any>(
         `SELECT run.id::text AS id,run.seller_key AS "sellerKey",run.observation_id::text AS "observationId",
-          run.cutoff_at AS "cutoffAt",run.status,run.evidence_fingerprint AS "evidenceFingerprint",run.unresolved,
-          observation.sku_count AS "skuCount",observation.positive_sku_count AS "positiveSkuCount",
-          observation.total_quantity AS "totalQuantity"
+          run.cutoff_at AS "cutoffAt",run.status,run.evidence_fingerprint AS "evidenceFingerprint",run.unresolved,run.limitations,
+          observation.item_count AS "itemCount",observation.positive_item_count AS "positiveItemCount",
+          observation.total_quantity AS "observedTotalQuantity",
+          observation.supported_positive_sku_count AS "positiveSkuCount",
+          observation.supported_total_quantity AS "totalQuantity",
+          observation.unsupported_positive_item_count AS "unsupportedPositiveItemCount",
+          observation.unsupported_positive_quantity AS "unsupportedPositiveQuantity"
          FROM inventory_opening_balance_runs run
          JOIN inventory_complete_observations observation ON observation.id=run.observation_id
          WHERE run.request_id=$1`,[input.requestId],db);
@@ -181,10 +294,26 @@ export const inventoryOpeningBalancesRepository = {
       const observation = await queryOne<any>(
         `SELECT id::text AS id,seller_key AS "sellerKey",status,cutoff_at AS "cutoffAt",
           started_at AS "startedAt", quantity_fingerprint AS "quantityFingerprint",
-          sku_count AS "skuCount",positive_sku_count AS "positiveSkuCount",total_quantity AS "totalQuantity"
+          supported_quantity_fingerprint AS "supportedQuantityFingerprint",
+          item_count AS "itemCount",positive_item_count AS "positiveItemCount",total_quantity AS "observedTotalQuantity",
+          supported_positive_sku_count AS "positiveSkuCount",supported_total_quantity AS "totalQuantity",
+          unsupported_positive_item_count AS "unsupportedPositiveItemCount",
+          unsupported_positive_quantity AS "unsupportedPositiveQuantity"
          FROM inventory_complete_observations WHERE id=$1`,
         [input.observationId],db);
       if (!observation || observation.sellerKey !== input.sellerKey) throw new Error("Complete inventory observation does not match seller.");
+      const retainedEvidence=await observationItemsEvidence(observation.id,db);
+      if(retainedEvidence.itemCount!==observation.itemCount ||
+          retainedEvidence.positiveItemCount!==observation.positiveItemCount ||
+          retainedEvidence.totalQuantity!==observation.observedTotalQuantity ||
+          retainedEvidence.positiveSkuCount!==observation.positiveSkuCount ||
+          retainedEvidence.supportedTotalQuantity!==observation.totalQuantity ||
+          retainedEvidence.unsupportedPositiveItemCount!==observation.unsupportedPositiveItemCount ||
+          retainedEvidence.unsupportedPositiveQuantity!==observation.unsupportedPositiveQuantity ||
+          retainedEvidence.quantityFingerprint!==observation.quantityFingerprint ||
+          retainedEvidence.supportedQuantityFingerprint!==observation.supportedQuantityFingerprint) {
+        throw new Error("Complete inventory observation item evidence is unavailable or inconsistent.");
+      }
       await db.query(
         `SELECT skus.sku FROM skus
          JOIN inventory_complete_observation_items item ON item.sku=skus.sku
@@ -198,7 +327,7 @@ export const inventoryOpeningBalancesRepository = {
       const missing = await query<{ sku: number }>(
         `SELECT item.sku FROM inventory_complete_observation_items item
          LEFT JOIN skus ON skus.sku=item.sku
-         WHERE item.observation_id=$1 AND item.quantity>0
+         WHERE item.observation_id=$1 AND item.sku IS NOT NULL AND item.quantity>0
            AND (skus.sku IS NULL OR skus.product_line_id IS NULL OR skus.set_id IS NULL OR skus.product_id IS NULL)`,[input.observationId],db);
       const intervalOrders = await queryOne<{ count: number }>(
         `SELECT COUNT(*)::int AS count FROM seller_orders
@@ -210,7 +339,10 @@ export const inventoryOpeningBalancesRepository = {
         [input.sellerKey,observation.startedAt,observation.cutoffAt],db);
       const unresolvedDifferences = await queryOne<{ count: number }>(
         `SELECT COUNT(*)::int AS count FROM inventory_observation_differences
-         WHERE observation_id=$1 AND status='unresolved'`, [input.observationId], db);
+         WHERE observation_id=$1 AND status='unresolved' AND sku IS NOT NULL`, [input.observationId], db);
+      const unsupportedDifferences = await queryOne<{ count: number }>(
+        `SELECT COUNT(*)::int AS count FROM inventory_observation_differences
+         WHERE observation_id=$1 AND status='unresolved' AND sku IS NULL`, [input.observationId], db);
       const appliedOpening = await queryOne<{ count: number }>(
         `SELECT COUNT(*)::int AS count FROM inventory_opening_balance_runs
          WHERE seller_key=$1 AND status='applied'`,[input.sellerKey],db);
@@ -223,16 +355,22 @@ export const inventoryOpeningBalancesRepository = {
         ...((unresolvedDifferences?.count ?? 0) > 0 ? [`${unresolvedDifferences?.count} inventory changes require review.`] : []),
         ...((appliedOpening?.count ?? 0) > 0 ? ["This seller already has an applied opening balance."] : []),
       ];
+      const limitations = [
+        ...(observation.unsupportedPositiveItemCount>0 ?
+          [`${observation.unsupportedPositiveItemCount} unsupported positive inventory items (${observation.unsupportedPositiveQuantity} units) are preserved as evidence and excluded from this standard-SKU opening balance.`] : []),
+        ...((unsupportedDifferences?.count??0)>0 ?
+          [`${unsupportedDifferences?.count} unsupported inventory identity changes remain unavailable to FIFO.`] : []),
+      ];
       const sourceEvidence = await evidence(input.sellerKey, observation.cutoffAt, input.observationId, db);
       const fingerprint = createHash("sha256").update(JSON.stringify({
-        observation: observation.quantityFingerprint, orderCoverage: coverage?.id ?? null, sourceEvidence,
+        observation: observation.supportedQuantityFingerprint, orderCoverage: coverage?.id ?? null, sourceEvidence,
       })).digest("hex");
       const run = await queryOne<{ id: string; status: string }>(
         `INSERT INTO inventory_opening_balance_runs
-          (request_id,seller_key,observation_id,order_coverage_run_id,order_coverage_evidence,cutoff_at,status,evidence_fingerprint,unresolved)
-         VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8,$9::jsonb) RETURNING id::text AS id,status`,
+          (request_id,seller_key,observation_id,order_coverage_run_id,order_coverage_evidence,cutoff_at,status,evidence_fingerprint,unresolved,limitations)
+         VALUES ($1,$2,$3,$4,$5::jsonb,$6,$7,$8,$9::jsonb,$10::jsonb) RETURNING id::text AS id,status`,
         [input.requestId,input.sellerKey,input.observationId,coverage?.id??null,asJson(coverage),
-          observation.cutoffAt,unresolved.length?"blocked":"previewed",fingerprint,asJson(unresolved)],db);
+          observation.cutoffAt,unresolved.length?"blocked":"previewed",fingerprint,asJson(unresolved),asJson(limitations)],db);
       if (!run) throw new Error("Failed to create opening preview.");
       await execute(
         `INSERT INTO inventory_opening_balance_items
@@ -243,36 +381,105 @@ export const inventoryOpeningBalancesRepository = {
            CASE WHEN skus.product_line_id IS NULL OR skus.set_id IS NULL OR skus.product_id IS NULL THEN NULL ELSE skus.product_id END
          FROM inventory_complete_observation_items item
          LEFT JOIN skus ON skus.sku=item.sku
-         WHERE item.observation_id=$2 AND item.quantity>0`,
+         WHERE item.observation_id=$2 AND item.sku IS NOT NULL AND item.quantity>0`,
         [run.id,input.observationId],db);
       return {
-        ...run, cutoffAt: observation.cutoffAt, evidenceFingerprint: fingerprint, unresolved,
-        skuCount: observation.skuCount, positiveSkuCount: observation.positiveSkuCount,
-        totalQuantity: observation.totalQuantity,
+        ...run, cutoffAt: observation.cutoffAt, evidenceFingerprint: fingerprint, unresolved,limitations,
+        itemCount:observation.itemCount,positiveItemCount:observation.positiveItemCount,
+        observedTotalQuantity:observation.observedTotalQuantity,
+        positiveSkuCount: observation.positiveSkuCount,totalQuantity: observation.totalQuantity,
+        unsupportedPositiveItemCount:observation.unsupportedPositiveItemCount,
+        unsupportedPositiveQuantity:observation.unsupportedPositiveQuantity,
       };
     });
   },
 
-  async apply(runId: string, expectedFingerprint: string, expectedSellerKey: string) {
+  async apply(input: {
+    runId: string; expectedFingerprint: string; sellerKey: string;
+    requestId: string; validationObservationId: string;
+  }) {
     return withTransaction(async (db) => {
       const run = await queryOne<any>(
         `SELECT id::text AS id,seller_key AS "sellerKey",cutoff_at AS "cutoffAt",status,
-          evidence_fingerprint AS "evidenceFingerprint",observation_id AS "observationId"
-         FROM inventory_opening_balance_runs WHERE id=$1 AND seller_key=$2 FOR UPDATE`,[runId,expectedSellerKey.trim()],db);
+          evidence_fingerprint AS "evidenceFingerprint",observation_id::text AS "observationId",
+          apply_request_id AS "applyRequestId"
+         FROM inventory_opening_balance_runs WHERE id=$1 AND seller_key=$2 FOR UPDATE`,[input.runId,input.sellerKey.trim()],db);
       if (!run) throw new Error("Opening balance preview was not found.");
       if (run.status === "applied") {
-        if (run.evidenceFingerprint !== expectedFingerprint) throw new Error("Opening balance evidence conflict.");
+        if (run.evidenceFingerprint !== input.expectedFingerprint || run.applyRequestId !== input.requestId.trim()) {
+          throw new Error("Opening balance application evidence conflicts.");
+        }
         return run;
       }
-      if (run.status !== "previewed" || run.evidenceFingerprint !== expectedFingerprint) throw new Error("Opening balance preview is blocked or stale.");
+      if (!input.requestId.trim() || run.status !== "previewed" || run.evidenceFingerprint !== input.expectedFingerprint) {
+        throw new Error("Opening balance preview is blocked or stale.");
+      }
       await db.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [`opening:${run.sellerKey}`]);
+      await db.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [`opening-observation:${run.sellerKey}`]);
+      const validation=await queryOne<any>(
+        `SELECT validation.id::text AS id,validation.seller_key AS "sellerKey",validation.status,
+          validation.started_at AS "startedAt",validation.cutoff_at AS "cutoffAt",
+          validation.quantity_fingerprint AS "quantityFingerprint",
+          validation.supported_quantity_fingerprint AS "supportedQuantityFingerprint",
+          validation.item_count AS "itemCount",validation.positive_item_count AS "positiveItemCount",
+          validation.total_quantity AS "observedTotalQuantity",
+          validation.supported_positive_sku_count AS "positiveSkuCount",
+          validation.supported_total_quantity AS "totalQuantity",
+          validation.unsupported_positive_item_count AS "unsupportedPositiveItemCount",
+          validation.unsupported_positive_quantity AS "unsupportedPositiveQuantity",
+          validation.cutoff_at >= NOW()-INTERVAL '5 minutes' AS "isFresh",
+          original.supported_quantity_fingerprint AS "originalSupportedQuantityFingerprint"
+         FROM inventory_complete_observations validation
+         JOIN inventory_complete_observations original ON original.id=$2
+         WHERE validation.id=$1`,[input.validationObservationId,run.observationId],db);
+      if(!validation || validation.sellerKey!==run.sellerKey || validation.status!=="complete" ||
+          validation.supportedQuantityFingerprint!==validation.originalSupportedQuantityFingerprint ||
+          validation.cutoffAt.getTime()<=run.cutoffAt.getTime() || !validation.isFresh) {
+        throw new Error("Current complete seller inventory does not match the opening preview.");
+      }
+      const validationItems=await observationItemsEvidence(validation.id,db);
+      if(validationItems.itemCount!==validation.itemCount ||
+          validationItems.positiveItemCount!==validation.positiveItemCount ||
+          validationItems.totalQuantity!==validation.observedTotalQuantity ||
+          validationItems.positiveSkuCount!==validation.positiveSkuCount ||
+          validationItems.supportedTotalQuantity!==validation.totalQuantity ||
+          validationItems.unsupportedPositiveItemCount!==validation.unsupportedPositiveItemCount ||
+          validationItems.unsupportedPositiveQuantity!==validation.unsupportedPositiveQuantity ||
+          validationItems.quantityFingerprint!==validation.quantityFingerprint ||
+          validationItems.supportedQuantityFingerprint!==validation.supportedQuantityFingerprint) {
+        throw new Error("Current inventory item evidence is unavailable or inconsistent.");
+      }
+      const latest=await queryOne<{id:string}>(`SELECT id::text AS id FROM inventory_complete_observations
+        WHERE seller_key=$1 ORDER BY cutoff_at DESC,id DESC LIMIT 1`,[run.sellerKey],db);
+      if(latest?.id!==validation.id) throw new Error("A newer seller inventory observation must be reconciled first.");
+      const validationDifferences=await queryOne<{count:number}>(`SELECT COUNT(*)::int AS count
+        FROM inventory_observation_differences
+        WHERE observation_id=$1 AND status='unresolved' AND sku IS NOT NULL`,[validation.id],db);
+      if((validationDifferences?.count??0)>0) throw new Error("Current seller inventory differences must be acknowledged before apply.");
+      const validationCoverage=await queryOne<any>(`SELECT id::text AS id,finished_at AS "finishedAt",
+          observed_from AS "observedFrom",observed_through AS "observedThrough",
+          orders_observed AS "ordersObserved",details_recorded AS "detailsRecorded"
+        FROM seller_order_sync_runs
+        WHERE seller_key=$1 AND source='tcgplayer_api' AND status='complete' AND finished_at >= $2
+        ORDER BY finished_at ASC LIMIT 1`,[run.sellerKey,validation.cutoffAt],db);
+      if(!validationCoverage) throw new Error("Complete seller order coverage after inventory revalidation is required.");
+      const validationIntervalOrders=await queryOne<{count:number}>(`SELECT COUNT(*)::int AS count FROM seller_orders
+        WHERE seller_key=$1 AND order_time >= $2 AND order_time < $3`,
+        [run.sellerKey,validation.startedAt,validation.cutoffAt],db);
+      const validationIntervalPublications=await queryOne<{count:number}>(`SELECT COUNT(*)::int AS count
+        FROM inventory_publication_receipt_links
+        WHERE target_seller_key=$1 AND live_at >= $2 AND live_at < $3`,
+        [run.sellerKey,validation.startedAt,validation.cutoffAt],db);
+      if((validationIntervalOrders?.count??0)>0 || (validationIntervalPublications?.count??0)>0) {
+        throw new Error("Seller inventory changed during apply revalidation.");
+      }
       const currentEvidence = await evidence(run.sellerKey, run.cutoffAt, run.observationId, db);
-      const coverage = await queryOne<{ id: string }>(`SELECT order_coverage_run_id::text AS id FROM inventory_opening_balance_runs WHERE id=$1`,[runId],db);
-      const observation = await queryOne<{ fp: string }>(`SELECT quantity_fingerprint AS fp FROM inventory_complete_observations WHERE id=$1`,[run.observationId],db);
+      const coverage = await queryOne<{ id: string }>(`SELECT order_coverage_run_id::text AS id FROM inventory_opening_balance_runs WHERE id=$1`,[input.runId],db);
+      const observation = await queryOne<{ fp: string }>(`SELECT supported_quantity_fingerprint AS fp FROM inventory_complete_observations WHERE id=$1`,[run.observationId],db);
       const recomputed = createHash("sha256").update(JSON.stringify({ observation: observation?.fp, orderCoverage: coverage?.id, sourceEvidence: currentEvidence })).digest("hex");
-      if (recomputed !== expectedFingerprint) throw new Error("Opening balance evidence changed; create a new preview.");
+      if (recomputed !== input.expectedFingerprint) throw new Error("Opening balance evidence changed; create a new preview.");
       const positive=await queryOne<{count:number}>(`SELECT COUNT(*)::int AS count FROM inventory_opening_balance_items
-        WHERE run_id=$1 AND opening_quantity>0`,[runId],db);
+        WHERE run_id=$1 AND opening_quantity>0`,[input.runId],db);
       const expectedCount=positive?.count??0;
       const mutations=await execute(`INSERT INTO inventory_pending_mutations
           (request_id,mutation_type,sku,requested_quantity,product_line_id,set_id,product_id,quantity_delta,resulting_quantity)
@@ -280,7 +487,7 @@ export const inventoryOpeningBalancesRepository = {
           item.product_line_id,item.set_id,item.product_id,item.opening_quantity,item.opening_quantity
         FROM inventory_opening_balance_items item
         WHERE item.run_id=$1::bigint AND item.opening_quantity>0
-          AND item.product_line_id IS NOT NULL AND item.set_id IS NOT NULL AND item.product_id IS NOT NULL`,[runId],db);
+          AND item.product_line_id IS NOT NULL AND item.set_id IS NOT NULL AND item.product_id IS NOT NULL`,[input.runId],db);
       if(mutations!==expectedCount) throw new Error("Opening balance catalog evidence is incomplete.");
       const receipts=await execute(`WITH inserted AS (INSERT INTO inventory_receipts
           (request_id,sku,original_quantity,product_line_id,set_id,product_id,seller_key,intake_at,
@@ -296,9 +503,11 @@ export const inventoryOpeningBalancesRepository = {
           RETURNING receipt_id,sku)
         UPDATE inventory_opening_balance_items item SET receipt_id=inserted.receipt_id
         FROM inserted WHERE item.run_id=$1::bigint AND item.sku=inserted.sku`,
-        [runId,run.sellerKey,run.observationId,run.cutoffAt],db);
+        [input.runId,run.sellerKey,run.observationId,run.cutoffAt],db);
       if(receipts!==expectedCount) throw new Error("Opening balance receipt conservation failed.");
-      await execute(`UPDATE inventory_opening_balance_runs SET status='applied',applied_at=NOW() WHERE id=$1`,[runId],db);
+      await execute(`UPDATE inventory_opening_balance_runs SET status='applied',apply_request_id=$2,
+        validation_observation_id=$3,validation_order_coverage_evidence=$4::jsonb,applied_at=NOW()
+        WHERE id=$1`,[input.runId,input.requestId.trim(),validation.id,asJson(validationCoverage)],db);
       return { ...run, status:"applied" };
     });
   },

--- a/app/core/db/repositories/inventoryOpeningBalances.server.ts
+++ b/app/core/db/repositories/inventoryOpeningBalances.server.ts
@@ -64,6 +64,30 @@ export const inventoryOpeningBalancesRepository = {
       ORDER BY id LIMIT $4`,[input.sellerKey.trim(),input.observationId,input.afterId??"0",limit]);
   },
 
+  async listApplicationDifferences(input: {
+    sellerKey:string;runId:string;validationObservationId:string;afterId?:string;limit?:number;
+  }) {
+    const limit=input.limit??100;
+    if(!Number.isInteger(limit)||limit<1||limit>200) throw new Error("Application difference page limit must be between 1 and 200.");
+    return query(`SELECT difference.id::text AS id,difference.observation_id::text AS "observationId",
+      difference.inventory_key AS "inventoryKey",difference.sku,
+      difference.previous_quantity AS "previousQuantity",difference.observed_quantity AS "observedQuantity",
+      difference.quantity_delta AS "quantityDelta",difference.status,
+      difference.acknowledgement_note AS "acknowledgementNote",
+      difference.acknowledged_at AS "acknowledgedAt"
+      FROM inventory_opening_balance_runs run
+      JOIN inventory_complete_observations validation
+        ON validation.id=$3 AND validation.seller_key=run.seller_key
+      JOIN inventory_complete_observations observation
+        ON observation.seller_key=run.seller_key
+        AND observation.cutoff_at>run.cutoff_at AND observation.cutoff_at<=validation.cutoff_at
+      JOIN inventory_observation_differences difference
+        ON difference.observation_id=observation.id AND difference.sku IS NOT NULL
+      WHERE run.id=$1 AND run.seller_key=$2 AND difference.id>$4::bigint
+      ORDER BY difference.id LIMIT $5`,
+      [input.runId,input.sellerKey.trim(),input.validationObservationId,input.afterId??"0",limit]);
+  },
+
   async listObservationItems(input: {
     sellerKey:string;observationId:string;afterInventoryKey?:string;limit?:number;unsupportedOnly?:boolean;
   }) {
@@ -253,7 +277,7 @@ export const inventoryOpeningBalancesRepository = {
             )
             AND NOT EXISTS (
               SELECT 1 FROM inventory_opening_balance_runs run
-              WHERE run.observation_id=old.id
+              WHERE run.observation_id=old.id OR run.validation_observation_id=old.id
             )
             AND old.id <> COALESCE((
               SELECT latest.id FROM inventory_complete_observations latest

--- a/app/core/db/repositories/pendingInventory.server.ts
+++ b/app/core/db/repositories/pendingInventory.server.ts
@@ -64,7 +64,8 @@ const pendingReceiptBalanceQuery = `WITH adjusted_receipts AS (
   JOIN pending_inventory pending ON pending.sku = receipt.sku
   LEFT JOIN inventory_receipt_adjustments adjustment
     ON adjustment.receipt_id = receipt.receipt_id
-  WHERE NOT EXISTS (
+  WHERE receipt.receipt_kind = 'received'
+    AND NOT EXISTS (
     SELECT 1 FROM inventory_receipt_batch_links linked
     WHERE linked.receipt_id = receipt.receipt_id
   )

--- a/app/core/db/repositories/pendingInventory.server.ts
+++ b/app/core/db/repositories/pendingInventory.server.ts
@@ -455,6 +455,7 @@ export const pendingInventoryRepository = {
       SET set_id = $1
       WHERE receipt.product_id = $2
         AND receipt.product_line_id = $3
+        AND receipt.receipt_kind = 'received'
         AND NOT EXISTS (
           SELECT 1 FROM inventory_receipt_batch_links link
           WHERE link.receipt_id = receipt.receipt_id

--- a/app/features/inventory-opening-balance/domain/inventoryObservation.test.ts
+++ b/app/features/inventory-opening-balance/domain/inventoryObservation.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { parseCompleteInventoryExport, quantityFingerprint, validateSellerPricingContext } from "./inventoryObservation";
+import { captureInventoryObservation } from "../services/captureInventoryObservation.server";
+
+const csv=(quantity:number,price="1.00")=>`TCGplayer Id,Product Line,Set Name,Product Name,Condition,Total Quantity,TCG Marketplace Price\n100,Game,Set,Card,Near Mint,${quantity},${price}`;
+validateSellerPricingContext(`{'sellerKey': 'seller-a'} sellerKey: 'seller-a'`,"seller-a");
+assert.throws(()=>validateSellerPricingContext(`{'sellerKey': 'seller-b'} sellerKey: 'seller-b'`,"seller-a"),/does not match/);
+assert.throws(()=>validateSellerPricingContext(`sellerKey: 'seller-a'`,"seller-a"),/declarations/);
+const one=parseCompleteInventoryExport(csv(2));
+assert.equal(one[0]?.quantity,2);
+assert.equal(quantityFingerprint(one),quantityFingerprint(parseCompleteInventoryExport(csv(2,"9.99"))));
+assert.throws(()=>parseCompleteInventoryExport(`${csv(2)}\n100,Game,Set,Card,Near Mint,2,1.00`),/repeats SKU/);
+assert.throws(()=>parseCompleteInventoryExport(csv(2_147_483_648)),/invalid SKU or quantity/);
+
+let recorded:any;
+const exports=[csv(2,"1.00"),csv(2,"1.25")];
+await captureInventoryObservation({requestId:"r1",sellerKey:"seller-a"},{
+  begin:async()=>({state:"claimed",claimToken:"00000000-0000-0000-0000-000000000001"}), fail:async()=>{},
+  getContext:async()=>`{'sellerKey': 'seller-a'} sellerKey: 'seller-a'`, exportInventory:async()=>exports.shift()!,
+  now:()=>new Date("2026-09-07T12:00:00Z"), record:async(input)=>{recorded=input;return input as any;},
+});
+assert.equal(recorded.status,"complete");
+assert.notEqual(recorded.firstContentFingerprint,recorded.secondContentFingerprint);
+let replayReads=0;
+const replay=await captureInventoryObservation({requestId:"r1",sellerKey:"seller-a"},{
+  begin:async()=>({state:"complete",observation:{id:"1",status:"complete"}} as const),
+  getContext:async()=>{replayReads++;return "";},exportInventory:async()=>{replayReads++;return "";},
+  now:()=>new Date(),record:async(value)=>value as any,fail:async()=>{},
+});
+assert.equal(replayReads,0);
+assert.equal(replay.id,"1");
+console.log("PASS complete inventory observations validate seller, rows, and stable quantity evidence");

--- a/app/features/inventory-opening-balance/domain/inventoryObservation.test.ts
+++ b/app/features/inventory-opening-balance/domain/inventoryObservation.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { parseCompleteInventoryExport, quantityFingerprint, validateSellerPricingContext } from "./inventoryObservation";
+import { parseCompleteInventoryExport, quantityFingerprint, supportedQuantityFingerprint, validateSellerPricingContext } from "./inventoryObservation";
 import { captureInventoryObservation } from "../services/captureInventoryObservation.server";
 
 const csv=(quantity:number,price="1.00")=>`TCGplayer Id,Product Line,Set Name,Product Name,Condition,Total Quantity,TCG Marketplace Price\n100,Game,Set,Card,Near Mint,${quantity},${price}`;
@@ -9,8 +9,14 @@ assert.throws(()=>validateSellerPricingContext(`sellerKey: 'seller-a'`,"seller-a
 const one=parseCompleteInventoryExport(csv(2));
 assert.equal(one[0]?.quantity,2);
 assert.equal(quantityFingerprint(one),quantityFingerprint(parseCompleteInventoryExport(csv(2,"9.99"))));
-assert.throws(()=>parseCompleteInventoryExport(`${csv(2)}\n100,Game,Set,Card,Near Mint,2,1.00`),/repeats SKU/);
+assert.throws(()=>parseCompleteInventoryExport(`${csv(2)}\n0100,Game,Set,Card,Near Mint,2,1.00`),/repeats identity/);
 assert.throws(()=>parseCompleteInventoryExport(csv(2_147_483_648)),/invalid SKU or quantity/);
+const withCustom=parseCompleteInventoryExport(`${csv(2)}\nC-3967723,Game,Set,Custom,Near Mint,1,4.00`);
+assert.deepEqual(withCustom.map(({inventoryKey,sku,identityKind})=>({inventoryKey,sku,identityKind})),[
+  {inventoryKey:"100",sku:100,identityKind:"standard_sku"},
+  {inventoryKey:"C-3967723",sku:null,identityKind:"unsupported"},
+]);
+assert.equal(supportedQuantityFingerprint(withCustom),supportedQuantityFingerprint(one));
 
 let recorded:any;
 const exports=[csv(2,"1.00"),csv(2,"1.25")];

--- a/app/features/inventory-opening-balance/domain/inventoryObservation.ts
+++ b/app/features/inventory-opening-balance/domain/inventoryObservation.ts
@@ -2,13 +2,15 @@ import { createHash } from "node:crypto";
 import Papa from "papaparse";
 
 export type InventoryObservationItem = {
-  sku: number; quantity: number; productLine: string; setName: string;
+  inventoryKey: string; identityKind: "standard_sku" | "unsupported"; sku: number | null;
+  quantity: number; productLine: string; setName: string;
   productName: string; condition: string; variant: string;
 };
 
 const MAX_BYTES = 8 * 1024 * 1024;
 const MAX_ROWS = 50_000;
 const MAX_DATABASE_INTEGER = 2_147_483_647;
+const compareInventoryKeys=(left:string,right:string)=>left<right?-1:left>right?1:0;
 
 export function validateSellerPricingContext(html: string, expectedSellerKey: string): number {
   const keys = [...html.matchAll(/(["']?sellerKey["']?)\s*[:=]\s*["']([^"']+)["']/gi)]
@@ -27,26 +29,31 @@ export function parseCompleteInventoryExport(csv: string): InventoryObservationI
   if (parsed.data.length > MAX_ROWS) throw new Error("Inventory export exceeds 50,000 rows.");
   const required = ["TCGplayer Id", "Total Quantity", "Product Line", "Set Name", "Product Name", "Condition"];
   for (const column of required) if (!parsed.meta.fields?.includes(column)) throw new Error(`Inventory export is missing ${column}.`);
-  const seen = new Set<number>();
+  const seen = new Set<string>();
+  const seenSkus = new Set<number>();
   const items = parsed.data.map((row, index) => {
-    const sku = Number(row["TCGplayer Id"]);
+    const inventoryKey=row["TCGplayer Id"]?.trim()??"";
+    const numericIdentity=/^\d+$/.test(inventoryKey);
+    const sku = numericIdentity ? Number(inventoryKey) : null;
     const quantityText = row["Total Quantity"]?.trim();
     const quantity = Number(quantityText);
-    if (!Number.isInteger(sku) || sku <= 0 || sku > MAX_DATABASE_INTEGER || !/^\d+$/.test(quantityText ?? "") ||
+    if (!/^[\x21-\x7e]{1,100}$/.test(inventoryKey) || (sku!==null && (!Number.isInteger(sku) || sku <= 0 || sku > MAX_DATABASE_INTEGER)) ||
+        !/^\d+$/.test(quantityText ?? "") ||
         !Number.isInteger(quantity) || quantity > MAX_DATABASE_INTEGER) {
       throw new Error(`Inventory export row ${index + 2} has an invalid SKU or quantity.`);
     }
-    if (seen.has(sku)) throw new Error(`Inventory export repeats SKU ${sku}.`);
-    seen.add(sku);
+    if (seen.has(inventoryKey) || (sku!==null && seenSkus.has(sku))) throw new Error(`Inventory export repeats identity ${inventoryKey}.`);
+    seen.add(inventoryKey);
+    if(sku!==null) seenSkus.add(sku);
     return {
-      sku, quantity,
+      inventoryKey,identityKind:sku===null?"unsupported" as const:"standard_sku" as const,sku,quantity,
       productLine: row["Product Line"]?.trim() ?? "",
       setName: row["Set Name"]?.trim() ?? "",
       productName: row["Product Name"]?.trim() ?? "",
       condition: row.Condition?.trim() ?? "",
       variant: row["Printing"]?.trim() ?? row["Sku Variant"]?.trim() ?? "",
     };
-  }).sort((a, b) => a.sku - b.sku);
+  }).sort((a, b) => compareInventoryKeys(a.inventoryKey,b.inventoryKey));
   const totalQuantity = items.reduce((total, item) => total + item.quantity, 0);
   if (!Number.isSafeInteger(totalQuantity) || totalQuantity > MAX_DATABASE_INTEGER) {
     throw new Error("Inventory export total quantity exceeds the supported range.");
@@ -55,7 +62,16 @@ export function parseCompleteInventoryExport(csv: string): InventoryObservationI
 }
 
 export function quantityFingerprint(items: InventoryObservationItem[]): string {
-  return createHash("sha256").update(JSON.stringify(items.map(({ sku, quantity }) => [sku, quantity]))).digest("hex");
+  return createHash("sha256").update(JSON.stringify([...items]
+    .sort((a,b)=>compareInventoryKeys(a.inventoryKey,b.inventoryKey))
+    .map(({ inventoryKey, quantity }) => [inventoryKey, quantity]))).digest("hex");
+}
+
+export function supportedQuantityFingerprint(items: InventoryObservationItem[]): string {
+  return createHash("sha256").update(JSON.stringify(items
+    .filter((item)=>item.sku!==null)
+    .sort((a,b)=>(a.sku??0)-(b.sku??0))
+    .map(({sku,quantity})=>[sku,quantity]))).digest("hex");
 }
 
 export function contentFingerprint(content: string): string {

--- a/app/features/inventory-opening-balance/domain/inventoryObservation.ts
+++ b/app/features/inventory-opening-balance/domain/inventoryObservation.ts
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+import Papa from "papaparse";
+
+export type InventoryObservationItem = {
+  sku: number; quantity: number; productLine: string; setName: string;
+  productName: string; condition: string; variant: string;
+};
+
+const MAX_BYTES = 8 * 1024 * 1024;
+const MAX_ROWS = 50_000;
+const MAX_DATABASE_INTEGER = 2_147_483_647;
+
+export function validateSellerPricingContext(html: string, expectedSellerKey: string): number {
+  const keys = [...html.matchAll(/(["']?sellerKey["']?)\s*[:=]\s*["']([^"']+)["']/gi)]
+    .map((match) => match[2]?.trim()).filter((value): value is string => Boolean(value));
+  if (keys.length < 2) throw new Error("Seller Portal context did not contain the verified seller identity declarations.");
+  if (keys.some((key) => key !== expectedSellerKey.trim())) {
+    throw new Error("Seller Portal context does not match the expected seller key.");
+  }
+  return keys.length;
+}
+
+export function parseCompleteInventoryExport(csv: string): InventoryObservationItem[] {
+  if (Buffer.byteLength(csv, "utf8") > MAX_BYTES) throw new Error("Inventory export exceeds 8 MB.");
+  const parsed = Papa.parse<Record<string, string>>(csv, { header: true, skipEmptyLines: "greedy" });
+  if (parsed.errors.length) throw new Error(`Inventory export is malformed: ${parsed.errors[0]?.message}`);
+  if (parsed.data.length > MAX_ROWS) throw new Error("Inventory export exceeds 50,000 rows.");
+  const required = ["TCGplayer Id", "Total Quantity", "Product Line", "Set Name", "Product Name", "Condition"];
+  for (const column of required) if (!parsed.meta.fields?.includes(column)) throw new Error(`Inventory export is missing ${column}.`);
+  const seen = new Set<number>();
+  const items = parsed.data.map((row, index) => {
+    const sku = Number(row["TCGplayer Id"]);
+    const quantityText = row["Total Quantity"]?.trim();
+    const quantity = Number(quantityText);
+    if (!Number.isInteger(sku) || sku <= 0 || sku > MAX_DATABASE_INTEGER || !/^\d+$/.test(quantityText ?? "") ||
+        !Number.isInteger(quantity) || quantity > MAX_DATABASE_INTEGER) {
+      throw new Error(`Inventory export row ${index + 2} has an invalid SKU or quantity.`);
+    }
+    if (seen.has(sku)) throw new Error(`Inventory export repeats SKU ${sku}.`);
+    seen.add(sku);
+    return {
+      sku, quantity,
+      productLine: row["Product Line"]?.trim() ?? "",
+      setName: row["Set Name"]?.trim() ?? "",
+      productName: row["Product Name"]?.trim() ?? "",
+      condition: row.Condition?.trim() ?? "",
+      variant: row["Printing"]?.trim() ?? row["Sku Variant"]?.trim() ?? "",
+    };
+  }).sort((a, b) => a.sku - b.sku);
+  const totalQuantity = items.reduce((total, item) => total + item.quantity, 0);
+  if (!Number.isSafeInteger(totalQuantity) || totalQuantity > MAX_DATABASE_INTEGER) {
+    throw new Error("Inventory export total quantity exceeds the supported range.");
+  }
+  return items;
+}
+
+export function quantityFingerprint(items: InventoryObservationItem[]): string {
+  return createHash("sha256").update(JSON.stringify(items.map(({ sku, quantity }) => [sku, quantity]))).digest("hex");
+}
+
+export function contentFingerprint(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}

--- a/app/features/inventory-opening-balance/routes/api.inventory-opening-balance.server.ts
+++ b/app/features/inventory-opening-balance/routes/api.inventory-opening-balance.server.ts
@@ -1,0 +1,41 @@
+import { data } from "react-router";
+import { inventoryOpeningBalancesRepository } from "~/core/db";
+import { getShippingExportConfig } from "~/features/shipping-export/config/shippingExportConfig.server";
+import { captureInventoryObservation } from "../services/captureInventoryObservation.server";
+
+export function createInventoryOpeningBalanceAction(dependencies = {
+  capture: captureInventoryObservation,
+  preview: inventoryOpeningBalancesRepository.preview,
+  apply: inventoryOpeningBalancesRepository.apply,
+  acknowledgeDifference: inventoryOpeningBalancesRepository.acknowledgeDifference,
+  getConfig: getShippingExportConfig,
+}) {
+  return async ({ request }: { request: Request }) => {
+    if (request.method !== "POST") return data({ error: "Method not allowed" }, { status: 405 });
+    try {
+      const payload = await request.json() as Record<string, unknown>;
+      const configured = (await dependencies.getConfig()).defaultSellerKey.trim();
+      const sellerKey = typeof payload.sellerKey === "string" ? payload.sellerKey.trim() : configured;
+      if (!sellerKey || sellerKey !== configured) return data({ error: "Seller key must match the configured seller." }, { status: 400 });
+      if (payload.action === "capture") {
+        if (typeof payload.requestId !== "string") return data({ error: "Request ID is required." }, { status: 400 });
+        return data({ observation: await dependencies.capture({ requestId: payload.requestId, sellerKey }) });
+      }
+      if (payload.action === "preview") {
+        if (typeof payload.requestId !== "string" || typeof payload.observationId !== "string") return data({ error: "Request and observation IDs are required." }, { status: 400 });
+        return data({ preview: await dependencies.preview({ requestId: payload.requestId, sellerKey, observationId: payload.observationId }) });
+      }
+      if (payload.action === "apply") {
+        if (typeof payload.runId !== "string" || typeof payload.evidenceFingerprint !== "string") return data({ error: "Run ID and evidence fingerprint are required." }, { status: 400 });
+        return data({ result: await dependencies.apply(payload.runId, payload.evidenceFingerprint, sellerKey) });
+      }
+      if (payload.action === "acknowledge_difference") {
+        if (typeof payload.requestId !== "string" || typeof payload.differenceId !== "string" || typeof payload.note !== "string") return data({ error: "Request ID, difference ID, and acknowledgement note are required." }, { status: 400 });
+        return data({ result: await dependencies.acknowledgeDifference({requestId:payload.requestId,id:payload.differenceId,sellerKey,note:payload.note}) });
+      }
+      return data({ error: "Unknown opening balance action." }, { status: 400 });
+    } catch (error) {
+      return data({ error: String(error) }, { status: 409 });
+    }
+  };
+}

--- a/app/features/inventory-opening-balance/routes/api.inventory-opening-balance.server.ts
+++ b/app/features/inventory-opening-balance/routes/api.inventory-opening-balance.server.ts
@@ -10,6 +10,7 @@ export function createInventoryOpeningBalanceAction(dependencies = {
   apply: applyInventoryOpeningBalance,
   acknowledgeDifference: inventoryOpeningBalancesRepository.acknowledgeDifference,
   listDifferences: inventoryOpeningBalancesRepository.listDifferences,
+  listApplicationDifferences: inventoryOpeningBalancesRepository.listApplicationDifferences,
   listObservationItems: inventoryOpeningBalancesRepository.listObservationItems,
   listPreviewItems: inventoryOpeningBalancesRepository.listPreviewItems,
   getConfig: getShippingExportConfig,
@@ -40,6 +41,13 @@ export function createInventoryOpeningBalanceAction(dependencies = {
       if (payload.action === "list_differences") {
         if (typeof payload.observationId !== "string") return data({ error: "Observation ID is required." }, { status: 400 });
         return data({ differences: await dependencies.listDifferences({sellerKey,observationId:payload.observationId,
+          ...(typeof payload.afterId==="string"?{afterId:payload.afterId}:{}),
+          ...(typeof payload.limit==="number"?{limit:payload.limit}:{})}) });
+      }
+      if (payload.action === "list_application_differences") {
+        if (typeof payload.runId !== "string" || typeof payload.validationObservationId !== "string") return data({ error: "Run and validation observation IDs are required." }, { status: 400 });
+        return data({ differences: await dependencies.listApplicationDifferences({sellerKey,runId:payload.runId,
+          validationObservationId:payload.validationObservationId,
           ...(typeof payload.afterId==="string"?{afterId:payload.afterId}:{}),
           ...(typeof payload.limit==="number"?{limit:payload.limit}:{})}) });
       }

--- a/app/features/inventory-opening-balance/routes/api.inventory-opening-balance.server.ts
+++ b/app/features/inventory-opening-balance/routes/api.inventory-opening-balance.server.ts
@@ -2,12 +2,16 @@ import { data } from "react-router";
 import { inventoryOpeningBalancesRepository } from "~/core/db";
 import { getShippingExportConfig } from "~/features/shipping-export/config/shippingExportConfig.server";
 import { captureInventoryObservation } from "../services/captureInventoryObservation.server";
+import { applyInventoryOpeningBalance } from "../services/applyInventoryOpeningBalance.server";
 
 export function createInventoryOpeningBalanceAction(dependencies = {
   capture: captureInventoryObservation,
   preview: inventoryOpeningBalancesRepository.preview,
-  apply: inventoryOpeningBalancesRepository.apply,
+  apply: applyInventoryOpeningBalance,
   acknowledgeDifference: inventoryOpeningBalancesRepository.acknowledgeDifference,
+  listDifferences: inventoryOpeningBalancesRepository.listDifferences,
+  listObservationItems: inventoryOpeningBalancesRepository.listObservationItems,
+  listPreviewItems: inventoryOpeningBalancesRepository.listPreviewItems,
   getConfig: getShippingExportConfig,
 }) {
   return async ({ request }: { request: Request }) => {
@@ -26,12 +30,31 @@ export function createInventoryOpeningBalanceAction(dependencies = {
         return data({ preview: await dependencies.preview({ requestId: payload.requestId, sellerKey, observationId: payload.observationId }) });
       }
       if (payload.action === "apply") {
-        if (typeof payload.runId !== "string" || typeof payload.evidenceFingerprint !== "string") return data({ error: "Run ID and evidence fingerprint are required." }, { status: 400 });
-        return data({ result: await dependencies.apply(payload.runId, payload.evidenceFingerprint, sellerKey) });
+        if (typeof payload.requestId !== "string" || typeof payload.runId !== "string" || typeof payload.evidenceFingerprint !== "string") return data({ error: "Request ID, run ID, and evidence fingerprint are required." }, { status: 400 });
+        return data({ result: await dependencies.apply({requestId:payload.requestId,runId:payload.runId,evidenceFingerprint:payload.evidenceFingerprint,sellerKey}) });
       }
       if (payload.action === "acknowledge_difference") {
         if (typeof payload.requestId !== "string" || typeof payload.differenceId !== "string" || typeof payload.note !== "string") return data({ error: "Request ID, difference ID, and acknowledgement note are required." }, { status: 400 });
         return data({ result: await dependencies.acknowledgeDifference({requestId:payload.requestId,id:payload.differenceId,sellerKey,note:payload.note}) });
+      }
+      if (payload.action === "list_differences") {
+        if (typeof payload.observationId !== "string") return data({ error: "Observation ID is required." }, { status: 400 });
+        return data({ differences: await dependencies.listDifferences({sellerKey,observationId:payload.observationId,
+          ...(typeof payload.afterId==="string"?{afterId:payload.afterId}:{}),
+          ...(typeof payload.limit==="number"?{limit:payload.limit}:{})}) });
+      }
+      if (payload.action === "list_observation_items") {
+        if (typeof payload.observationId !== "string") return data({ error: "Observation ID is required." }, { status: 400 });
+        return data({ items: await dependencies.listObservationItems({sellerKey,observationId:payload.observationId,
+          ...(typeof payload.afterInventoryKey==="string"?{afterInventoryKey:payload.afterInventoryKey}:{}),
+          ...(typeof payload.limit==="number"?{limit:payload.limit}:{}),
+          ...(typeof payload.unsupportedOnly==="boolean"?{unsupportedOnly:payload.unsupportedOnly}:{})}) });
+      }
+      if (payload.action === "list_preview_items") {
+        if (typeof payload.runId !== "string") return data({ error: "Run ID is required." }, { status: 400 });
+        return data({ items: await dependencies.listPreviewItems({sellerKey,runId:payload.runId,
+          ...(typeof payload.afterSku==="number"?{afterSku:payload.afterSku}:{}),
+          ...(typeof payload.limit==="number"?{limit:payload.limit}:{})}) });
       }
       return data({ error: "Unknown opening balance action." }, { status: 400 });
     } catch (error) {

--- a/app/features/inventory-opening-balance/routes/api.inventory-opening-balance.ts
+++ b/app/features/inventory-opening-balance/routes/api.inventory-opening-balance.ts
@@ -1,0 +1,2 @@
+import { createInventoryOpeningBalanceAction } from "./api.inventory-opening-balance.server";
+export const action = createInventoryOpeningBalanceAction();

--- a/app/features/inventory-opening-balance/services/applyInventoryOpeningBalance.server.ts
+++ b/app/features/inventory-opening-balance/services/applyInventoryOpeningBalance.server.ts
@@ -1,0 +1,54 @@
+import { randomUUID } from "node:crypto";
+import { inventoryOpeningBalancesRepository } from "~/core/db";
+import { synchronizeSellerOrders } from "~/features/seller-order-history/services/synchronizeSellerOrders.server";
+import { captureInventoryObservation } from "./captureInventoryObservation.server";
+
+type Dependencies = {
+  capture: typeof captureInventoryObservation;
+  findReplay: typeof inventoryOpeningBalancesRepository.findApplicationReplay;
+  synchronizeOrders: typeof synchronizeSellerOrders;
+  apply: typeof inventoryOpeningBalancesRepository.apply;
+};
+
+export async function applyInventoryOpeningBalance(
+  input: { requestId: string; runId: string; evidenceFingerprint: string; sellerKey: string },
+  overrides: Partial<Dependencies> = {},
+) {
+  const dependencies: Dependencies = {
+    capture: captureInventoryObservation,
+    findReplay: (value) => inventoryOpeningBalancesRepository.findApplicationReplay(value),
+    synchronizeOrders: synchronizeSellerOrders,
+    apply: (value) => inventoryOpeningBalancesRepository.apply(value),
+    ...overrides,
+  };
+  const requestId=input.requestId.trim();
+  if(!requestId) throw new Error("Application request ID is required.");
+  const replay=await dependencies.findReplay({
+    runId:input.runId,sellerKey:input.sellerKey,requestId,
+    expectedFingerprint:input.evidenceFingerprint,
+  });
+  if(replay) return replay;
+  const observation=await dependencies.capture({
+    requestId:`${requestId}:inventory-revalidation:${randomUUID()}`,
+    sellerKey:input.sellerKey,
+    purposeEvidence:{
+      kind:"opening_apply",applicationRequestId:requestId,runId:input.runId,
+      evidenceFingerprint:input.evidenceFingerprint,
+    },
+  });
+  if(observation.status!=="complete") {
+    throw new Error("Current seller inventory could not be observed consistently.");
+  }
+  await dependencies.synchronizeOrders(input.sellerKey,{maxPages:4,maxDetails:25,pageSize:500,detailConcurrency:5});
+  try {
+    return await dependencies.apply({
+      runId:input.runId,
+      expectedFingerprint:input.evidenceFingerprint,
+      sellerKey:input.sellerKey,
+      requestId,
+      validationObservationId:observation.id,
+    });
+  } catch(error) {
+    throw new Error(`${String(error)} Current inventory evidence is observation ${observation.id}.`);
+  }
+}

--- a/app/features/inventory-opening-balance/services/applyInventoryOpeningBalance.test.ts
+++ b/app/features/inventory-opening-balance/services/applyInventoryOpeningBalance.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { applyInventoryOpeningBalance } from "./applyInventoryOpeningBalance.server";
+
+let reads=0;
+const replay=await applyInventoryOpeningBalance({
+  requestId:"apply-a",runId:"1",evidenceFingerprint:"fp-a",sellerKey:"seller-a",
+},{
+  findReplay:async()=>({id:"1",status:"applied"}),
+  capture:async()=>{reads++;throw new Error("unexpected capture");},
+  synchronizeOrders:async()=>{reads++;throw new Error("unexpected sync");},
+  apply:async()=>{reads++;throw new Error("unexpected apply");},
+} as any);
+assert.equal(replay.status,"applied");
+assert.equal(reads,0);
+
+const captureRequestIds:string[]=[];
+const attempt=()=>applyInventoryOpeningBalance({
+  requestId:"apply-b",runId:"2",evidenceFingerprint:"fp-b",sellerKey:"seller-a",
+},{
+  findReplay:async()=>null,
+  capture:async(input:{requestId:string})=>{
+    captureRequestIds.push(input.requestId);
+    return {id:String(captureRequestIds.length+10),status:"complete"};
+  },
+  synchronizeOrders:async()=>({coverage:{status:"complete"},changedOrderNumbers:[]}),
+  apply:async()=>{throw new Error("coverage has not advanced");},
+} as any);
+await assert.rejects(attempt,/observation 11/);
+await assert.rejects(attempt,/observation 12/);
+assert.equal(new Set(captureRequestIds).size,2);
+assert.ok(captureRequestIds.every((value)=>value.startsWith("apply-b:inventory-revalidation:")));
+
+console.log("PASS opening apply replays local success and refreshes source proof after an uncommitted attempt");

--- a/app/features/inventory-opening-balance/services/captureInventoryObservation.server.ts
+++ b/app/features/inventory-opening-balance/services/captureInventoryObservation.server.ts
@@ -7,6 +7,7 @@ import {
   contentFingerprint,
   parseCompleteInventoryExport,
   quantityFingerprint,
+  supportedQuantityFingerprint,
 } from "../domain/inventoryObservation";
 import { validateSellerPricingContext } from "../domain/inventoryObservation";
 
@@ -20,7 +21,7 @@ type Dependencies = {
 };
 
 export async function captureInventoryObservation(
-  input: { requestId: string; sellerKey: string },
+  input: { requestId: string; sellerKey: string; purposeEvidence?: Record<string,unknown> },
   overrides: Partial<Dependencies> = {},
 ) {
   const dependencies: Dependencies = {
@@ -35,7 +36,7 @@ export async function captureInventoryObservation(
   const sellerKey = input.sellerKey.trim();
   if (!input.requestId.trim() || !sellerKey) throw new Error("Request ID and seller key are required.");
   const requestId=input.requestId.trim();
-  const claim=await dependencies.begin({requestId,sellerKey});
+  const claim=await dependencies.begin({requestId,sellerKey,...(input.purposeEvidence?{purposeEvidence:input.purposeEvidence}:{})});
   if (claim.state === "complete") return claim.observation;
   const abortController=new AbortController();
   const deadline=setTimeout(()=>abortController.abort(),150_000);
@@ -58,6 +59,7 @@ export async function captureInventoryObservation(
       status: stable ? "complete" : "unstable",
       startedAt, cutoffAt: dependencies.now(),
       quantityFingerprint: secondQuantityFingerprint,
+      supportedQuantityFingerprint:supportedQuantityFingerprint(secondItems),
       firstContentFingerprint: contentFingerprint(firstCsv),
       secondContentFingerprint: contentFingerprint(secondCsv),
       items: secondItems,

--- a/app/features/inventory-opening-balance/services/captureInventoryObservation.server.ts
+++ b/app/features/inventory-opening-balance/services/captureInventoryObservation.server.ts
@@ -1,0 +1,72 @@
+import { inventoryOpeningBalancesRepository } from "~/core/db";
+import {
+  exportLiveSellerInventory,
+  getSellerPricingContext,
+} from "~/integrations/tcgplayer/client/export-live-inventory.server";
+import {
+  contentFingerprint,
+  parseCompleteInventoryExport,
+  quantityFingerprint,
+} from "../domain/inventoryObservation";
+import { validateSellerPricingContext } from "../domain/inventoryObservation";
+
+type Dependencies = {
+  begin: typeof inventoryOpeningBalancesRepository.beginObservationCapture;
+  getContext: typeof getSellerPricingContext;
+  exportInventory: typeof exportLiveSellerInventory;
+  now: () => Date;
+  record: typeof inventoryOpeningBalancesRepository.recordObservation;
+  fail: typeof inventoryOpeningBalancesRepository.failObservationCapture;
+};
+
+export async function captureInventoryObservation(
+  input: { requestId: string; sellerKey: string },
+  overrides: Partial<Dependencies> = {},
+) {
+  const dependencies: Dependencies = {
+    begin: (value) => inventoryOpeningBalancesRepository.beginObservationCapture(value),
+    getContext: getSellerPricingContext,
+    exportInventory: exportLiveSellerInventory,
+    now: () => new Date(),
+    record: (value) => inventoryOpeningBalancesRepository.recordObservation(value),
+    fail: (requestId,claimToken,error) => inventoryOpeningBalancesRepository.failObservationCapture(requestId,claimToken,error),
+    ...overrides,
+  };
+  const sellerKey = input.sellerKey.trim();
+  if (!input.requestId.trim() || !sellerKey) throw new Error("Request ID and seller key are required.");
+  const requestId=input.requestId.trim();
+  const claim=await dependencies.begin({requestId,sellerKey});
+  if (claim.state === "complete") return claim.observation;
+  const abortController=new AbortController();
+  const deadline=setTimeout(()=>abortController.abort(),150_000);
+  try {
+    const startedAt = dependencies.now();
+    const beforeContext = await dependencies.getContext({signal:abortController.signal});
+    const beforeIdentityDeclarationCount=validateSellerPricingContext(beforeContext, sellerKey);
+    const firstCsv = await dependencies.exportInventory({signal:abortController.signal});
+    const firstItems = parseCompleteInventoryExport(firstCsv);
+    const secondCsv = await dependencies.exportInventory({signal:abortController.signal});
+    const secondItems = parseCompleteInventoryExport(secondCsv);
+    const afterContext = await dependencies.getContext({signal:abortController.signal});
+    const afterIdentityDeclarationCount=validateSellerPricingContext(afterContext, sellerKey);
+    const firstQuantityFingerprint = quantityFingerprint(firstItems);
+    const secondQuantityFingerprint = quantityFingerprint(secondItems);
+    const stable = firstQuantityFingerprint === secondQuantityFingerprint;
+    return await dependencies.record({
+      requestId, sellerKey, claimToken: claim.claimToken,
+      beforeIdentityDeclarationCount, afterIdentityDeclarationCount,
+      status: stable ? "complete" : "unstable",
+      startedAt, cutoffAt: dependencies.now(),
+      quantityFingerprint: secondQuantityFingerprint,
+      firstContentFingerprint: contentFingerprint(firstCsv),
+      secondContentFingerprint: contentFingerprint(secondCsv),
+      items: secondItems,
+      ...(!stable ? { error: "Seller quantities changed between complete exports." } : {}),
+    });
+  } catch (error) {
+    await dependencies.fail(requestId,claim.claimToken,String(error));
+    throw error;
+  } finally {
+    clearTimeout(deadline);
+  }
+}

--- a/app/integrations/tcgplayer/client/export-live-inventory.server.ts
+++ b/app/integrations/tcgplayer/client/export-live-inventory.server.ts
@@ -1,0 +1,15 @@
+import { sellerPortal } from "~/core/clients";
+
+export function getSellerPricingContext(options?: { signal?: AbortSignal }) {
+  return sellerPortal.get<string>("/admin/pricing", undefined, {
+    responseType: "text", retry: false, signal: options?.signal, timeout: 30_000,
+  });
+}
+
+export function exportLiveSellerInventory(options?: { signal?: AbortSignal }) {
+  return sellerPortal.get<string>(
+    "/Admin/Pricing/DownloadMyExportCSV?type=Pricing",
+    undefined,
+    { responseType: "text", retry: false, signal: options?.signal, timeout: 30_000 },
+  );
+}

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,6 +1,7 @@
 import { type RouteConfig, index } from "@react-router/dev/routes";
 
 export default [
+  { path: "/api/inventory-opening-balance", file: "features/inventory-opening-balance/routes/api.inventory-opening-balance.ts" },
   {
     path: "/api/seller-order-history",
     file: "features/seller-order-history/routes/api.seller-order-history.ts",

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -2,6 +2,7 @@ import "../core/clients/baseDomainClient.server.test";
 import "../integrations/tcgplayer/client/get-price-points.server.test";
 import "../features/inventory-history/domain/receiptBalances.test";
 import "../features/inventory-opening-balance/domain/inventoryObservation.test";
+import "../features/inventory-opening-balance/services/applyInventoryOpeningBalance.test";
 import "../features/seller-order-history/domain/sellerOrderObservation.test";
 import "../features/seller-order-history/services/sellerOrderFileImport.test";
 import "../features/seller-order-history/services/synchronizeSellerOrders.test";

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -1,6 +1,7 @@
 import "../core/clients/baseDomainClient.server.test";
 import "../integrations/tcgplayer/client/get-price-points.server.test";
 import "../features/inventory-history/domain/receiptBalances.test";
+import "../features/inventory-opening-balance/domain/inventoryObservation.test";
 import "../features/seller-order-history/domain/sellerOrderObservation.test";
 import "../features/seller-order-history/services/sellerOrderFileImport.test";
 import "../features/seller-order-history/services/synchronizeSellerOrders.test";

--- a/db/migrations/038_add_inventory_opening_balances.sql
+++ b/db/migrations/038_add_inventory_opening_balances.sql
@@ -1,0 +1,144 @@
+CREATE TABLE inventory_complete_observations (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  request_id TEXT NOT NULL UNIQUE,
+  seller_key TEXT NOT NULL CHECK (length(trim(seller_key)) > 0),
+  source TEXT NOT NULL CHECK (source = 'seller_portal_live_export'),
+  status TEXT NOT NULL CHECK (status IN ('complete', 'unstable', 'invalid')),
+  quantity_semantics TEXT NOT NULL CHECK (quantity_semantics = 'sellable_excludes_reserved'),
+  started_at TIMESTAMPTZ NOT NULL,
+  cutoff_at TIMESTAMPTZ NOT NULL,
+  quantity_fingerprint TEXT NOT NULL,
+  first_content_fingerprint TEXT NOT NULL,
+  second_content_fingerprint TEXT NOT NULL,
+  sku_count INTEGER NOT NULL CHECK (sku_count >= 0),
+  positive_sku_count INTEGER NOT NULL CHECK (positive_sku_count >= 0),
+  total_quantity INTEGER NOT NULL CHECK (total_quantity >= 0),
+  identity_evidence JSONB NOT NULL,
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX inventory_complete_observations_seller_cutoff_idx
+  ON inventory_complete_observations (seller_key, cutoff_at DESC, id DESC)
+  WHERE status = 'complete';
+
+CREATE TABLE inventory_complete_observation_items (
+  observation_id BIGINT NOT NULL REFERENCES inventory_complete_observations(id) ON DELETE RESTRICT,
+  sku INTEGER NOT NULL CHECK (sku > 0),
+  quantity INTEGER NOT NULL CHECK (quantity >= 0),
+  PRIMARY KEY (observation_id, sku)
+);
+
+CREATE TABLE inventory_complete_observation_requests (
+  request_id TEXT PRIMARY KEY,
+  seller_key TEXT NOT NULL CHECK (length(trim(seller_key)) > 0),
+  status TEXT NOT NULL CHECK (status IN ('capturing', 'complete', 'failed')),
+  claim_token TEXT,
+  claim_expires_at TIMESTAMPTZ,
+  observation_id BIGINT REFERENCES inventory_complete_observations(id) ON DELETE RESTRICT,
+  error TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CHECK (
+    (status = 'capturing' AND claim_token IS NOT NULL AND claim_expires_at IS NOT NULL AND observation_id IS NULL)
+    OR (status = 'complete' AND claim_token IS NULL AND claim_expires_at IS NULL AND observation_id IS NOT NULL)
+    OR (status = 'failed' AND claim_token IS NULL AND claim_expires_at IS NULL AND observation_id IS NULL)
+  )
+);
+
+CREATE TABLE inventory_observation_differences (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  seller_key TEXT NOT NULL,
+  previous_observation_id BIGINT NOT NULL REFERENCES inventory_complete_observations(id) ON DELETE RESTRICT,
+  observation_id BIGINT NOT NULL REFERENCES inventory_complete_observations(id) ON DELETE RESTRICT,
+  sku INTEGER NOT NULL,
+  quantity_delta INTEGER NOT NULL CHECK (quantity_delta <> 0),
+  previous_quantity INTEGER NOT NULL CHECK (previous_quantity >= 0),
+  observed_quantity INTEGER NOT NULL CHECK (observed_quantity >= 0),
+  status TEXT NOT NULL DEFAULT 'unresolved' CHECK (status IN ('unresolved','acknowledged')),
+  acknowledgement_request_id TEXT UNIQUE,
+  acknowledgement_note TEXT,
+  acknowledged_at TIMESTAMPTZ,
+  UNIQUE (previous_observation_id, observation_id, sku)
+);
+
+CREATE INDEX inventory_observation_differences_unresolved_idx
+  ON inventory_observation_differences (observation_id, id) WHERE status = 'unresolved';
+
+CREATE TABLE inventory_opening_balance_runs (
+  id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  request_id TEXT NOT NULL UNIQUE,
+  seller_key TEXT NOT NULL CHECK (length(trim(seller_key)) > 0),
+  observation_id BIGINT NOT NULL REFERENCES inventory_complete_observations(id) ON DELETE RESTRICT,
+  -- Coverage runs are retention-bounded; this is copied evidence, not a live FK.
+  order_coverage_run_id BIGINT,
+  order_coverage_evidence JSONB,
+  cutoff_at TIMESTAMPTZ NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('previewed', 'blocked', 'applied')),
+  evidence_fingerprint TEXT NOT NULL,
+  unresolved JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  applied_at TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX inventory_opening_balance_one_applied_seller_idx
+  ON inventory_opening_balance_runs (seller_key) WHERE status = 'applied';
+
+CREATE TABLE inventory_opening_balance_items (
+  run_id BIGINT NOT NULL REFERENCES inventory_opening_balance_runs(id) ON DELETE RESTRICT,
+  sku INTEGER NOT NULL,
+  opening_quantity INTEGER NOT NULL CHECK (opening_quantity >= 0),
+  product_line_id INTEGER,
+  set_id INTEGER,
+  product_id INTEGER,
+  receipt_id INTEGER,
+  CHECK (
+    (product_line_id IS NULL AND set_id IS NULL AND product_id IS NULL)
+    OR (product_line_id IS NOT NULL AND set_id IS NOT NULL AND product_id IS NOT NULL)
+  ),
+  PRIMARY KEY (run_id, sku)
+);
+
+ALTER TABLE inventory_pending_mutations
+  DROP CONSTRAINT inventory_pending_mutations_mutation_type_check,
+  ADD CONSTRAINT inventory_pending_mutations_mutation_type_check
+    CHECK (mutation_type IN ('add', 'remove', 'set', 'clear', 'opening'));
+
+ALTER TABLE inventory_receipts
+  ADD COLUMN receipt_kind TEXT NOT NULL DEFAULT 'received'
+    CHECK (receipt_kind IN ('received', 'opening_balance')),
+  ADD COLUMN opening_balance_run_id BIGINT
+    REFERENCES inventory_opening_balance_runs(id) ON DELETE RESTRICT,
+  ADD COLUMN fifo_precedence SMALLINT NOT NULL DEFAULT 1 CHECK (fifo_precedence IN (0, 1)),
+  ADD CONSTRAINT inventory_receipts_opening_kind_check CHECK (
+    (receipt_kind = 'opening_balance' AND opening_balance_run_id IS NOT NULL AND fifo_precedence = 0)
+    OR (receipt_kind = 'received' AND opening_balance_run_id IS NULL AND fifo_precedence = 1)
+  ),
+  ADD CONSTRAINT inventory_receipts_opening_sku_unique UNIQUE (opening_balance_run_id, sku);
+
+ALTER TABLE inventory_opening_balance_items
+  ADD CONSTRAINT inventory_opening_balance_items_receipt_fk
+  FOREIGN KEY (receipt_id) REFERENCES inventory_receipts(receipt_id) ON DELETE RESTRICT;
+
+CREATE OR REPLACE FUNCTION preserve_inventory_receipt_evidence()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.request_id IS DISTINCT FROM NEW.request_id
+    OR OLD.sku IS DISTINCT FROM NEW.sku
+    OR OLD.original_quantity IS DISTINCT FROM NEW.original_quantity
+    OR OLD.intake_at IS DISTINCT FROM NEW.intake_at
+    OR OLD.recorded_at IS DISTINCT FROM NEW.recorded_at
+    OR OLD.market_value IS DISTINCT FROM NEW.market_value
+    OR OLD.market_observed_at IS DISTINCT FROM NEW.market_observed_at
+    OR OLD.market_calculated_at IS DISTINCT FROM NEW.market_calculated_at
+    OR OLD.market_provenance IS DISTINCT FROM NEW.market_provenance
+    OR OLD.source_evidence IS DISTINCT FROM NEW.source_evidence
+    OR OLD.receipt_kind IS DISTINCT FROM NEW.receipt_kind
+    OR OLD.opening_balance_run_id IS DISTINCT FROM NEW.opening_balance_run_id
+    OR OLD.fifo_precedence IS DISTINCT FROM NEW.fifo_precedence
+  THEN RAISE EXCEPTION 'Inventory receipt evidence is immutable'; END IF;
+  IF OLD.seller_key IS NOT NULL AND OLD.seller_key IS DISTINCT FROM NEW.seller_key
+  THEN RAISE EXCEPTION 'Inventory receipt seller ownership cannot be reassigned'; END IF;
+  RETURN NEW;
+END;
+$$;

--- a/db/migrations/038_add_inventory_opening_balances.sql
+++ b/db/migrations/038_add_inventory_opening_balances.sql
@@ -8,11 +8,16 @@ CREATE TABLE inventory_complete_observations (
   started_at TIMESTAMPTZ NOT NULL,
   cutoff_at TIMESTAMPTZ NOT NULL,
   quantity_fingerprint TEXT NOT NULL,
+  supported_quantity_fingerprint TEXT NOT NULL,
   first_content_fingerprint TEXT NOT NULL,
   second_content_fingerprint TEXT NOT NULL,
-  sku_count INTEGER NOT NULL CHECK (sku_count >= 0),
-  positive_sku_count INTEGER NOT NULL CHECK (positive_sku_count >= 0),
+  item_count INTEGER NOT NULL CHECK (item_count >= 0),
+  positive_item_count INTEGER NOT NULL CHECK (positive_item_count >= 0),
   total_quantity INTEGER NOT NULL CHECK (total_quantity >= 0),
+  supported_positive_sku_count INTEGER NOT NULL CHECK (supported_positive_sku_count >= 0),
+  supported_total_quantity INTEGER NOT NULL CHECK (supported_total_quantity >= 0),
+  unsupported_positive_item_count INTEGER NOT NULL CHECK (unsupported_positive_item_count >= 0),
+  unsupported_positive_quantity INTEGER NOT NULL CHECK (unsupported_positive_quantity >= 0),
   identity_evidence JSONB NOT NULL,
   error TEXT,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -22,16 +27,24 @@ CREATE INDEX inventory_complete_observations_seller_cutoff_idx
   ON inventory_complete_observations (seller_key, cutoff_at DESC, id DESC)
   WHERE status = 'complete';
 
+CREATE INDEX inventory_complete_observations_all_seller_cutoff_idx
+  ON inventory_complete_observations (seller_key, cutoff_at DESC, id DESC);
+
 CREATE TABLE inventory_complete_observation_items (
   observation_id BIGINT NOT NULL REFERENCES inventory_complete_observations(id) ON DELETE RESTRICT,
-  sku INTEGER NOT NULL CHECK (sku > 0),
+  inventory_key TEXT NOT NULL CHECK (length(trim(inventory_key)) > 0),
+  identity_kind TEXT NOT NULL CHECK (identity_kind IN ('standard_sku','unsupported')),
+  sku INTEGER CHECK (sku > 0),
   quantity INTEGER NOT NULL CHECK (quantity >= 0),
-  PRIMARY KEY (observation_id, sku)
+  PRIMARY KEY (observation_id, inventory_key),
+  UNIQUE (observation_id, sku),
+  CHECK ((identity_kind='standard_sku' AND sku IS NOT NULL) OR (identity_kind='unsupported' AND sku IS NULL))
 );
 
 CREATE TABLE inventory_complete_observation_requests (
   request_id TEXT PRIMARY KEY,
   seller_key TEXT NOT NULL CHECK (length(trim(seller_key)) > 0),
+  purpose_evidence JSONB NOT NULL DEFAULT '{"kind":"opening_observation"}'::jsonb,
   status TEXT NOT NULL CHECK (status IN ('capturing', 'complete', 'failed')),
   claim_token TEXT,
   claim_expires_at TIMESTAMPTZ,
@@ -43,7 +56,8 @@ CREATE TABLE inventory_complete_observation_requests (
     (status = 'capturing' AND claim_token IS NOT NULL AND claim_expires_at IS NOT NULL AND observation_id IS NULL)
     OR (status = 'complete' AND claim_token IS NULL AND claim_expires_at IS NULL AND observation_id IS NOT NULL)
     OR (status = 'failed' AND claim_token IS NULL AND claim_expires_at IS NULL AND observation_id IS NULL)
-  )
+  ),
+  CHECK (jsonb_typeof(purpose_evidence) = 'object')
 );
 
 CREATE TABLE inventory_observation_differences (
@@ -51,7 +65,8 @@ CREATE TABLE inventory_observation_differences (
   seller_key TEXT NOT NULL,
   previous_observation_id BIGINT NOT NULL REFERENCES inventory_complete_observations(id) ON DELETE RESTRICT,
   observation_id BIGINT NOT NULL REFERENCES inventory_complete_observations(id) ON DELETE RESTRICT,
-  sku INTEGER NOT NULL,
+  inventory_key TEXT NOT NULL,
+  sku INTEGER,
   quantity_delta INTEGER NOT NULL CHECK (quantity_delta <> 0),
   previous_quantity INTEGER NOT NULL CHECK (previous_quantity >= 0),
   observed_quantity INTEGER NOT NULL CHECK (observed_quantity >= 0),
@@ -59,11 +74,14 @@ CREATE TABLE inventory_observation_differences (
   acknowledgement_request_id TEXT UNIQUE,
   acknowledgement_note TEXT,
   acknowledged_at TIMESTAMPTZ,
-  UNIQUE (previous_observation_id, observation_id, sku)
+  UNIQUE (previous_observation_id, observation_id, inventory_key)
 );
 
 CREATE INDEX inventory_observation_differences_unresolved_idx
   ON inventory_observation_differences (observation_id, id) WHERE status = 'unresolved';
+
+CREATE INDEX inventory_observation_differences_seller_page_idx
+  ON inventory_observation_differences (seller_key, observation_id, id);
 
 CREATE TABLE inventory_opening_balance_runs (
   id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
@@ -77,8 +95,17 @@ CREATE TABLE inventory_opening_balance_runs (
   status TEXT NOT NULL CHECK (status IN ('previewed', 'blocked', 'applied')),
   evidence_fingerprint TEXT NOT NULL,
   unresolved JSONB NOT NULL DEFAULT '[]'::jsonb,
+  limitations JSONB NOT NULL DEFAULT '[]'::jsonb,
+  apply_request_id TEXT UNIQUE,
+  validation_observation_id BIGINT REFERENCES inventory_complete_observations(id) ON DELETE RESTRICT,
+  validation_order_coverage_evidence JSONB,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  applied_at TIMESTAMPTZ
+  applied_at TIMESTAMPTZ,
+  CHECK (
+    status <> 'applied'
+    OR (apply_request_id IS NOT NULL AND validation_observation_id IS NOT NULL
+      AND validation_order_coverage_evidence IS NOT NULL AND applied_at IS NOT NULL)
+  )
 );
 
 CREATE UNIQUE INDEX inventory_opening_balance_one_applied_seller_idx
@@ -136,6 +163,14 @@ BEGIN
     OR OLD.receipt_kind IS DISTINCT FROM NEW.receipt_kind
     OR OLD.opening_balance_run_id IS DISTINCT FROM NEW.opening_balance_run_id
     OR OLD.fifo_precedence IS DISTINCT FROM NEW.fifo_precedence
+    OR (
+      OLD.receipt_kind = 'opening_balance'
+      AND (
+        OLD.product_line_id IS DISTINCT FROM NEW.product_line_id
+        OR OLD.set_id IS DISTINCT FROM NEW.set_id
+        OR OLD.product_id IS DISTINCT FROM NEW.product_id
+      )
+    )
   THEN RAISE EXCEPTION 'Inventory receipt evidence is immutable'; END IF;
   IF OLD.seller_key IS NOT NULL AND OLD.seller_key IS DISTINCT FROM NEW.seller_key
   THEN RAISE EXCEPTION 'Inventory receipt seller ownership cannot be reassigned'; END IF;

--- a/docs/inventory-opening-balance.md
+++ b/docs/inventory-opening-balance.md
@@ -6,6 +6,8 @@ The opening-balance workflow establishes the forward FIFO boundary for one confi
 
 `capture` reads the authenticated Seller Portal pricing context, downloads the complete **Export From Live** CSV twice, and then reads the pricing context again. Both context reads must identify the configured seller. Both exports must contain the same normalized `(SKU, Total Quantity)` set. Raw content hashes are retained as provenance, while price-only changes do not make the quantity observation unstable.
 
+Capture claims its request before portal I/O. A completed request replays its stored result; an expired or failed attempt can be retried without letting the former owner overwrite the replacement. Compact SKU/quantity rows are retained for the latest three observations, the latest complete observation, and every referenced opening run. Preview and apply verify their row counts, totals, and fingerprint before trusting a retained observation.
+
 The export's `Total Quantity` is treated as sellable inventory and excludes units already reserved by orders such as Ready to Ship. Those reserved units are not subtracted again. The capture interval starts before the first identity check and ends after the final identity check. Any order or confirmed publication in that half-open interval `[startedAt, cutoffAt)` blocks the preview because its inclusion in the export is ambiguous.
 
 Before preview, seller-order history must complete a gap-free TCGplayer API scan after the cutoff. The opening run copies the allowlisted coverage evidence because completed sync runs have bounded retention. A preview also freezes the pre-cutoff order revisions, confirmed receipt activations, and positive-SKU catalog mappings. Apply rechecks that evidence under a seller-scoped advisory lock.
@@ -36,19 +38,35 @@ The endpoint is `POST /api/inventory-opening-balance`. The seller may be omitted
    {"action":"preview","requestId":"opening-preview-2026-09-07","sellerKey":"seller-a","observationId":"123"}
    ```
 
-   Review `skuCount`, `positiveSkuCount`, `totalQuantity`, and every `unresolved` item. A blocked preview cannot be applied. Capture a new observation after resolving an unstable capture or interval conflict. Inventory changes against an earlier observation must be reviewed explicitly:
+   Review the complete-export `itemCount` and `observedTotalQuantity`, the standard-SKU opening `positiveSkuCount` and `totalQuantity`, both unsupported-positive counts, all `limitations`, and every `unresolved` item. A blocked preview cannot be applied. Capture a new observation after resolving an unstable capture or interval conflict. Inventory changes against an earlier observation must be reviewed explicitly:
+
+   ```json
+   {"action":"list_preview_items","sellerKey":"seller-a","runId":"67","afterSku":0,"limit":100}
+   ```
+
+   ```json
+   {"action":"list_differences","sellerKey":"seller-a","observationId":"123","afterId":"0","limit":100}
+   ```
+
+   Unsupported custom listing identities are retained exactly as the export supplied them and excluded from standard-SKU FIFO. Inspect them before apply:
+
+   ```json
+   {"action":"list_observation_items","sellerKey":"seller-a","observationId":"123","afterInventoryKey":"","limit":100,"unsupportedOnly":true}
+   ```
 
    ```json
    {"action":"acknowledge_difference","requestId":"opening-difference-45-review","sellerKey":"seller-a","differenceId":"45","note":"Compared with the Seller Portal export; no inventory cause was inferred."}
    ```
 
-4. Apply the exact preview:
+4. Apply the exact preview. Apply first performs another durable pair of seller-validated exports and advances one bounded seller-order catch-up pass. If coverage cannot finish beyond that revalidation cutoff, wait for the independent worker and retry the identical application request. Every uncommitted retry takes fresh source evidence; an exact retry after a committed application returns locally without another portal read.
 
    ```json
-   {"action":"apply","sellerKey":"seller-a","runId":"67","evidenceFingerprint":"<fingerprint returned by preview>"}
+   {"action":"apply","requestId":"opening-apply-2026-09-07","sellerKey":"seller-a","runId":"67","evidenceFingerprint":"<fingerprint returned by preview>"}
    ```
 
-Apply is idempotent for the same run and fingerprint. A changed fingerprint or seller is rejected. Only one opening balance can be applied per seller.
+Apply is idempotent for the same request, run, and fingerprint. It rejects changed current quantities, a newer unreviewed observation, missing post-revalidation order coverage, changed local evidence, or a different seller. Only one opening balance can be applied per seller.
+
+Applying an opening balance is the point after which an older application version must not be used to edit or batch inventory. Before application, migration rollback is safe because no opening receipts exist.
 
 ## Integration test
 

--- a/docs/inventory-opening-balance.md
+++ b/docs/inventory-opening-balance.md
@@ -64,7 +64,9 @@ The endpoint is `POST /api/inventory-opening-balance`. The seller may be omitted
    {"action":"apply","requestId":"opening-apply-2026-09-07","sellerKey":"seller-a","runId":"67","evidenceFingerprint":"<fingerprint returned by preview>"}
    ```
 
-Apply is idempotent for the same request, run, and fingerprint. It rejects changed current quantities, a newer unreviewed observation, missing post-revalidation order coverage, changed local evidence, or a different seller. Only one opening balance can be applied per seller.
+Apply is idempotent for the same request, run, and fingerprint. It rejects changed current standard-SKU quantities, a newer unstable observation, missing post-revalidation order coverage, changed local evidence, or a different seller. Only one opening balance can be applied per seller.
+
+The applied response records and returns `validationObservationId`, `unsupportedPositiveItemCount`, and `unsupportedPositiveQuantity`. Custom-listing quantities do not become standard-SKU lots, but their current identities and deltas remain inspectable through `list_observation_items` and `list_differences` for that validation observation.
 
 Applying an opening balance is the point after which an older application version must not be used to edit or batch inventory. Before application, migration rollback is safe because no opening receipts exist.
 

--- a/docs/inventory-opening-balance.md
+++ b/docs/inventory-opening-balance.md
@@ -1,0 +1,63 @@
+# Inventory opening balance
+
+The opening-balance workflow establishes the forward FIFO boundary for one configured seller. It does not reconstruct purchase dates or costs that the application cannot prove.
+
+## Evidence and cutoff
+
+`capture` reads the authenticated Seller Portal pricing context, downloads the complete **Export From Live** CSV twice, and then reads the pricing context again. Both context reads must identify the configured seller. Both exports must contain the same normalized `(SKU, Total Quantity)` set. Raw content hashes are retained as provenance, while price-only changes do not make the quantity observation unstable.
+
+The export's `Total Quantity` is treated as sellable inventory and excludes units already reserved by orders such as Ready to Ship. Those reserved units are not subtracted again. The capture interval starts before the first identity check and ends after the final identity check. Any order or confirmed publication in that half-open interval `[startedAt, cutoffAt)` blocks the preview because its inclusion in the export is ambiguous.
+
+Before preview, seller-order history must complete a gap-free TCGplayer API scan after the cutoff. The opening run copies the allowlisted coverage evidence because completed sync runs have bounded retention. A preview also freezes the pre-cutoff order revisions, confirmed receipt activations, and positive-SKU catalog mappings. Apply rechecks that evidence under a seller-scoped advisory lock.
+
+## Forward-only policy
+
+Positive export quantities become one opening receipt per SKU. These receipts have explicit FIFO precedence before ordinary receipts, but their `intake_at`, intake market value, and market observation time remain `NULL`. The system records their provenance as `opening_balance_unknown`; it never substitutes capture time or current market value for missing history.
+
+The cutoff is half-open: activity before `cutoffAt` belongs to the historical side, while activity at or after `cutoffAt` belongs to forward processing. Downstream FIFO allocation must dynamically exclude orders and confirmed receipt activations with evidence before the applied cutoff. This also covers pre-cutoff evidence discovered after the opening run. Opening receipts never enter pending inventory, pricing batches, or publication.
+
+This workflow deliberately does not restore canceled or refunded stock, estimate historical purchases, or infer a receipt or sale from an inventory difference. A later complete observation records per-SKU deltas against the prior observation. An operator may acknowledge that a discrepancy was reviewed, but that action does not classify it as a receipt or sale and does not change inventory. A stock correction is a separate, evidenced operation composed with forward reconciliation.
+
+## Operator workflow
+
+The endpoint is `POST /api/inventory-opening-balance`. The seller may be omitted and then defaults to the configured shipping seller. Keep each request ID stable when retrying the same operation.
+
+1. Capture a stable observation:
+
+   ```json
+   {"action":"capture","requestId":"opening-observation-2026-09-07","sellerKey":"seller-a"}
+   ```
+
+2. Let the independent seller-order worker finish a complete API scan after the returned cutoff.
+
+3. Preview without changing stock:
+
+   ```json
+   {"action":"preview","requestId":"opening-preview-2026-09-07","sellerKey":"seller-a","observationId":"123"}
+   ```
+
+   Review `skuCount`, `positiveSkuCount`, `totalQuantity`, and every `unresolved` item. A blocked preview cannot be applied. Capture a new observation after resolving an unstable capture or interval conflict. Inventory changes against an earlier observation must be reviewed explicitly:
+
+   ```json
+   {"action":"acknowledge_difference","requestId":"opening-difference-45-review","sellerKey":"seller-a","differenceId":"45","note":"Compared with the Seller Portal export; no inventory cause was inferred."}
+   ```
+
+4. Apply the exact preview:
+
+   ```json
+   {"action":"apply","sellerKey":"seller-a","runId":"67","evidenceFingerprint":"<fingerprint returned by preview>"}
+   ```
+
+Apply is idempotent for the same run and fingerprint. A changed fingerprint or seller is rejected. Only one opening balance can be applied per seller.
+
+## Integration test
+
+Use a disposable database whose name starts with `tcgplayer_fifo_test_`. The test refuses to load the database module until both variables point to that same database.
+
+```powershell
+$env:TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/tcgplayer_fifo_test_opening_58'
+$env:DATABASE_URL = $env:TEST_DATABASE_URL
+npx tsx app/core/db/repositories/inventoryOpeningBalances.server.integration.test.ts
+```
+
+Apply all migrations through `038_add_inventory_opening_balances.sql` before running the test.

--- a/docs/inventory-opening-balance.md
+++ b/docs/inventory-opening-balance.md
@@ -48,6 +48,12 @@ The endpoint is `POST /api/inventory-opening-balance`. The seller may be omitted
    {"action":"list_differences","sellerKey":"seller-a","observationId":"123","afterId":"0","limit":100}
    ```
 
+   If apply reports a validation observation but says intervening standard-SKU differences remain unresolved, list the entire guarded interval, including intermediate captures:
+
+   ```json
+   {"action":"list_application_differences","sellerKey":"seller-a","runId":"67","validationObservationId":"130","afterId":"0","limit":100}
+   ```
+
    Unsupported custom listing identities are retained exactly as the export supplied them and excluded from standard-SKU FIFO. Inspect them before apply:
 
    ```json


### PR DESCRIPTION
A complete Seller Portal live export can establish sellable opening stock, but its historical receipt date and price are unknown and its quantities already exclude reserved Ready-to-Ship units. This change captures two seller-validated complete exports, waits for a completed seller-order scan after the cutoff, blocks concurrent interval activity or unresolved standard-SKU changes, and applies one seller-scoped opening lot per positive standard SKU without inventing intake evidence.

The forward-only cutoff is half-open: pre-cutoff orders and confirmed receipt activations remain preserved evidence and stay outside forward FIFO supply/consumption, while opening lots sort before later receipts through explicit precedence. Capture, preview, acknowledgement, and apply use durable request identity. Apply takes fresh seller evidence, advances one bounded order catch-up, freezes catalog metadata, rechecks source evidence, and writes mutations/receipts set-wise with conservation checks. Opening lots are excluded from pending edits, catalog maintenance, and pricing batches.

Custom Seller Portal inventory IDs remain in the complete observation with exact raw identity and quantity. They are reported as an explicit unsupported limitation and remain inspectable, while the opening lot scope is limited to proven numeric catalog SKUs. Successful apply and every replay return the persisted validation observation and current unsupported totals.

Validation:
- `npm test`
- `npm run typecheck`
- `npm run build`
- fresh migrations 001-038 on disposable `tcgplayer_fifo_test_opening_58`
- guarded repository integration covering request/seller isolation, incomplete coverage, sale-during-capture, stale and unstable source observations, hidden intermediate differences, frozen catalog evidence, idempotent/concurrent replay, custom inventory visibility/retention, and opening5 + pending2 batch isolation
- independent 27,389-row Seller Portal-shaped fixture and concurrency/recovery harnesses

Closes #58
