### PR TITLE
Show intake history throughout shipping

### DIFF
--- a/app/core/db/repositories/inventoryFifo.server.ts
+++ b/app/core/db/repositories/inventoryFifo.server.ts
@@ -808,7 +808,8 @@ export const inventoryFifoRepository={
         WHERE orders.seller_key=$1 AND orders.order_number=ANY($2::text[])
       ) SELECT orders.order_number AS "orderNumber",orders.order_time AS "currentOrderTime",
         orders.source_revision AS "currentSourceOrderRevision",current_line.sku_id AS "skuId",
-        current_line.ordered_quantity::int AS "currentOrderedQuantity",fifo.state,fifo.hold_reason AS "holdReason",
+        current_line.ordered_quantity::int AS "currentOrderedQuantity",current_line.gross_item_proceeds::float8 AS "persistedSoldTotal",
+        fifo.state,fifo.hold_reason AS "holdReason",
         fifo.order_time AS "allocatedOrderTime",fifo.ordered_quantity::int AS "allocatedOrderedQuantity",fifo.matched_quantity::int AS "matchedQuantity",
         fifo.unmatched_quantity::int AS "unmatchedQuantity",fifo.price_known_quantity::int AS "priceKnownQuantity",
         fifo.date_known_quantity::int AS "dateKnownQuantity",fifo.intake_market_total::float8 AS "intakeMarketTotal",

--- a/app/core/db/repositories/inventoryFifo.server.ts
+++ b/app/core/db/repositories/inventoryFifo.server.ts
@@ -799,6 +799,39 @@ export const inventoryFifoRepository={
       ORDER BY identities."skuId"`,[sellerKey.trim(),orderNumber.trim()]);
   },
 
+  async findShippingOrderAllocations(sellerKey:string,orderNumbers:string[]){
+    const normalized=[...new Set(orderNumbers.map((value)=>value.trim()).filter(Boolean))];
+    if(!normalized.length)return [];
+    if(normalized.length>500)throw new Error("Shipping intake history is limited to 500 orders per request.");
+    return query(`WITH target_orders AS (
+        SELECT orders.* FROM seller_orders orders
+        WHERE orders.seller_key=$1 AND orders.order_number=ANY($2::text[])
+      ) SELECT orders.order_number AS "orderNumber",orders.order_time AS "currentOrderTime",
+        orders.source_revision AS "currentSourceOrderRevision",current_line.sku_id AS "skuId",
+        current_line.ordered_quantity::int AS "currentOrderedQuantity",fifo.state,fifo.hold_reason AS "holdReason",
+        fifo.order_time AS "allocatedOrderTime",fifo.ordered_quantity::int AS "allocatedOrderedQuantity",fifo.matched_quantity::int AS "matchedQuantity",
+        fifo.unmatched_quantity::int AS "unmatchedQuantity",fifo.price_known_quantity::int AS "priceKnownQuantity",
+        fifo.date_known_quantity::int AS "dateKnownQuantity",fifo.intake_market_total::float8 AS "intakeMarketTotal",
+        fifo.weighted_days_held::float8 AS "weightedDaysHeld",fifo.current_revision_id::text AS "revisionId",
+        fifo.source_order_revision AS "allocatedSourceOrderRevision",queue.status AS "replayStatus",
+        queue.hold_reason AS "queueHoldReason",
+        (fifo.id IS NULL OR queue.generation IS NOT NULL OR fifo.source_order_revision<>orders.source_revision) AS "allocationPending",
+        COALESCE((SELECT jsonb_agg(jsonb_build_object(
+          'supplyKey',allocation.supply_key,'receiptId',allocation.receipt_id,'quantity',allocation.allocated_quantity,
+          'availableAt',allocation.available_at,'dispositionId',allocation.disposition_id::text,
+          'quantityCorrectionId',allocation.quantity_correction_id::text,'receiptKind',receipt.receipt_kind,
+          'intakeAt',receipt.intake_at,'marketValue',receipt.market_value::float8,
+          'marketProvenance',receipt.market_provenance,'marketCalculatedAt',receipt.market_calculated_at)
+          ORDER BY allocation.available_at,allocation.supply_key)
+          FROM inventory_fifo_revision_allocations allocation
+          JOIN inventory_receipts receipt ON receipt.receipt_id=allocation.receipt_id
+          WHERE allocation.revision_id=fifo.current_revision_id),'[]'::jsonb) AS lots
+      FROM target_orders orders JOIN seller_order_lines current_line ON current_line.order_id=orders.id
+      LEFT JOIN inventory_fifo_lines fifo ON fifo.order_id=orders.id AND fifo.order_line_sku_id=current_line.sku_id
+      LEFT JOIN inventory_fifo_replay_queue queue ON queue.seller_key=orders.seller_key AND queue.sku=fifo.sku
+      ORDER BY orders.order_number,current_line.sku_id`,[sellerKey.trim(),normalized]);
+  },
+
   async listLineRevisions(input:{sellerKey:string;lineId:string;afterRevision?:number;limit?:number}){
     const limit=input.limit??50;
     if(!Number.isInteger(limit)||limit<1||limit>100)throw new Error("Revision limit must be between 1 and 100.");

--- a/app/features/pull-sheet/components/PullSheetGrid.tsx
+++ b/app/features/pull-sheet/components/PullSheetGrid.tsx
@@ -39,9 +39,10 @@ const PRICE_TONE_COLORS: Record<MarketDeltaTone, string> = {
 function PriceBadgeLine({ badge }: { badge: PullSheetPriceBadge }) {
   const percent = percentAboveMarket(badge.soldPrice, badge.marketPrice);
   const tone = getMarketDeltaTone(percent);
-  const marketLabel = percent === null ? "" : `Mkt ${formatUsd(badge.marketPrice ?? 0)} | `;
-  const percentLabel = percent === null ? "No market" : formatSignedPercent(percent);
+  const marketLabel = percent === null ? "" : `Current ${formatUsd(badge.marketPrice ?? 0)} | `;
+  const percentLabel = percent === null ? "Current unavailable" : formatSignedPercent(percent);
 
+  const intakeAvailable = (badge.intakePriceKnownQuantity ?? 0) > 0;
   return (
     <Typography
       variant="caption"
@@ -57,6 +58,16 @@ function PriceBadgeLine({ badge }: { badge: PullSheetPriceBadge }) {
       <Box component="span" sx={{ color: PRICE_TONE_COLORS[tone], fontWeight: 700 }}>
         {percentLabel}
       </Box>
+      {badge.intakeOrderedQuantity !== undefined && (
+        <>
+          <br />
+          SKU intake {intakeAvailable ? formatUsd(badge.intakeMarketTotal ?? 0) : "unavailable"}
+          {` · price ${badge.intakePriceKnownQuantity ?? 0}/${badge.intakeOrderedQuantity}`}
+          {` · age ${badge.intakeWeightedDaysHeld === null || badge.intakeWeightedDaysHeld === undefined ? "unavailable" : `${badge.intakeWeightedDaysHeld.toFixed(1)}d`}`}
+          {` (${badge.intakeDateKnownQuantity ?? 0}/${badge.intakeOrderedQuantity} dated)`}
+          {badge.intakeStatus && badge.intakeStatus !== "current" ? ` · ${badge.intakeStatus}` : ""}
+        </>
+      )}
     </Typography>
   );
 }

--- a/app/features/pull-sheet/components/PullSheetGrid.tsx
+++ b/app/features/pull-sheet/components/PullSheetGrid.tsx
@@ -61,7 +61,7 @@ function PriceBadgeLine({ badge }: { badge: PullSheetPriceBadge }) {
       {badge.intakeOrderedQuantity !== undefined && (
         <>
           <br />
-          SKU intake {intakeAvailable ? formatUsd(badge.intakeMarketTotal ?? 0) : "unavailable"}
+          Intake total {intakeAvailable ? formatUsd(badge.intakeMarketTotal ?? 0) : "unavailable"}
           {` · price ${badge.intakePriceKnownQuantity ?? 0}/${badge.intakeOrderedQuantity}`}
           {` · age ${badge.intakeWeightedDaysHeld === null || badge.intakeWeightedDaysHeld === undefined ? "unavailable" : `${badge.intakeWeightedDaysHeld.toFixed(1)}d`}`}
           {` (${badge.intakeDateKnownQuantity ?? 0}/${badge.intakeOrderedQuantity} dated)`}

--- a/app/features/pull-sheet/types/pullSheetTypes.ts
+++ b/app/features/pull-sheet/types/pullSheetTypes.ts
@@ -37,4 +37,11 @@ export interface PullSheetItem {
 export interface PullSheetPriceBadge {
   soldPrice: number;
   marketPrice?: number;
+  /** Shipping-only SKU aggregate. Kept optional for non-shipping pull sheets. */
+  intakeMarketTotal?: number | null;
+  intakeOrderedQuantity?: number;
+  intakePriceKnownQuantity?: number;
+  intakeDateKnownQuantity?: number;
+  intakeWeightedDaysHeld?: number | null;
+  intakeStatus?: string;
 }

--- a/app/features/shipping-export/components/IntakeHistorySummary.test.tsx
+++ b/app/features/shipping-export/components/IntakeHistorySummary.test.tsx
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { renderToStaticMarkup } from "react-dom/server";
+import { IntakeHistorySummary } from "./IntakeHistorySummary";
+import type { TcgPlayerShippingOrder } from "../types/shippingExport";
+
+const order = {
+  "Order #": "A", "Value Of Products": 10, "Item Count": 1,
+  products: [{ name: "Card", quantity: 1, unitPrice: 10, skuId: 1, inventorySkuId: "1" }],
+  intakeHistory: { orderNumber: "A", refreshedAt: "2026-08-01T12:00:00.000Z", lines: [{
+    skuId: "1", status: "current", allocationRevisionId: "1", allocatedSourceOrderRevision: 1,
+    currentSourceOrderRevision: 1, orderTime: "2026-08-01T12:00:00.000Z", orderedQuantity: 1,
+    matchedQuantity: 1, unmatchedQuantity: 0, priceKnownQuantity: 1, dateKnownQuantity: 1,
+    recordedPriceQuantity: 1, estimatedPriceQuantity: 0, intakeMarketTotal: 0, weightedDaysHeld: 10,
+    minimumDaysHeld: 10, maximumDaysHeld: 10, lots: [{ supplyKey: "receipt:1", receiptId: 1, quantity: 1,
+      availableAt: "2026-07-01T12:00:00.000Z", sourceKind: "received", intakeAt: "2026-07-22T12:00:00.000Z",
+      daysHeld: 10, intakeMarketValue: 0, priceProvenance: "recorded" }],
+  }] },
+} as TcgPlayerShippingOrder;
+
+const html = renderToStaticMarkup(<IntakeHistorySummary sourceOrders={[order]} label="Shipment" />);
+assert.match(html, /Shipment intake market/);
+assert.match(html, /\$0\.00/);
+assert.match(html, /Sold vs intake market/);
+assert.match(html, /Age at sale/);
+assert.match(html, /<details/);
+assert.match(html, /<summary/);
+assert.match(html, /Receipt 1/);
+assert.doesNotMatch(html, /profit/i);
+
+console.log("PASS intake history summary labels zero-value coverage, fixed sale age, and keyboard-native lot disclosure");

--- a/app/features/shipping-export/components/IntakeHistorySummary.test.tsx
+++ b/app/features/shipping-export/components/IntakeHistorySummary.test.tsx
@@ -6,9 +6,10 @@ import type { TcgPlayerShippingOrder } from "../types/shippingExport";
 const order = {
   "Order #": "A", "Value Of Products": 10, "Item Count": 1,
   products: [{ name: "Card", quantity: 1, unitPrice: 10, skuId: 1, inventorySkuId: "1" }],
-  intakeHistory: { orderNumber: "A", refreshedAt: "2026-08-01T12:00:00.000Z", lines: [{
+  intakeHistory: { orderNumber: "A", sellerKey: "seller", refreshedAt: "2026-08-01T12:00:00.000Z", lines: [{
     skuId: "1", status: "current", allocationRevisionId: "1", allocatedSourceOrderRevision: 1,
     currentSourceOrderRevision: 1, orderTime: "2026-08-01T12:00:00.000Z", orderedQuantity: 1,
+    soldTotal: 10,
     matchedQuantity: 1, unmatchedQuantity: 0, priceKnownQuantity: 1, dateKnownQuantity: 1,
     recordedPriceQuantity: 1, estimatedPriceQuantity: 0, intakeMarketTotal: 0, weightedDaysHeld: 10,
     minimumDaysHeld: 10, maximumDaysHeld: 10, lots: [{ supplyKey: "receipt:1", receiptId: 1, quantity: 1,

--- a/app/features/shipping-export/components/IntakeHistorySummary.tsx
+++ b/app/features/shipping-export/components/IntakeHistorySummary.tsx
@@ -1,0 +1,88 @@
+import { Box, Chip, Divider, Stack, Typography } from "@mui/material";
+import { compareOrdersToIntake, intakeDeltaAmount, intakeDeltaPercent } from "../services/orderIntakeComparison";
+import type { TcgPlayerShippingOrder } from "../types/shippingExport";
+
+function usd(value: number) {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(value);
+}
+
+function days(value: number | null) {
+  return value === null ? "Unavailable" : `${value.toFixed(1)} days`;
+}
+
+function coverage(known: number, total: number) {
+  return `${known} of ${total} units`;
+}
+
+function sourceLabel(value: string) {
+  return value.replaceAll("_", " ");
+}
+
+export function IntakeHistorySummary({
+  sourceOrders,
+  label = "Intake history",
+  compact = false,
+}: {
+  sourceOrders: TcgPlayerShippingOrder[];
+  label?: string;
+  compact?: boolean;
+}) {
+  if (!sourceOrders.length) return null;
+  const comparison = compareOrdersToIntake(sourceOrders);
+  const delta = intakeDeltaAmount(comparison);
+  const percent = intakeDeltaPercent(comparison);
+  const uniqueOrders = [...new Map(sourceOrders.map((order) => [order["Order #"], order])).values()];
+  const statusCount = comparison.pendingLineCount + comparison.heldLineCount
+    + comparison.mismatchLineCount + comparison.unavailableLineCount;
+
+  return (
+    <Stack spacing={compact ? 0.5 : 1} sx={{ minWidth: 0 }}>
+      <Stack direction={{ xs: "column", sm: "row" }} spacing={{ xs: 0.25, sm: 2 }} useFlexGap flexWrap="wrap">
+        <Typography variant={compact ? "caption" : "body2"}>
+          <strong>{label} intake market:</strong>{" "}
+          {comparison.priceKnownQuantity ? usd(comparison.intakeMarketTotal) : "Unavailable"}
+        </Typography>
+        <Typography variant={compact ? "caption" : "body2"}>
+          <strong>Sold vs intake market:</strong>{" "}
+          {delta === null ? "Unavailable" : `${delta >= 0 ? "+" : ""}${usd(delta)}${percent === null ? "" : ` (${percent >= 0 ? "+" : ""}${percent.toFixed(1)}%)`}`}
+        </Typography>
+        <Typography variant={compact ? "caption" : "body2"}>
+          <strong>Age at sale:</strong> {days(comparison.weightedDaysHeld)}
+          {comparison.minimumDaysHeld !== null && comparison.maximumDaysHeld !== null
+            && comparison.minimumDaysHeld !== comparison.maximumDaysHeld
+            ? ` (${comparison.minimumDaysHeld.toFixed(1)}–${comparison.maximumDaysHeld.toFixed(1)} day range)` : ""}
+        </Typography>
+      </Stack>
+      <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+        <Chip size="small" variant="outlined" label={`Matched ${coverage(comparison.matchedQuantity, comparison.orderedQuantity)}`} />
+        <Chip size="small" variant="outlined" label={`Intake price ${coverage(comparison.priceKnownQuantity, comparison.orderedQuantity)}`} />
+        <Chip size="small" variant="outlined" label={`Intake date ${coverage(comparison.dateKnownQuantity, comparison.orderedQuantity)}`} />
+        {comparison.estimatedPriceQuantity > 0 && <Chip size="small" color="warning" variant="outlined" label={`${comparison.estimatedPriceQuantity} estimated price units`} />}
+        {statusCount > 0 && <Chip size="small" color="warning" label={`${statusCount} history ${statusCount === 1 ? "line needs" : "lines need"} review`} />}
+      </Stack>
+      <Box component="details" sx={{ maxWidth: "100%" }}>
+        <Box component="summary" sx={{ cursor: "pointer", color: "text.secondary", typography: "caption" }}>
+          Receipt lots and history status ({comparison.lotCount})
+        </Box>
+        <Stack spacing={1} sx={{ mt: 1, pl: 1 }} divider={<Divider flexItem />}>
+          {uniqueOrders.flatMap((order) => (order.intakeHistory?.lines ?? []).map((line) => (
+            <Box key={`${order["Order #"]}:${line.skuId}`}>
+              <Typography variant="caption" component="div">
+                Order {order["Order #"]} · SKU {line.skuId} · {line.status}
+                {line.statusReason ? ` — ${line.statusReason}` : ""}
+              </Typography>
+              {line.lots.map((lot) => (
+                <Typography key={lot.supplyKey} variant="caption" color="text.secondary" component="div">
+                  Receipt {lot.receiptId}: {lot.quantity} {lot.quantity === 1 ? "unit" : "units"} · {sourceLabel(lot.sourceKind)} ·
+                  {" "}available {new Date(lot.availableAt).toLocaleDateString()} · intake {lot.intakeAt ? new Date(lot.intakeAt).toLocaleDateString() : "unknown"} ·
+                  {" "}market {lot.intakeMarketValue === null ? "unknown" : `${usd(lot.intakeMarketValue)} (${lot.priceProvenance})`} · age {days(lot.daysHeld)}
+                </Typography>
+              ))}
+              {!line.lots.length && <Typography variant="caption" color="text.secondary">No current receipt allocation detail.</Typography>}
+            </Box>
+          )))}
+        </Stack>
+      </Box>
+    </Stack>
+  );
+}

--- a/app/features/shipping-export/components/IntakeHistorySummary.tsx
+++ b/app/features/shipping-export/components/IntakeHistorySummary.tsx
@@ -20,7 +20,7 @@ function sourceLabel(value: string) {
 
 export function IntakeHistorySummary({
   sourceOrders,
-  label = "Intake history",
+  label = "Order",
   compact = false,
 }: {
   sourceOrders: TcgPlayerShippingOrder[];
@@ -32,8 +32,7 @@ export function IntakeHistorySummary({
   const delta = intakeDeltaAmount(comparison);
   const percent = intakeDeltaPercent(comparison);
   const uniqueOrders = [...new Map(sourceOrders.map((order) => [order["Order #"], order])).values()];
-  const statusCount = comparison.pendingLineCount + comparison.heldLineCount
-    + comparison.mismatchLineCount + comparison.unavailableLineCount;
+  const reviewCount = comparison.heldLineCount + comparison.mismatchLineCount;
 
   return (
     <Stack spacing={compact ? 0.5 : 1} sx={{ minWidth: 0 }}>
@@ -58,7 +57,9 @@ export function IntakeHistorySummary({
         <Chip size="small" variant="outlined" label={`Intake price ${coverage(comparison.priceKnownQuantity, comparison.orderedQuantity)}`} />
         <Chip size="small" variant="outlined" label={`Intake date ${coverage(comparison.dateKnownQuantity, comparison.orderedQuantity)}`} />
         {comparison.estimatedPriceQuantity > 0 && <Chip size="small" color="warning" variant="outlined" label={`${comparison.estimatedPriceQuantity} estimated price units`} />}
-        {statusCount > 0 && <Chip size="small" color="warning" label={`${statusCount} history ${statusCount === 1 ? "line needs" : "lines need"} review`} />}
+        {comparison.pendingLineCount > 0 && <Chip size="small" color="info" variant="outlined" label={`${comparison.pendingLineCount} allocation ${comparison.pendingLineCount === 1 ? "line" : "lines"} pending`} />}
+        {comparison.unavailableLineCount > 0 && <Chip size="small" variant="outlined" label={`${comparison.unavailableLineCount} history ${comparison.unavailableLineCount === 1 ? "line" : "lines"} unavailable`} />}
+        {reviewCount > 0 && <Chip size="small" color="warning" label={`${reviewCount} history ${reviewCount === 1 ? "line needs" : "lines need"} review`} />}
       </Stack>
       <Box component="details" sx={{ maxWidth: "100%" }}>
         <Box component="summary" sx={{ cursor: "pointer", color: "text.secondary", typography: "caption" }}>

--- a/app/features/shipping-export/components/MarketDeltaChip.tsx
+++ b/app/features/shipping-export/components/MarketDeltaChip.tsx
@@ -48,14 +48,15 @@ export function MarketDeltaChip({
 
     return (
       <Tooltip title="No market price was available for these lines.">
-        <Chip label="No market" size="small" variant="outlined" />
+        <Chip label="Current market unavailable" size="small" variant="outlined" />
       </Tooltip>
     );
   }
 
-  const label = showAmount
+  const deltaLabel = showAmount
     ? `${formatSignedPercent(percent)} (${formatSignedUsd(amount)})`
     : formatSignedPercent(percent);
+  const label = `Current ${deltaLabel}`;
   const coverage = describeMarketCoverage(comparison);
   const title = coverage
     ? `${describeMarketDelta(comparison)} · ${coverage}`
@@ -68,7 +69,7 @@ export function MarketDeltaChip({
         size="small"
         variant="outlined"
         color={TONE_COLORS[tone]}
-        aria-label={`Sold versus market: ${title}`}
+        aria-label={`Sold versus current market: ${title}`}
       />
     </Tooltip>
   );

--- a/app/features/shipping-export/components/OrderMarketSummary.test.tsx
+++ b/app/features/shipping-export/components/OrderMarketSummary.test.tsx
@@ -69,8 +69,8 @@ const testCases: TestCase[] = [
       assert.match(html, /\$22\.00/);
       assert.match(html, /\$20\.00/);
       assert.match(html, /\+10\.0% · \+\$2\.00/);
-      assert.match(html, /10\.0% above market/);
-      assert.match(html, /Every line has a market price/);
+      assert.match(html, /10\.0% above current market/);
+      assert.match(html, /Every line has a current market price/);
     },
   },
   {
@@ -90,7 +90,7 @@ const testCases: TestCase[] = [
 
       assert.match(partial, /1 of 2 lines priced/);
       assert.match(partial, /-20\.0% · -\$1\.00/);
-      assert.match(partial, /20\.0% below market/);
+      assert.match(partial, /20\.0% below current market/);
 
       const unavailable = renderToStaticMarkup(
         <OrderMarketSummary
@@ -102,7 +102,7 @@ const testCases: TestCase[] = [
       );
 
       assert.match(unavailable, /Not available/);
-      assert.match(unavailable, /No market price/);
+      assert.match(unavailable, /No current market price/);
     },
   },
 ];

--- a/app/features/shipping-export/components/OrderMarketSummary.tsx
+++ b/app/features/shipping-export/components/OrderMarketSummary.tsx
@@ -80,7 +80,7 @@ export function OrderMarketSummary({ sourceOrders, shipmentCount }: OrderMarketS
       : `${formatSignedPercent(deltaPercent)} · ${formatSignedUsd(deltaAmount)}`;
   const marketDetail =
     coverage ??
-    (comparison.lineCount > 0 ? "Every line has a market price" : "No line items to price");
+    (comparison.lineCount > 0 ? "Every line has a current market price" : "No line items to price");
 
   return (
     <Paper variant="outlined" sx={{ px: 2.5, py: 1.5, mb: 3 }}>
@@ -112,13 +112,13 @@ export function OrderMarketSummary({ sourceOrders, shipmentCount }: OrderMarketS
           detail="Product value, before shipping"
         />
         <SummaryMetric
-          label="Market"
+          label="Current market"
           value={formatUsd(comparison.comparableMarketTotal)}
           detail={marketDetail}
           detailColor={coverage ? "warning.main" : "text.secondary"}
         />
         <SummaryMetric
-          label="Sold vs market"
+          label="Sold vs current market"
           value={deltaValue}
           valueColor={TONE_TEXT_COLORS[tone]}
           detail={describeMarketDelta(comparison)}

--- a/app/features/shipping-export/components/OrderMarketSummary.tsx
+++ b/app/features/shipping-export/components/OrderMarketSummary.tsx
@@ -14,6 +14,7 @@ import {
   getMarketDeltaPercent,
 } from "../services/orderMarketComparison";
 import type { TcgPlayerShippingOrder } from "../types/shippingExport";
+import { IntakeHistorySummary } from "./IntakeHistorySummary";
 
 interface OrderMarketSummaryProps {
   sourceOrders: TcgPlayerShippingOrder[];
@@ -124,6 +125,9 @@ export function OrderMarketSummary({ sourceOrders, shipmentCount }: OrderMarketS
           detailColor={TONE_TEXT_COLORS[tone]}
         />
       </Stack>
+      <Box sx={{ mt: 1.5, pt: 1.5, borderTop: 1, borderColor: "divider" }}>
+        <IntakeHistorySummary sourceOrders={sourceOrders} label="Order load" />
+      </Box>
     </Paper>
   );
 }

--- a/app/features/shipping-export/components/steps/BuyPostageStep.tsx
+++ b/app/features/shipping-export/components/steps/BuyPostageStep.tsx
@@ -32,6 +32,7 @@ import type {
 import type { EasyPostEnvironmentStatus } from "../../types/shippingExport";
 import { compareShipmentToMarket } from "../../services/orderMarketComparison";
 import { MarketDeltaChip } from "../MarketDeltaChip";
+import { IntakeHistorySummary } from "../IntakeHistorySummary";
 
 interface BuyPostageStepProps {
   config: ShippingExportConfig;
@@ -183,6 +184,8 @@ export function BuyPostageStep({
                 shipmentToOrderMap,
                 shipment.reference,
               );
+              const shipmentOrderNumbers = new Set(shipmentToOrderMap[shipment.reference] ?? [shipment.reference]);
+              const shipmentSourceOrders = sourceOrders.filter((sourceOrder) => shipmentOrderNumbers.has(sourceOrder["Order #"]));
               const purchaseEntry = outboundPurchaseResultsByReference[shipment.reference];
               const returnPurchaseEntry = returnPurchaseResultsByReference[shipment.reference];
               const isBuyingOutbound = purchasingActionKey === `outbound:${shipment.reference}`;
@@ -214,6 +217,9 @@ export function BuyPostageStep({
                       </Typography>
                       <MarketDeltaChip comparison={marketComparison} hideWhenUnavailable />
                     </Stack>
+                    <Box sx={{ mt: 1 }}>
+                      <IntakeHistorySummary sourceOrders={shipmentSourceOrders} label="Shipment" compact />
+                    </Box>
                   </TableCell>
                   <TableCell>
                     <Typography variant="body2">{shipment.service}</Typography>

--- a/app/features/shipping-export/components/steps/PackStep.test.tsx
+++ b/app/features/shipping-export/components/steps/PackStep.test.tsx
@@ -262,12 +262,12 @@ const testCases: TestCase[] = [
         ],
       });
 
-      assert.match(html, />Market</);
-      assert.match(html, />vs Market</);
+      assert.match(html, />Current market</);
+      assert.match(html, />vs current market</);
       assert.match(html, /\$4\.00/);
       assert.match(html, /\+25\.0% \(\+\$1\.00\)/);
       assert.match(html, /Sold \$5\.00/);
-      assert.match(html, /Mkt \$4\.00/);
+      assert.match(html, /Current \$4\.00/);
       assert.match(html, /\+25\.0%/);
     },
   },
@@ -290,12 +290,23 @@ const testCases: TestCase[] = [
       });
 
       assert.match(html, />Sold</);
-      assert.match(html, />Market</);
+      assert.match(html, />Current market</);
       assert.match(html, /\$6\.00/);
       assert.match(html, /\$8\.00/);
       assert.match(html, /-25\.0%/);
-      assert.match(html, /No market/);
+      assert.match(html, /Current market unavailable/);
       assert.match(html, /1 of 2 lines priced/);
+    },
+  },
+  {
+    name: "PackStep keeps intake history available in card and list layouts",
+    run: () => {
+      const card = renderPackStep();
+      const list = renderPackStep({ initialViewMode: "list" });
+      assert.match(card, /Order intake market/);
+      assert.match(card, /Receipt lots and history status/);
+      assert.match(list, />Intake history</);
+      assert.match(list, /Shipment intake market/);
     },
   },
 ];

--- a/app/features/shipping-export/components/steps/PackStep.tsx
+++ b/app/features/shipping-export/components/steps/PackStep.tsx
@@ -40,6 +40,7 @@ import {
 } from "../../services/orderMarketComparison";
 import { getOrderNumbersForShipmentReference } from "../../services/shippingExportUtils";
 import { MarketDeltaChip } from "../MarketDeltaChip";
+import { IntakeHistorySummary } from "../IntakeHistorySummary";
 import type {
   PackPullSheetLoadStatus,
   PackPullSheetShipmentMatch,
@@ -500,6 +501,10 @@ export function PackStep({
                           </Box>
                         </Box>
 
+                        <Box sx={{ minWidth: 260, flex: "1 1 260px" }}>
+                          <IntakeHistorySummary sourceOrders={mergedOrders} label="Shipment" compact />
+                        </Box>
+
                         <Box sx={{ minWidth: 128 }}>
                           <Typography variant="body2" color="text.secondary">
                             Method
@@ -642,6 +647,7 @@ export function PackStep({
                                     items={orderPullSheetItems}
                                     priceBadgesBySku={priceBadgesBySku}
                                   />
+                                  <IntakeHistorySummary sourceOrders={[order]} label="Order" compact />
                                 </Stack>
                               </Box>
                             ),
@@ -690,6 +696,7 @@ export function PackStep({
                                   </Stack>
                                 </Stack>
                                 {renderFallbackPullSheetTable(fallbackRows)}
+                                <IntakeHistorySummary sourceOrders={[order]} label="Order" compact />
                               </Stack>
                             </Box>
                           ))}
@@ -719,6 +726,7 @@ export function PackStep({
                 <TableCell align="right">Items</TableCell>
                 <TableCell align="right">Value</TableCell>
                 <TableCell>vs Market</TableCell>
+                <TableCell>Intake history</TableCell>
                 <TableCell>Postage</TableCell>
               </TableRow>
             </TableHead>
@@ -791,6 +799,9 @@ export function PackStep({
                     </TableCell>
                     <TableCell>
                       <MarketDeltaChip comparison={compareOrdersToMarket(rowOrders)} />
+                    </TableCell>
+                    <TableCell sx={{ minWidth: 280 }}>
+                      <IntakeHistorySummary sourceOrders={rowOrders} label="Shipment" compact />
                     </TableCell>
                     <TableCell>
                       {purchase ? (

--- a/app/features/shipping-export/components/steps/PackStep.tsx
+++ b/app/features/shipping-export/components/steps/PackStep.tsx
@@ -150,6 +150,7 @@ function SkuIntakeFigures({ history }: { history: ShippingIntakeLineHistory | nu
     <Typography variant="caption">{history.priceKnownQuantity ? formatUsd(history.intakeMarketTotal ?? 0) : "Unavailable"}</Typography>
     <Typography variant="caption" color={history.status === "current" ? "text.secondary" : "warning.main"}>
       {history.priceKnownQuantity}/{history.orderedQuantity} priced · {history.weightedDaysHeld === null ? "age unavailable" : `${history.weightedDaysHeld.toFixed(1)} days`}
+      {` · ${history.dateKnownQuantity}/${history.orderedQuantity} dated`}
       {history.status === "current" ? "" : ` · ${history.status}`}
     </Typography>
   </Stack>;

--- a/app/features/shipping-export/components/steps/PackStep.tsx
+++ b/app/features/shipping-export/components/steps/PackStep.tsx
@@ -41,6 +41,7 @@ import {
 import { getOrderNumbersForShipmentReference } from "../../services/shippingExportUtils";
 import { MarketDeltaChip } from "../MarketDeltaChip";
 import { IntakeHistorySummary } from "../IntakeHistorySummary";
+import { shippingInventorySkuId } from "../../services/shippingOrderIdentity";
 import type {
   PackPullSheetLoadStatus,
   PackPullSheetShipmentMatch,
@@ -65,8 +66,16 @@ type FallbackRow = {
   intakeHistory: ShippingIntakeLineHistory | null;
 };
 
-function findLineForSku(lines: OrderLineItem[], skuId: number): OrderLineItem | undefined {
-  return lines.find((line) => line.skuId === skuId);
+function compareSkuQuantityToCurrentMarket(lines: OrderLineItem[], skuId: number, quantity: number): MarketComparison | null {
+  const matching = lines.filter((line) => line.skuId === skuId);
+  const totalQuantity = matching.reduce((sum, line) => sum + line.quantity, 0);
+  if (!totalQuantity) return null;
+  const soldPrice = matching.reduce((sum, line) => sum + line.unitPrice * line.quantity, 0) / totalQuantity;
+  const marketQuantity = matching.filter((line) => line.marketPrice !== undefined).reduce((sum, line) => sum + line.quantity, 0);
+  const marketPrice = marketQuantity === totalQuantity
+    ? matching.reduce((sum, line) => sum + (line.marketPrice ?? 0) * line.quantity, 0) / totalQuantity : undefined;
+  return compareLinesToMarket([{ name: matching[0]?.name ?? "", quantity, unitPrice: soldPrice,
+    ...(marketPrice === undefined ? {} : { marketPrice }) }]);
 }
 
 function buildPriceBadgesBySku(order: TcgPlayerShippingOrder): Record<number, PullSheetPriceBadge> {
@@ -101,7 +110,6 @@ function buildFallbackRowsFromPullSheet(
 ): FallbackRow[] {
   const shownHistory = new Set<string>();
   return items.map((item, index) => {
-    const line = findLineForSku(lines, item.skuId);
     const history = histories.get(String(item.skuId));
     const intakeHistory = history && !shownHistory.has(history.skuId) ? history : null;
     if (history) shownHistory.add(history.skuId);
@@ -110,35 +118,35 @@ function buildFallbackRowsFromPullSheet(
       key: `${orderNumber}-${item.skuId}-${index}`,
       name: item.productName,
       quantity: item.quantity,
-      comparison: line
-        ? compareLinesToMarket([{ ...line, quantity: item.quantity }])
-        : null,
+      comparison: compareSkuQuantityToCurrentMarket(lines, item.skuId, item.quantity),
       intakeHistory,
     };
   });
 }
 
 function buildFallbackRowsFromLines(orderNumber: string, lines: OrderLineItem[], histories: Map<string, ShippingIntakeLineHistory>): FallbackRow[] {
-  const linesByName = new Map<string, { index: number; lines: OrderLineItem[] }>();
+  const groups = new Map<string, { index: number; name: string; lines: OrderLineItem[] }>();
 
   lines.forEach((line, index) => {
-    const group = linesByName.get(line.name);
+    const identity = shippingInventorySkuId(line);
+    const key = identity ? `sku:${identity}` : `name:${line.name}`;
+    const group = groups.get(key);
 
     if (group) {
       group.lines.push(line);
       return;
     }
 
-    linesByName.set(line.name, { index, lines: [line] });
+    groups.set(key, { index, name: line.name, lines: [line] });
   });
 
   const shownHistory = new Set<string>();
-  return Array.from(linesByName.entries()).map(([name, group]) => {
-    const skuId = group.lines[0]?.inventorySkuId ?? (group.lines[0]?.skuId === undefined ? null : String(group.lines[0].skuId));
+  return Array.from(groups.values()).map((group) => {
+    const skuId = group.lines[0] ? shippingInventorySkuId(group.lines[0]) : null;
     const history = skuId ? histories.get(skuId) : undefined;
     const intakeHistory = history && !shownHistory.has(history.skuId) ? history : null;
     if (history) shownHistory.add(history.skuId);
-    return { key: `${orderNumber}-${name}-${group.index}`, name,
+    return { key: `${orderNumber}-${skuId ?? group.name}-${group.index}`, name: group.name,
       quantity: group.lines.reduce((sum, line) => sum + line.quantity, 0),
       comparison: compareLinesToMarket(group.lines), intakeHistory };
   });

--- a/app/features/shipping-export/components/steps/PackStep.tsx
+++ b/app/features/shipping-export/components/steps/PackStep.tsx
@@ -52,6 +52,7 @@ import type {
   OrderLineItem,
   ShipmentToOrderMap,
   ShippingPostagePurchaseEntry,
+  ShippingIntakeLineHistory,
   TcgPlayerShippingOrder,
 } from "../../types/shippingExport";
 
@@ -61,23 +62,31 @@ type FallbackRow = {
   quantity: number;
   /** Comparison for just this row, so sold and market cells can be shown per card. */
   comparison: MarketComparison | null;
+  intakeHistory: ShippingIntakeLineHistory | null;
 };
 
 function findLineForSku(lines: OrderLineItem[], skuId: number): OrderLineItem | undefined {
   return lines.find((line) => line.skuId === skuId);
 }
 
-function buildPriceBadgesBySku(lines: OrderLineItem[]): Record<number, PullSheetPriceBadge> {
+function buildPriceBadgesBySku(order: TcgPlayerShippingOrder): Record<number, PullSheetPriceBadge> {
   const badges: Record<number, PullSheetPriceBadge> = {};
-
-  for (const line of lines) {
-    if (line.skuId === undefined || badges[line.skuId]) {
-      continue;
-    }
-
-    badges[line.skuId] = {
-      soldPrice: line.unitPrice,
-      ...(line.marketPrice !== undefined ? { marketPrice: line.marketPrice } : {}),
+  const histories = new Map((order.intakeHistory?.lines ?? []).map((line) => [line.skuId, line]));
+  const grouped = new Map<number, { quantity: number; sold: number; marketQuantity: number; market: number }>();
+  for (const line of order.products ?? []) {
+    if (line.skuId === undefined) continue;
+    const value = grouped.get(line.skuId) ?? { quantity: 0, sold: 0, marketQuantity: 0, market: 0 };
+    value.quantity += line.quantity; value.sold += line.unitPrice * line.quantity;
+    if (line.marketPrice !== undefined) { value.marketQuantity += line.quantity; value.market += line.marketPrice * line.quantity; }
+    grouped.set(line.skuId, value);
+  }
+  for (const [sku, value] of grouped) {
+    const history = histories.get(String(sku));
+    badges[sku] = { soldPrice: value.sold / value.quantity,
+      ...(value.marketQuantity === value.quantity ? { marketPrice: value.market / value.quantity } : {}),
+      ...(history ? { intakeMarketTotal: history.intakeMarketTotal, intakeOrderedQuantity: history.orderedQuantity,
+        intakePriceKnownQuantity: history.priceKnownQuantity, intakeDateKnownQuantity: history.dateKnownQuantity,
+        intakeWeightedDaysHeld: history.weightedDaysHeld, intakeStatus: history.status } : {}),
     };
   }
 
@@ -88,9 +97,14 @@ function buildFallbackRowsFromPullSheet(
   orderNumber: string,
   items: PullSheetItem[],
   lines: OrderLineItem[],
+  histories: Map<string, ShippingIntakeLineHistory>,
 ): FallbackRow[] {
+  const shownHistory = new Set<string>();
   return items.map((item, index) => {
     const line = findLineForSku(lines, item.skuId);
+    const history = histories.get(String(item.skuId));
+    const intakeHistory = history && !shownHistory.has(history.skuId) ? history : null;
+    if (history) shownHistory.add(history.skuId);
 
     return {
       key: `${orderNumber}-${item.skuId}-${index}`,
@@ -99,11 +113,12 @@ function buildFallbackRowsFromPullSheet(
       comparison: line
         ? compareLinesToMarket([{ ...line, quantity: item.quantity }])
         : null,
+      intakeHistory,
     };
   });
 }
 
-function buildFallbackRowsFromLines(orderNumber: string, lines: OrderLineItem[]): FallbackRow[] {
+function buildFallbackRowsFromLines(orderNumber: string, lines: OrderLineItem[], histories: Map<string, ShippingIntakeLineHistory>): FallbackRow[] {
   const linesByName = new Map<string, { index: number; lines: OrderLineItem[] }>();
 
   lines.forEach((line, index) => {
@@ -117,12 +132,27 @@ function buildFallbackRowsFromLines(orderNumber: string, lines: OrderLineItem[])
     linesByName.set(line.name, { index, lines: [line] });
   });
 
-  return Array.from(linesByName.entries()).map(([name, group]) => ({
-    key: `${orderNumber}-${name}-${group.index}`,
-    name,
-    quantity: group.lines.reduce((sum, line) => sum + line.quantity, 0),
-    comparison: compareLinesToMarket(group.lines),
-  }));
+  const shownHistory = new Set<string>();
+  return Array.from(linesByName.entries()).map(([name, group]) => {
+    const skuId = group.lines[0]?.inventorySkuId ?? (group.lines[0]?.skuId === undefined ? null : String(group.lines[0].skuId));
+    const history = skuId ? histories.get(skuId) : undefined;
+    const intakeHistory = history && !shownHistory.has(history.skuId) ? history : null;
+    if (history) shownHistory.add(history.skuId);
+    return { key: `${orderNumber}-${name}-${group.index}`, name,
+      quantity: group.lines.reduce((sum, line) => sum + line.quantity, 0),
+      comparison: compareLinesToMarket(group.lines), intakeHistory };
+  });
+}
+
+function SkuIntakeFigures({ history }: { history: ShippingIntakeLineHistory | null }) {
+  if (!history) return <Typography variant="caption" color="text.secondary">—</Typography>;
+  return <Stack spacing={0.25}>
+    <Typography variant="caption">{history.priceKnownQuantity ? formatUsd(history.intakeMarketTotal ?? 0) : "Unavailable"}</Typography>
+    <Typography variant="caption" color={history.status === "current" ? "text.secondary" : "warning.main"}>
+      {history.priceKnownQuantity}/{history.orderedQuantity} priced · {history.weightedDaysHeld === null ? "age unavailable" : `${history.weightedDaysHeld.toFixed(1)} days`}
+      {history.status === "current" ? "" : ` · ${history.status}`}
+    </Typography>
+  </Stack>;
 }
 
 function MarketFigure({
@@ -165,6 +195,7 @@ interface PackStepProps {
   onOrderPacked: (reference: string, packed: boolean) => void;
   onBack: () => void;
   onContinue: () => void;
+  initialViewMode?: ViewMode;
 }
 
 type ViewMode = "card" | "list";
@@ -181,9 +212,10 @@ export function PackStep({
   onOrderPacked,
   onBack,
   onContinue,
+  initialViewMode = "card",
 }: PackStepProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [viewMode, setViewMode] = useState<ViewMode>("card");
+  const [viewMode, setViewMode] = useState<ViewMode>(initialViewMode);
 
   const totalShipments = shipmentReferences.length;
   const currentReference = shipmentReferences[currentIndex] ?? null;
@@ -229,8 +261,9 @@ export function PackStep({
               <TableCell>Card</TableCell>
               <TableCell align="right">Qty</TableCell>
               <TableCell align="right">Sold</TableCell>
-              <TableCell align="right">Market</TableCell>
-              <TableCell align="right">vs Market</TableCell>
+              <TableCell align="right">Current market</TableCell>
+              <TableCell align="right">vs current market</TableCell>
+              <TableCell>SKU intake market / age</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -249,6 +282,7 @@ export function PackStep({
                 <TableCell align="right">
                   {row.comparison ? <MarketDeltaChip comparison={row.comparison} /> : "-"}
                 </TableCell>
+                <TableCell><SkuIntakeFigures history={row.intakeHistory} /></TableCell>
               </TableRow>
             ))}
           </TableBody>
@@ -263,17 +297,18 @@ export function PackStep({
       order["Order #"],
     );
     const orderLineItems = order.products ?? [];
+    const histories = new Map((order.intakeHistory?.lines ?? []).map((line) => [line.skuId, line]));
     const fallbackRows =
       orderPullSheetItems.length > 0
-        ? buildFallbackRowsFromPullSheet(order["Order #"], orderPullSheetItems, orderLineItems)
-        : buildFallbackRowsFromLines(order["Order #"], orderLineItems);
+        ? buildFallbackRowsFromPullSheet(order["Order #"], orderPullSheetItems, orderLineItems, histories)
+        : buildFallbackRowsFromLines(order["Order #"], orderLineItems, histories);
 
     return {
       order,
       orderPullSheetItems,
       fallbackRows,
       comparison: compareOrderToMarket(order),
-      priceBadgesBySku: buildPriceBadgesBySku(orderLineItems),
+      priceBadgesBySku: buildPriceBadgesBySku(order),
     };
   });
 
@@ -490,11 +525,11 @@ export function PackStep({
                           </Typography>
                         </Box>
 
-                        <MarketFigure label="Market" comparison={shipmentComparison} />
+                        <MarketFigure label="Current market" comparison={shipmentComparison} />
 
                         <Box sx={{ minWidth: 128 }}>
                           <Typography variant="body2" color="text.secondary">
-                            vs Market
+                            vs current market
                           </Typography>
                           <Box sx={{ mt: 0.25 }}>
                             <MarketDeltaChip comparison={shipmentComparison} showAmount />
@@ -725,7 +760,7 @@ export function PackStep({
                 <TableCell>Method</TableCell>
                 <TableCell align="right">Items</TableCell>
                 <TableCell align="right">Value</TableCell>
-                <TableCell>vs Market</TableCell>
+                <TableCell>vs current market</TableCell>
                 <TableCell>Intake history</TableCell>
                 <TableCell>Postage</TableCell>
               </TableRow>

--- a/app/features/shipping-export/components/steps/PullSheetStep.test.tsx
+++ b/app/features/shipping-export/components/steps/PullSheetStep.test.tsx
@@ -127,6 +127,8 @@ const testCases: TestCase[] = [
       const html = renderPullSheetStep();
 
       assert.match(html, /Pull Sheet Workspace/);
+      assert.match(html, /Pull sheet intake market/);
+      assert.match(html, /Receipt lots and history status/);
       assert.match(html, /Card View/);
       assert.match(html, /Grid View/);
       assert.match(html, /12345_in_400x400\.jpg/);

--- a/app/features/shipping-export/components/steps/PullSheetStep.tsx
+++ b/app/features/shipping-export/components/steps/PullSheetStep.tsx
@@ -24,6 +24,7 @@ import type {
   TcgPlayerShippingOrder,
 } from "../../types/shippingExport";
 import { MarketDeltaChip } from "../MarketDeltaChip";
+import { IntakeHistorySummary } from "../IntakeHistorySummary";
 
 interface PullSheetStepProps {
   sourceOrders: TcgPlayerShippingOrder[];
@@ -132,6 +133,10 @@ export function PullSheetStep({
           <Chip label={`${parcelCount} Parcel`} size="small" variant="outlined" />
         )}
       </Stack>
+
+      <Paper variant="outlined" sx={{ p: 2 }}>
+        <IntakeHistorySummary sourceOrders={sourceOrders} label="Pull sheet" compact />
+      </Paper>
 
       <Paper variant="outlined" sx={{ p: 2.5 }}>
         <Stack spacing={2}>

--- a/app/features/shipping-export/routes/api.shipping-export-intake-history.server.ts
+++ b/app/features/shipping-export/routes/api.shipping-export-intake-history.server.ts
@@ -11,15 +11,17 @@ function parseOrders(value: unknown): ShippingIntakeHistoryRequestOrder[] {
     if (!item || typeof item !== "object") throw new Error("Each history order must be an object.");
     const order = item as Partial<ShippingIntakeHistoryRequestOrder>;
     if (typeof order.orderNumber !== "string" || !order.orderNumber.trim() || typeof order.orderDate !== "string"
-      || !Number.isInteger(order.itemCount) || (order.itemCount ?? -1) < 0 || !Array.isArray(order.products)) throw new Error("History order identity is incomplete.");
+      || !Number.isInteger(order.itemCount) || (order.itemCount ?? -1) < 0 || !Number.isFinite(order.valueOfProducts)
+      || !Array.isArray(order.products)) throw new Error("History order identity is incomplete.");
     const products = order.products.map((product) => {
       if (!product || typeof product !== "object") throw new Error("History product identity is incomplete.");
       const line = product as ShippingIntakeHistoryRequestOrder["products"][number];
-      if (!Number.isInteger(line.quantity) || line.quantity <= 0
+      if (!Number.isInteger(line.quantity) || line.quantity <= 0 || !Number.isFinite(line.unitPrice)
         || (line.skuId === undefined && typeof line.inventorySkuId !== "string")) throw new Error("History product identity is incomplete.");
       return line;
     });
-    return { orderNumber: order.orderNumber.trim(), orderDate: order.orderDate, itemCount: order.itemCount as number, products };
+    return { orderNumber: order.orderNumber.trim(), orderDate: order.orderDate, itemCount: order.itemCount as number,
+      valueOfProducts: order.valueOfProducts as number, products };
   });
 }
 
@@ -39,10 +41,10 @@ export function createShippingIntakeHistoryAction(dependencies: {
       if (!sellerKey) return data({ error: "A configured seller key is required to refresh intake history." }, { status: 400 });
       if (requestedSeller && requestedSeller !== sellerKey) return data({ error: "The intake history seller does not match Shipping Configuration." }, { status: 403 });
       const orders = parseOrders(payload.orders).map<TcgPlayerShippingOrder>((order) => ({
-        "Order #": order.orderNumber, "Order Date": order.orderDate, "Value Of Products": 0,
+        "Order #": order.orderNumber, "Order Date": order.orderDate, "Value Of Products": order.valueOfProducts,
         FirstName: "", LastName: "", Address1: "", Address2: "", City: "", State: "", PostalCode: "",
         Country: "US", "Product Weight": 0, "Shipping Method": "Standard", "Item Count": order.itemCount,
-        "Shipping Fee Paid": 0, "Tracking #": "", Carrier: "", products: order.products.map((line) => ({ name: "", unitPrice: 0, ...line })),
+        "Shipping Fee Paid": 0, "Tracking #": "", Carrier: "", products: order.products.map((line) => ({ name: "", ...line })),
       }));
       const enriched = await enrich(orders, sellerKey);
       return data({ histories: enriched.flatMap((order) => order.intakeHistory ? [order.intakeHistory] : []) });

--- a/app/features/shipping-export/routes/api.shipping-export-intake-history.server.ts
+++ b/app/features/shipping-export/routes/api.shipping-export-intake-history.server.ts
@@ -1,0 +1,53 @@
+import { data } from "react-router";
+import { getShippingExportConfig } from "../config/shippingExportConfig.server";
+import { enrichShippingOrdersWithIntakeHistory } from "../services/shippingIntakeHistory.server";
+import type { ShippingIntakeHistoryRequestOrder, TcgPlayerShippingOrder } from "../types/shippingExport";
+
+const MAX_ORDERS = 500;
+
+function parseOrders(value: unknown): ShippingIntakeHistoryRequestOrder[] {
+  if (!Array.isArray(value) || value.length > MAX_ORDERS) throw new Error(`Orders must contain at most ${MAX_ORDERS} items.`);
+  return value.map((item) => {
+    if (!item || typeof item !== "object") throw new Error("Each history order must be an object.");
+    const order = item as Partial<ShippingIntakeHistoryRequestOrder>;
+    if (typeof order.orderNumber !== "string" || !order.orderNumber.trim() || typeof order.orderDate !== "string"
+      || !Number.isInteger(order.itemCount) || (order.itemCount ?? -1) < 0 || !Array.isArray(order.products)) throw new Error("History order identity is incomplete.");
+    const products = order.products.map((product) => {
+      if (!product || typeof product !== "object") throw new Error("History product identity is incomplete.");
+      const line = product as ShippingIntakeHistoryRequestOrder["products"][number];
+      if (!Number.isInteger(line.quantity) || line.quantity <= 0
+        || (line.skuId === undefined && typeof line.inventorySkuId !== "string")) throw new Error("History product identity is incomplete.");
+      return line;
+    });
+    return { orderNumber: order.orderNumber.trim(), orderDate: order.orderDate, itemCount: order.itemCount as number, products };
+  });
+}
+
+export function createShippingIntakeHistoryAction(dependencies: {
+  getConfig?: typeof getShippingExportConfig;
+  enrich?: typeof enrichShippingOrdersWithIntakeHistory;
+} = {}) {
+  const getConfig = dependencies.getConfig ?? getShippingExportConfig;
+  const enrich = dependencies.enrich ?? enrichShippingOrdersWithIntakeHistory;
+  return async ({ request }: { request: Request }) => {
+    if (request.method !== "POST") return data({ error: "Method not allowed" }, { status: 405 });
+    try {
+      const payload = await request.json() as { sellerKey?: unknown; orders?: unknown };
+      const config = await getConfig();
+      const sellerKey = config.defaultSellerKey.trim();
+      const requestedSeller = typeof payload.sellerKey === "string" ? payload.sellerKey.trim() : "";
+      if (!sellerKey) return data({ error: "A configured seller key is required to refresh intake history." }, { status: 400 });
+      if (requestedSeller && requestedSeller !== sellerKey) return data({ error: "The intake history seller does not match Shipping Configuration." }, { status: 403 });
+      const orders = parseOrders(payload.orders).map<TcgPlayerShippingOrder>((order) => ({
+        "Order #": order.orderNumber, "Order Date": order.orderDate, "Value Of Products": 0,
+        FirstName: "", LastName: "", Address1: "", Address2: "", City: "", State: "", PostalCode: "",
+        Country: "US", "Product Weight": 0, "Shipping Method": "Standard", "Item Count": order.itemCount,
+        "Shipping Fee Paid": 0, "Tracking #": "", Carrier: "", products: order.products.map((line) => ({ name: "", unitPrice: 0, ...line })),
+      }));
+      const enriched = await enrich(orders, sellerKey);
+      return data({ histories: enriched.flatMap((order) => order.intakeHistory ? [order.intakeHistory] : []) });
+    } catch (error) {
+      return data({ error: String(error) }, { status: 400 });
+    }
+  };
+}

--- a/app/features/shipping-export/routes/api.shipping-export-intake-history.server.ts
+++ b/app/features/shipping-export/routes/api.shipping-export-intake-history.server.ts
@@ -12,12 +12,13 @@ function parseOrders(value: unknown): ShippingIntakeHistoryRequestOrder[] {
     const order = item as Partial<ShippingIntakeHistoryRequestOrder>;
     if (typeof order.orderNumber !== "string" || !order.orderNumber.trim() || typeof order.orderDate !== "string"
       || !Number.isInteger(order.itemCount) || (order.itemCount ?? -1) < 0 || !Number.isFinite(order.valueOfProducts)
+      || (order.valueOfProducts ?? -1) < 0
       || !Array.isArray(order.products)) throw new Error("History order identity is incomplete.");
     const products = order.products.map((product) => {
       if (!product || typeof product !== "object") throw new Error("History product identity is incomplete.");
       const line = product as ShippingIntakeHistoryRequestOrder["products"][number];
-      if (!Number.isInteger(line.quantity) || line.quantity <= 0 || !Number.isFinite(line.unitPrice)
-        || (line.skuId === undefined && typeof line.inventorySkuId !== "string")) throw new Error("History product identity is incomplete.");
+      if (!Number.isInteger(line.quantity) || line.quantity <= 0 || !Number.isFinite(line.unitPrice) || line.unitPrice < 0)
+        throw new Error("History product quantity or sale value is incomplete.");
       return line;
     });
     return { orderNumber: order.orderNumber.trim(), orderDate: order.orderDate, itemCount: order.itemCount as number,

--- a/app/features/shipping-export/routes/api.shipping-export-intake-history.test.ts
+++ b/app/features/shipping-export/routes/api.shipping-export-intake-history.test.ts
@@ -24,6 +24,13 @@ const success = await createShippingIntakeHistoryAction({ getConfig: configured,
 assert.equal(success.init?.status ?? 200, 200);
 assert.deepEqual(success.data, { histories: [{ orderNumber: "A", sellerKey: "seller-a", refreshedAt: "now", lines: [] }] });
 
+const unidentified = await createShippingIntakeHistoryAction({ getConfig: configured, enrich: async (orders) => {
+  assert.equal(orders[0]?.products?.[0]?.skuId, undefined);
+  return [];
+} })({ request: request({ sellerKey: "seller-a", orders: [{ ...order,
+  products: [{ quantity: 1, unitPrice: 5 }] }] }) });
+assert.equal(unidentified.init?.status ?? 200, 200);
+
 const oversized = await createShippingIntakeHistoryAction({ getConfig: configured, enrich: async () => [] })(
   { request: request({ sellerKey: "seller-a", orders: Array.from({ length: 501 }, () => order) }) },
 );

--- a/app/features/shipping-export/routes/api.shipping-export-intake-history.test.ts
+++ b/app/features/shipping-export/routes/api.shipping-export-intake-history.test.ts
@@ -19,10 +19,10 @@ assert.equal(called, false);
 const success = await createShippingIntakeHistoryAction({ getConfig: configured, enrich: async (orders, sellerKey) => {
   assert.equal(sellerKey, "seller-a");
   assert.equal(orders[0]?.FirstName, "");
-  return orders.map((value) => ({ ...value, intakeHistory: { orderNumber: value["Order #"], refreshedAt: "now", lines: [] } }));
+  return orders.map((value) => ({ ...value, intakeHistory: { orderNumber: value["Order #"], sellerKey, refreshedAt: "now", lines: [] } }));
 } })({ request: request({ sellerKey: "seller-a", orders: [order] }) });
 assert.equal(success.init?.status ?? 200, 200);
-assert.deepEqual(success.data, { histories: [{ orderNumber: "A", refreshedAt: "now", lines: [] }] });
+assert.deepEqual(success.data, { histories: [{ orderNumber: "A", sellerKey: "seller-a", refreshedAt: "now", lines: [] }] });
 
 const oversized = await createShippingIntakeHistoryAction({ getConfig: configured, enrich: async () => [] })(
   { request: request({ sellerKey: "seller-a", orders: Array.from({ length: 501 }, () => order) }) },

--- a/app/features/shipping-export/routes/api.shipping-export-intake-history.test.ts
+++ b/app/features/shipping-export/routes/api.shipping-export-intake-history.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { createShippingIntakeHistoryAction } from "./api.shipping-export-intake-history.server";
+import { DEFAULT_SHIPPING_EXPORT_CONFIG } from "../types/shippingExport";
+
+const configured = async () => ({ ...DEFAULT_SHIPPING_EXPORT_CONFIG, defaultSellerKey: "seller-a" });
+const request = (body: unknown) => new Request("http://localhost/api/shipping-export/intake-history", {
+  method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
+});
+const order = { orderNumber: "A", orderDate: "2026-08-01T12:00:00.000Z", itemCount: 1,
+  products: [{ inventorySkuId: "9001", skuId: 9001, quantity: 1 }] };
+
+let called = false;
+const mismatched = await createShippingIntakeHistoryAction({ getConfig: configured, enrich: async () => {
+  called = true; return [];
+} })({ request: request({ sellerKey: "seller-b", orders: [order] }) });
+assert.equal(mismatched.init?.status, 403);
+assert.equal(called, false);
+
+const success = await createShippingIntakeHistoryAction({ getConfig: configured, enrich: async (orders, sellerKey) => {
+  assert.equal(sellerKey, "seller-a");
+  assert.equal(orders[0]?.FirstName, "");
+  return orders.map((value) => ({ ...value, intakeHistory: { orderNumber: value["Order #"], refreshedAt: "now", lines: [] } }));
+} })({ request: request({ sellerKey: "seller-a", orders: [order] }) });
+assert.equal(success.init?.status ?? 200, 200);
+assert.deepEqual(success.data, { histories: [{ orderNumber: "A", refreshedAt: "now", lines: [] }] });
+
+const oversized = await createShippingIntakeHistoryAction({ getConfig: configured, enrich: async () => [] })(
+  { request: request({ sellerKey: "seller-a", orders: Array.from({ length: 501 }, () => order) }) },
+);
+assert.equal(oversized.init?.status, 400);
+
+console.log("PASS shipping intake history route binds the configured seller and bounds local bulk refreshes");

--- a/app/features/shipping-export/routes/api.shipping-export-intake-history.test.ts
+++ b/app/features/shipping-export/routes/api.shipping-export-intake-history.test.ts
@@ -7,7 +7,7 @@ const request = (body: unknown) => new Request("http://localhost/api/shipping-ex
   method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body),
 });
 const order = { orderNumber: "A", orderDate: "2026-08-01T12:00:00.000Z", itemCount: 1,
-  products: [{ inventorySkuId: "9001", skuId: 9001, quantity: 1 }] };
+  valueOfProducts: 5, products: [{ inventorySkuId: "9001", skuId: 9001, quantity: 1, unitPrice: 5 }] };
 
 let called = false;
 const mismatched = await createShippingIntakeHistoryAction({ getConfig: configured, enrich: async () => {

--- a/app/features/shipping-export/routes/api.shipping-export-intake-history.ts
+++ b/app/features/shipping-export/routes/api.shipping-export-intake-history.ts
@@ -1,0 +1,3 @@
+import { createShippingIntakeHistoryAction } from "./api.shipping-export-intake-history.server";
+
+export const action = createShippingIntakeHistoryAction();

--- a/app/features/shipping-export/routes/api.shipping-export-tcgplayer-orders.server.ts
+++ b/app/features/shipping-export/routes/api.shipping-export-tcgplayer-orders.server.ts
@@ -47,9 +47,14 @@ export function createShippingTcgplayerOrdersAction(
 
   async function attachIntakeHistory<T extends { orders: Awaited<ReturnType<typeof loadSellerShippingOrders>>["orders"]; warnings?: string[] }>(
     sellerKey: string,
+    configuredSellerKey: string,
     response: T,
   ) {
     if (!enrichIntakeHistory) return response;
+    if (!configuredSellerKey || sellerKey !== configuredSellerKey) return {
+      ...response,
+      warnings: [...(response.warnings ?? []), "Intake history is unavailable because this order load does not match the configured seller."],
+    };
     try {
       return { ...response, orders: await enrichIntakeHistory(response.orders, sellerKey) };
     } catch (error) {
@@ -86,12 +91,12 @@ export function createShippingTcgplayerOrdersAction(
 
       if (providedOrderNumber) {
         const response = await loadSingleOrder(sellerKey, providedOrderNumber);
-        const withIntake = await attachIntakeHistory(sellerKey, response);
+        const withIntake = await attachIntakeHistory(sellerKey, config.defaultSellerKey.trim(), response);
         return data(await attachHistoryCoverage(sellerKey, withIntake), { status: 200 });
       }
 
       const response = await loadOrders(sellerKey);
-      const withIntake = await attachIntakeHistory(sellerKey, response);
+      const withIntake = await attachIntakeHistory(sellerKey, config.defaultSellerKey.trim(), response);
       return data(await attachHistoryCoverage(sellerKey, withIntake), { status: 200 });
     } catch (error) {
       return data({ error: String(error) }, { status: 500 });

--- a/app/features/shipping-export/routes/api.shipping-export-tcgplayer-orders.server.ts
+++ b/app/features/shipping-export/routes/api.shipping-export-tcgplayer-orders.server.ts
@@ -5,12 +5,14 @@ import {
   loadSingleSellerShippingOrder,
 } from "../services/tcgplayerSellerOrders.server";
 import { sellerOrderHistoryRepository } from "~/core/db";
+import { enrichShippingOrdersWithIntakeHistory } from "../services/shippingIntakeHistory.server";
 
 type ShippingTcgplayerOrdersActionDependencies = {
   getShippingExportConfig?: typeof getShippingExportConfig;
   loadSellerShippingOrders?: typeof loadSellerShippingOrders;
   loadSingleSellerShippingOrder?: typeof loadSingleSellerShippingOrder;
   getHistoryCoverage?: typeof sellerOrderHistoryRepository.getCoverage;
+  enrichIntakeHistory?: typeof enrichShippingOrdersWithIntakeHistory;
 };
 
 export function createShippingTcgplayerOrdersAction(
@@ -23,6 +25,7 @@ export function createShippingTcgplayerOrdersAction(
   const loadSingleOrder =
     dependencies.loadSingleSellerShippingOrder ?? loadSingleSellerShippingOrder;
   const getHistoryCoverage = dependencies.getHistoryCoverage;
+  const enrichIntakeHistory = dependencies.enrichIntakeHistory;
 
   async function attachHistoryCoverage<T extends { warnings?: string[] }>(
     sellerKey: string,
@@ -39,6 +42,18 @@ export function createShippingTcgplayerOrdersAction(
           `Seller order history status is unavailable: ${String(error)}`,
         ],
       };
+    }
+  }
+
+  async function attachIntakeHistory<T extends { orders: Awaited<ReturnType<typeof loadSellerShippingOrders>>["orders"]; warnings?: string[] }>(
+    sellerKey: string,
+    response: T,
+  ) {
+    if (!enrichIntakeHistory) return response;
+    try {
+      return { ...response, orders: await enrichIntakeHistory(response.orders, sellerKey) };
+    } catch (error) {
+      return { ...response, warnings: [...(response.warnings ?? []), `Intake history is unavailable: ${String(error)}`] };
     }
   }
 
@@ -71,11 +86,13 @@ export function createShippingTcgplayerOrdersAction(
 
       if (providedOrderNumber) {
         const response = await loadSingleOrder(sellerKey, providedOrderNumber);
-        return data(await attachHistoryCoverage(sellerKey, response), { status: 200 });
+        const withIntake = await attachIntakeHistory(sellerKey, response);
+        return data(await attachHistoryCoverage(sellerKey, withIntake), { status: 200 });
       }
 
       const response = await loadOrders(sellerKey);
-      return data(await attachHistoryCoverage(sellerKey, response), { status: 200 });
+      const withIntake = await attachIntakeHistory(sellerKey, response);
+      return data(await attachHistoryCoverage(sellerKey, withIntake), { status: 200 });
     } catch (error) {
       return data({ error: String(error) }, { status: 500 });
     }

--- a/app/features/shipping-export/routes/api.shipping-export-tcgplayer-orders.ts
+++ b/app/features/shipping-export/routes/api.shipping-export-tcgplayer-orders.ts
@@ -1,6 +1,8 @@
 import { createShippingTcgplayerOrdersAction } from "./api.shipping-export-tcgplayer-orders.server";
 import { sellerOrderHistoryRepository } from "~/core/db";
+import { enrichShippingOrdersWithIntakeHistory } from "../services/shippingIntakeHistory.server";
 
 export const action = createShippingTcgplayerOrdersAction({
   getHistoryCoverage: (sellerKey) => sellerOrderHistoryRepository.getCoverage(sellerKey),
+  enrichIntakeHistory: enrichShippingOrdersWithIntakeHistory,
 });

--- a/app/features/shipping-export/routes/shipping-export.tsx
+++ b/app/features/shipping-export/routes/shipping-export.tsx
@@ -267,6 +267,9 @@ export default function ShippingExportRoute() {
   const postageLookupSequenceRef = useRef(0);
   /** Fences saved restore and remote loads so an older response cannot replace a newer order source. */
   const orderSourceSequenceRef = useRef(0);
+  const intakeRefreshSequenceRef = useRef(0);
+  const sourceOrdersRef = useRef(sourceOrders);
+  sourceOrdersRef.current = sourceOrders;
 
   // ── Derived values ────────────────────────────────────────────────────────
   const availableLabelSizes = getAllLabelSizes().filter((labelSize) =>
@@ -414,6 +417,7 @@ export default function ShippingExportRoute() {
   ): Promise<boolean> => {
     if (expectedSequence !== undefined && expectedSequence !== orderSourceSequenceRef.current) return Promise.resolve(false);
     if (expectedSequence === undefined) orderSourceSequenceRef.current += 1;
+    intakeRefreshSequenceRef.current += 1;
     const nextState = buildShippingWorkflowOrderState(nextSourceOrders, config);
 
     setSourceOrders(nextState.sourceOrders);
@@ -474,12 +478,14 @@ export default function ShippingExportRoute() {
 
     let restoredOrders = withoutShippingIntakeHistory(saved.sourceOrders);
     const restoredWarnings = [...saved.loadWarnings];
+    const refreshSequence = ++intakeRefreshSequenceRef.current;
     try {
       const configuredSeller = config.defaultSellerKey.trim();
       if (!configuredSeller || saved.sellerKey.trim() !== configuredSeller) {
         throw new Error("The saved workflow seller does not match Shipping Configuration.");
       }
       restoredOrders = await refreshShippingIntakeHistory(saved.sourceOrders, configuredSeller);
+      if (refreshSequence !== intakeRefreshSequenceRef.current) throw new Error("A newer intake history refresh replaced this one.");
     } catch (historyError) {
       restoredWarnings.push(`Saved intake history was cleared because it could not be refreshed: ${String(historyError)}`);
     }
@@ -514,17 +520,19 @@ export default function ShippingExportRoute() {
 
   useEffect(() => {
     if (!sourceOrders.length) return;
-    const expectedOrders = sourceOrders.map((order) => order["Order #"]).join("|");
     const refresh = async () => {
+      const sourceSnapshot = sourceOrdersRef.current;
+      const expectedOrders = sourceSnapshot.map((order) => order["Order #"]).join("|");
       const expectedSequence = orderSourceSequenceRef.current;
+      const refreshSequence = ++intakeRefreshSequenceRef.current;
       try {
-        const refreshed = await refreshShippingIntakeHistory(sourceOrders, config.defaultSellerKey.trim());
-        if (expectedSequence !== orderSourceSequenceRef.current) return;
+        const refreshed = await refreshShippingIntakeHistory(sourceSnapshot, sellerKeyInput.trim());
+        if (expectedSequence !== orderSourceSequenceRef.current || refreshSequence !== intakeRefreshSequenceRef.current) return;
         setSourceOrders((current) => current.map((order) => order["Order #"]).join("|") === expectedOrders ? refreshed : current);
         const histories = new Map(refreshed.map((order) => [order["Order #"], order.intakeHistory]));
         setOrders((current) => current.map((order) => ({ ...order, intakeHistory: histories.get(order["Order #"]) })));
       } catch (refreshError) {
-        if (expectedSequence !== orderSourceSequenceRef.current) return;
+        if (expectedSequence !== orderSourceSequenceRef.current || refreshSequence !== intakeRefreshSequenceRef.current) return;
         setSourceOrders((current) => current.map((order) => order["Order #"]).join("|") === expectedOrders
           ? withoutShippingIntakeHistory(current) : current);
         setOrders((current) => withoutShippingIntakeHistory(current));
@@ -536,7 +544,7 @@ export default function ShippingExportRoute() {
     window.addEventListener("focus", onFocus);
     const interval = window.setInterval(() => void refresh(), 5 * 60_000);
     return () => { window.removeEventListener("focus", onFocus); window.clearInterval(interval); };
-  }, [config.defaultSellerKey, sourceOrderNumbersKey]);
+  }, [sellerKeyInput, sourceOrderNumbersKey]);
 
   // ── Handlers: load orders ─────────────────────────────────────────────────
   useEffect(() => {
@@ -713,6 +721,7 @@ export default function ShippingExportRoute() {
     payload: { action: "catch_up"; orderNumbers: string[] } | { action: "import_csv"; csvText: string; fileName: string },
   ) => {
     const sourceSequence = orderSourceSequenceRef.current;
+    const refreshSequence = ++intakeRefreshSequenceRef.current;
     setIsUpdatingHistory(true);
     setError(null);
     try {
@@ -728,12 +737,13 @@ export default function ShippingExportRoute() {
       setHistoryCoverage(result.coverage);
       if (sourceOrders.length && sourceSequence === orderSourceSequenceRef.current) {
         try {
-          const refreshed = await refreshShippingIntakeHistory(sourceOrders, config.defaultSellerKey.trim());
-          if (sourceSequence !== orderSourceSequenceRef.current) return;
+          const refreshed = await refreshShippingIntakeHistory(sourceOrders, sellerKeyInput.trim());
+          if (sourceSequence !== orderSourceSequenceRef.current || refreshSequence !== intakeRefreshSequenceRef.current) return;
           const histories = new Map(refreshed.map((order) => [order["Order #"], order.intakeHistory]));
           setSourceOrders(refreshed);
           setOrders((current) => current.map((order) => ({ ...order, intakeHistory: histories.get(order["Order #"]) })));
         } catch (refreshError) {
+          if (sourceSequence !== orderSourceSequenceRef.current || refreshSequence !== intakeRefreshSequenceRef.current) return;
           setSourceOrders((current) => withoutShippingIntakeHistory(current));
           setOrders((current) => withoutShippingIntakeHistory(current));
           setLoadWarnings((current) => [...current, `Intake history is unavailable after catch-up: ${String(refreshError)}`]);

--- a/app/features/shipping-export/routes/shipping-export.tsx
+++ b/app/features/shipping-export/routes/shipping-export.tsx
@@ -77,6 +77,7 @@ import { ApplyTrackingStep } from "../components/steps/ApplyTrackingStep";
 import { NotifyStep } from "../components/steps/NotifyStep";
 import { ReturnFlowPanel } from "../components/ReturnFlowPanel";
 import type { SellerOrderCoverage } from "~/features/seller-order-history/types/sellerOrderHistory";
+import { refreshShippingIntakeHistory, withoutShippingIntakeHistory } from "../services/shippingIntakeHistory";
 
 const OUTBOUND_STEPS = [
   { key: "load-orders", label: "Load Orders" },
@@ -264,6 +265,8 @@ export default function ShippingExportRoute() {
 
   /** Only the newest postage lookup may write results, so a slow older one cannot overwrite them. */
   const postageLookupSequenceRef = useRef(0);
+  /** Fences saved restore and remote loads so an older response cannot replace a newer order source. */
+  const orderSourceSequenceRef = useRef(0);
 
   // ── Derived values ────────────────────────────────────────────────────────
   const availableLabelSizes = getAllLabelSizes().filter((labelSize) =>
@@ -275,6 +278,7 @@ export default function ShippingExportRoute() {
   );
   const shipmentReferencesKey = shipmentReferences.join("|");
   const orderedWorkflowOrderNumbersKey = orderedWorkflowOrderNumbers.join("|");
+  const sourceOrderNumbersKey = sourceOrders.map((order) => order["Order #"]).join("|");
   const hasPackPullSheetSourceData = sourceOrders.some(
     (order) => (order.products?.length ?? 0) > 0,
   );
@@ -406,7 +410,10 @@ export default function ShippingExportRoute() {
     nextSourceOrders: TcgPlayerShippingOrder[],
     nextSourceLabel: string,
     nextWarnings: string[] = [],
+    expectedSequence?: number,
   ): Promise<boolean> => {
+    if (expectedSequence !== undefined && expectedSequence !== orderSourceSequenceRef.current) return Promise.resolve(false);
+    if (expectedSequence === undefined) orderSourceSequenceRef.current += 1;
     const nextState = buildShippingWorkflowOrderState(nextSourceOrders, config);
 
     setSourceOrders(nextState.sourceOrders);
@@ -460,16 +467,33 @@ export default function ShippingExportRoute() {
   );
 
   const restoreSavedWorkflow = async (saved: SavedShippingWorkflow) => {
+    const restoreSequence = ++orderSourceSequenceRef.current;
     if (saved.sellerKey) {
       setSellerKeyInput(saved.sellerKey);
+    }
+
+    let restoredOrders = withoutShippingIntakeHistory(saved.sourceOrders);
+    const restoredWarnings = [...saved.loadWarnings];
+    try {
+      const configuredSeller = config.defaultSellerKey.trim();
+      if (!configuredSeller || saved.sellerKey.trim() !== configuredSeller) {
+        throw new Error("The saved workflow seller does not match Shipping Configuration.");
+      }
+      restoredOrders = await refreshShippingIntakeHistory(saved.sourceOrders, configuredSeller);
+    } catch (historyError) {
+      restoredWarnings.push(`Saved intake history was cleared because it could not be refreshed: ${String(historyError)}`);
+    }
+    if (restoreSequence !== orderSourceSequenceRef.current) {
+      throw new Error("A newer order load replaced the saved workflow.");
     }
 
     // Waits for the postage lookup so labels are present, or its failure shown,
     // before the saved step renders.
     const isCurrent = await applyOrderSource(
-      saved.sourceOrders,
+      restoredOrders,
       saved.loadedSourceLabel,
-      saved.loadWarnings,
+      restoredWarnings,
+      restoreSequence,
     );
 
     if (!isCurrent) {
@@ -487,6 +511,32 @@ export default function ShippingExportRoute() {
     input: savedWorkflowInput,
     onRestore: restoreSavedWorkflow,
   });
+
+  useEffect(() => {
+    if (!sourceOrders.length) return;
+    const expectedOrders = sourceOrders.map((order) => order["Order #"]).join("|");
+    const refresh = async () => {
+      const expectedSequence = orderSourceSequenceRef.current;
+      try {
+        const refreshed = await refreshShippingIntakeHistory(sourceOrders, config.defaultSellerKey.trim());
+        if (expectedSequence !== orderSourceSequenceRef.current) return;
+        setSourceOrders((current) => current.map((order) => order["Order #"]).join("|") === expectedOrders ? refreshed : current);
+        const histories = new Map(refreshed.map((order) => [order["Order #"], order.intakeHistory]));
+        setOrders((current) => current.map((order) => ({ ...order, intakeHistory: histories.get(order["Order #"]) })));
+      } catch (refreshError) {
+        if (expectedSequence !== orderSourceSequenceRef.current) return;
+        setSourceOrders((current) => current.map((order) => order["Order #"]).join("|") === expectedOrders
+          ? withoutShippingIntakeHistory(current) : current);
+        setOrders((current) => withoutShippingIntakeHistory(current));
+        const warning = `Intake history refresh failed: ${String(refreshError)}`;
+        setLoadWarnings((current) => current.includes(warning) ? current : [...current, warning]);
+      }
+    };
+    const onFocus = () => void refresh();
+    window.addEventListener("focus", onFocus);
+    const interval = window.setInterval(() => void refresh(), 5 * 60_000);
+    return () => { window.removeEventListener("focus", onFocus); window.clearInterval(interval); };
+  }, [config.defaultSellerKey, sourceOrderNumbersKey]);
 
   // ── Handlers: load orders ─────────────────────────────────────────────────
   useEffect(() => {
@@ -580,6 +630,7 @@ export default function ShippingExportRoute() {
   ]);
 
   const handleLoadLiveOrders = async () => {
+    const loadSequence = ++orderSourceSequenceRef.current;
     setIsLoadingLiveOrders(true);
     setError(null);
 
@@ -594,6 +645,7 @@ export default function ShippingExportRoute() {
         response,
         "Failed to load live seller orders.",
       );
+      if (loadSequence !== orderSourceSequenceRef.current) return;
 
       setSellerKeyInput(liveOrderResponse.sellerKey);
       setHistoryCoverage(liveOrderResponse.historyCoverage);
@@ -601,6 +653,7 @@ export default function ShippingExportRoute() {
         liveOrderResponse.orders,
         `Live seller orders: ${liveOrderResponse.sellerKey}`,
         liveOrderResponse.warnings ?? [],
+        loadSequence,
       );
     } catch (loadError) {
       setError(String(loadError));
@@ -617,6 +670,7 @@ export default function ShippingExportRoute() {
       return;
     }
 
+    const loadSequence = ++orderSourceSequenceRef.current;
     setIsLoadingSingleOrder(true);
     setError(null);
 
@@ -634,6 +688,7 @@ export default function ShippingExportRoute() {
         response,
         "Failed to load the requested TCGPlayer order.",
       );
+      if (loadSequence !== orderSourceSequenceRef.current) return;
 
       if (singleOrderResponse.sellerKey) {
         setSellerKeyInput(singleOrderResponse.sellerKey);
@@ -645,6 +700,7 @@ export default function ShippingExportRoute() {
         singleOrderResponse.orders,
         `Single TCGPlayer order: ${singleOrderResponse.loadedOrderNumbers[0] ?? normalizedOrderNumber}`,
         singleOrderResponse.warnings ?? [],
+        loadSequence,
       );
     } catch (loadError) {
       setError(String(loadError));
@@ -656,6 +712,7 @@ export default function ShippingExportRoute() {
   const updateSellerOrderHistory = async (
     payload: { action: "catch_up"; orderNumbers: string[] } | { action: "import_csv"; csvText: string; fileName: string },
   ) => {
+    const sourceSequence = orderSourceSequenceRef.current;
     setIsUpdatingHistory(true);
     setError(null);
     try {
@@ -669,6 +726,19 @@ export default function ShippingExportRoute() {
         "Failed to update seller order history.",
       );
       setHistoryCoverage(result.coverage);
+      if (sourceOrders.length && sourceSequence === orderSourceSequenceRef.current) {
+        try {
+          const refreshed = await refreshShippingIntakeHistory(sourceOrders, config.defaultSellerKey.trim());
+          if (sourceSequence !== orderSourceSequenceRef.current) return;
+          const histories = new Map(refreshed.map((order) => [order["Order #"], order.intakeHistory]));
+          setSourceOrders(refreshed);
+          setOrders((current) => current.map((order) => ({ ...order, intakeHistory: histories.get(order["Order #"]) })));
+        } catch (refreshError) {
+          setSourceOrders((current) => withoutShippingIntakeHistory(current));
+          setOrders((current) => withoutShippingIntakeHistory(current));
+          setLoadWarnings((current) => [...current, `Intake history is unavailable after catch-up: ${String(refreshError)}`]);
+        }
+      }
     } catch (historyError) {
       setError(String(historyError));
     } finally {

--- a/app/features/shipping-export/services/orderIntakeComparison.test.ts
+++ b/app/features/shipping-export/services/orderIntakeComparison.test.ts
@@ -6,6 +6,7 @@ function history(overrides: Partial<ShippingIntakeLineHistory> = {}): ShippingIn
   return {
     skuId: "9001", status: "current", allocationRevisionId: "1", allocatedSourceOrderRevision: 1,
     currentSourceOrderRevision: 1, orderTime: "2026-08-01T12:00:00.000Z", orderedQuantity: 3,
+    soldTotal: 20,
     matchedQuantity: 3, unmatchedQuantity: 0, priceKnownQuantity: 2, dateKnownQuantity: 1,
     recordedPriceQuantity: 1, estimatedPriceQuantity: 1, intakeMarketTotal: 8,
     weightedDaysHeld: 40, minimumDaysHeld: 40, maximumDaysHeld: 40, lots: [], ...overrides,
@@ -20,7 +21,7 @@ function order(line = history()): TcgPlayerShippingOrder {
     "Tracking #": "", Carrier: "", products: [
       { name: "same SKU lower sale", quantity: 2, unitPrice: 5, skuId: 9001, inventorySkuId: "9001" },
       { name: "same SKU higher sale", quantity: 1, unitPrice: 10, skuId: 9001, inventorySkuId: "9001" },
-    ], intakeHistory: { orderNumber: "A", refreshedAt: "2026-08-01T12:01:00.000Z", lines: [line] },
+    ], intakeHistory: { orderNumber: "A", sellerKey: "seller", refreshedAt: "2026-08-01T12:01:00.000Z", lines: [line] },
   };
 }
 
@@ -46,5 +47,20 @@ const held = compareOrdersToIntake([order(history({ status: "held" }))]);
 assert.equal(held.priceKnownQuantity, 0);
 assert.equal(held.heldLineCount, 1);
 assert.equal(intakeDeltaAmount(held), null);
+
+const noProducts = { ...order(), products: undefined, "Item Count": 2, "Value Of Products": 22,
+  intakeHistory: { orderNumber: "A", sellerKey: "seller", refreshedAt: "now", lines: [
+    history({ skuId: "9001", orderedQuantity: 1, soldTotal: 2, matchedQuantity: 1, priceKnownQuantity: 1,
+      dateKnownQuantity: 0, recordedPriceQuantity: 1, estimatedPriceQuantity: 0, intakeMarketTotal: 1,
+      weightedDaysHeld: null, minimumDaysHeld: null, maximumDaysHeld: null }),
+    history({ skuId: "9002", orderedQuantity: 1, soldTotal: 20, matchedQuantity: 1, priceKnownQuantity: 0,
+      dateKnownQuantity: 0, recordedPriceQuantity: 0, estimatedPriceQuantity: 0, intakeMarketTotal: null,
+      weightedDaysHeld: null, minimumDaysHeld: null, maximumDaysHeld: null }),
+  ] } };
+assert.equal(compareOrdersToIntake([noProducts]).comparableSoldTotal, 2);
+
+const whitespaceSku = order();
+whitespaceSku.products![0]!.inventorySkuId = " 9001 ";
+assert.equal(compareOrdersToIntake([whitespaceSku]).comparableSoldTotal, 40 / 3);
 
 console.log("PASS intake comparison de-duplicates orders and preserves SKU-weighted sale, price, date, and zero-value coverage");

--- a/app/features/shipping-export/services/orderIntakeComparison.test.ts
+++ b/app/features/shipping-export/services/orderIntakeComparison.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { compareOrdersToIntake, intakeDeltaAmount, intakeDeltaPercent } from "./orderIntakeComparison";
+import type { ShippingIntakeLineHistory, TcgPlayerShippingOrder } from "../types/shippingExport";
+
+function history(overrides: Partial<ShippingIntakeLineHistory> = {}): ShippingIntakeLineHistory {
+  return {
+    skuId: "9001", status: "current", allocationRevisionId: "1", allocatedSourceOrderRevision: 1,
+    currentSourceOrderRevision: 1, orderTime: "2026-08-01T12:00:00.000Z", orderedQuantity: 3,
+    matchedQuantity: 3, unmatchedQuantity: 0, priceKnownQuantity: 2, dateKnownQuantity: 1,
+    recordedPriceQuantity: 1, estimatedPriceQuantity: 1, intakeMarketTotal: 8,
+    weightedDaysHeld: 40, minimumDaysHeld: 40, maximumDaysHeld: 40, lots: [], ...overrides,
+  };
+}
+
+function order(line = history()): TcgPlayerShippingOrder {
+  return {
+    "Order #": "A", FirstName: "", LastName: "", Address1: "", Address2: "", City: "", State: "",
+    PostalCode: "", Country: "US", "Order Date": line.orderTime, "Product Weight": 0,
+    "Shipping Method": "Standard", "Item Count": 3, "Value Of Products": 20, "Shipping Fee Paid": 0,
+    "Tracking #": "", Carrier: "", products: [
+      { name: "same SKU lower sale", quantity: 2, unitPrice: 5, skuId: 9001, inventorySkuId: "9001" },
+      { name: "same SKU higher sale", quantity: 1, unitPrice: 10, skuId: 9001, inventorySkuId: "9001" },
+    ], intakeHistory: { orderNumber: "A", refreshedAt: "2026-08-01T12:01:00.000Z", lines: [line] },
+  };
+}
+
+const repeated = order();
+const comparison = compareOrdersToIntake([repeated, repeated]);
+assert.equal(comparison.soldTotal, 20);
+assert.equal(comparison.comparableSoldTotal, 40 / 3);
+assert.equal(comparison.intakeMarketTotal, 8);
+assert.equal(comparison.orderedQuantity, 3);
+assert.equal(comparison.priceKnownQuantity, 2);
+assert.equal(comparison.dateKnownQuantity, 1);
+assert.equal(comparison.estimatedPriceQuantity, 1);
+assert.ok(Math.abs((intakeDeltaAmount(comparison) ?? 0) - 16 / 3) < 1e-12);
+assert.equal(comparison.weightedDaysHeld, 40);
+
+const knownZero = compareOrdersToIntake([order(history({ orderedQuantity: 1, matchedQuantity: 1,
+  priceKnownQuantity: 1, dateKnownQuantity: 0, recordedPriceQuantity: 1, estimatedPriceQuantity: 0,
+  intakeMarketTotal: 0, weightedDaysHeld: null, minimumDaysHeld: null, maximumDaysHeld: null }))]);
+assert.equal(intakeDeltaAmount(knownZero), 20 / 3);
+assert.equal(intakeDeltaPercent(knownZero), null);
+
+const held = compareOrdersToIntake([order(history({ status: "held" }))]);
+assert.equal(held.priceKnownQuantity, 0);
+assert.equal(held.heldLineCount, 1);
+assert.equal(intakeDeltaAmount(held), null);
+
+console.log("PASS intake comparison de-duplicates orders and preserves SKU-weighted sale, price, date, and zero-value coverage");

--- a/app/features/shipping-export/services/orderIntakeComparison.ts
+++ b/app/features/shipping-export/services/orderIntakeComparison.ts
@@ -1,6 +1,7 @@
 import type { ShippingIntakeLineHistory, TcgPlayerShippingOrder } from "../types/shippingExport";
 import { getOrderNumbersForShipmentReference } from "./shippingExportUtils";
 import type { ShipmentToOrderMap } from "../types/shippingExport";
+import { shippingInventorySkuId } from "./shippingOrderIdentity";
 
 export interface IntakeComparison {
   soldTotal: number;
@@ -42,15 +43,10 @@ const empty = (): IntakeComparison => ({
   lotCount: 0,
 });
 
-function shippingSkuId(line: NonNullable<TcgPlayerShippingOrder["products"]>[number]): string | null {
-  if (line.inventorySkuId) return line.inventorySkuId;
-  return line.skuId === undefined ? null : String(line.skuId);
-}
-
 function soldBySku(order: TcgPlayerShippingOrder) {
   const result = new Map<string, { quantity: number; soldTotal: number }>();
   for (const line of order.products ?? []) {
-    const skuId = shippingSkuId(line);
+    const skuId = shippingInventorySkuId(line);
     if (!skuId) continue;
     const previous = result.get(skuId) ?? { quantity: 0, soldTotal: 0 };
     result.set(skuId, {
@@ -75,14 +71,16 @@ export function compareOrderToIntake(order: TcgPlayerShippingOrder): IntakeCompa
     : order["Value Of Products"];
   const sold = soldBySku(order);
   const historyLines = order.intakeHistory?.lines ?? [];
+  result.orderedQuantity = order["Item Count"];
+  if (!historyLines.length && result.orderedQuantity > 0) result.unavailableLineCount = 1;
   const historyQuantity = historyLines.reduce((sum, line) => sum + line.orderedQuantity, 0);
   const fallbackSoldPrice = historyQuantity ? result.soldTotal / historyQuantity : 0;
   for (const line of historyLines) {
-    result.orderedQuantity += line.orderedQuantity;
     statusCount(result, line);
     if (line.status !== "current") continue;
     const sale = sold.get(line.skuId);
-    const averageSoldPrice = sale?.quantity ? sale.soldTotal / sale.quantity : fallbackSoldPrice;
+    const averageSoldPrice = sale?.quantity ? sale.soldTotal / sale.quantity
+      : line.soldTotal !== null && line.orderedQuantity ? line.soldTotal / line.orderedQuantity : fallbackSoldPrice;
     result.matchedQuantity += line.matchedQuantity;
     result.priceKnownQuantity += line.priceKnownQuantity;
     result.dateKnownQuantity += line.dateKnownQuantity;

--- a/app/features/shipping-export/services/orderIntakeComparison.ts
+++ b/app/features/shipping-export/services/orderIntakeComparison.ts
@@ -1,0 +1,156 @@
+import type { ShippingIntakeLineHistory, TcgPlayerShippingOrder } from "../types/shippingExport";
+import { getOrderNumbersForShipmentReference } from "./shippingExportUtils";
+import type { ShipmentToOrderMap } from "../types/shippingExport";
+
+export interface IntakeComparison {
+  soldTotal: number;
+  comparableSoldTotal: number;
+  intakeMarketTotal: number;
+  orderedQuantity: number;
+  matchedQuantity: number;
+  priceKnownQuantity: number;
+  dateKnownQuantity: number;
+  recordedPriceQuantity: number;
+  estimatedPriceQuantity: number;
+  weightedDaysHeld: number | null;
+  minimumDaysHeld: number | null;
+  maximumDaysHeld: number | null;
+  pendingLineCount: number;
+  heldLineCount: number;
+  mismatchLineCount: number;
+  unavailableLineCount: number;
+  lotCount: number;
+}
+
+const empty = (): IntakeComparison => ({
+  soldTotal: 0,
+  comparableSoldTotal: 0,
+  intakeMarketTotal: 0,
+  orderedQuantity: 0,
+  matchedQuantity: 0,
+  priceKnownQuantity: 0,
+  dateKnownQuantity: 0,
+  recordedPriceQuantity: 0,
+  estimatedPriceQuantity: 0,
+  weightedDaysHeld: null,
+  minimumDaysHeld: null,
+  maximumDaysHeld: null,
+  pendingLineCount: 0,
+  heldLineCount: 0,
+  mismatchLineCount: 0,
+  unavailableLineCount: 0,
+  lotCount: 0,
+});
+
+function shippingSkuId(line: NonNullable<TcgPlayerShippingOrder["products"]>[number]): string | null {
+  if (line.inventorySkuId) return line.inventorySkuId;
+  return line.skuId === undefined ? null : String(line.skuId);
+}
+
+function soldBySku(order: TcgPlayerShippingOrder) {
+  const result = new Map<string, { quantity: number; soldTotal: number }>();
+  for (const line of order.products ?? []) {
+    const skuId = shippingSkuId(line);
+    if (!skuId) continue;
+    const previous = result.get(skuId) ?? { quantity: 0, soldTotal: 0 };
+    result.set(skuId, {
+      quantity: previous.quantity + line.quantity,
+      soldTotal: previous.soldTotal + line.quantity * line.unitPrice,
+    });
+  }
+  return result;
+}
+
+function statusCount(comparison: IntakeComparison, line: ShippingIntakeLineHistory) {
+  if (line.status === "pending") comparison.pendingLineCount += 1;
+  if (line.status === "held") comparison.heldLineCount += 1;
+  if (line.status === "mismatch") comparison.mismatchLineCount += 1;
+  if (line.status === "unavailable") comparison.unavailableLineCount += 1;
+}
+
+export function compareOrderToIntake(order: TcgPlayerShippingOrder): IntakeComparison {
+  const result = empty();
+  result.soldTotal = order.products?.length
+    ? order.products.reduce((sum, line) => sum + line.unitPrice * line.quantity, 0)
+    : order["Value Of Products"];
+  const sold = soldBySku(order);
+  const historyLines = order.intakeHistory?.lines ?? [];
+  const historyQuantity = historyLines.reduce((sum, line) => sum + line.orderedQuantity, 0);
+  const fallbackSoldPrice = historyQuantity ? result.soldTotal / historyQuantity : 0;
+  for (const line of historyLines) {
+    result.orderedQuantity += line.orderedQuantity;
+    statusCount(result, line);
+    if (line.status !== "current") continue;
+    const sale = sold.get(line.skuId);
+    const averageSoldPrice = sale?.quantity ? sale.soldTotal / sale.quantity : fallbackSoldPrice;
+    result.matchedQuantity += line.matchedQuantity;
+    result.priceKnownQuantity += line.priceKnownQuantity;
+    result.dateKnownQuantity += line.dateKnownQuantity;
+    result.recordedPriceQuantity += line.recordedPriceQuantity;
+    result.estimatedPriceQuantity += line.estimatedPriceQuantity;
+    result.comparableSoldTotal += averageSoldPrice * line.priceKnownQuantity;
+    result.intakeMarketTotal += line.intakeMarketTotal ?? 0;
+    result.lotCount += line.lots.length;
+    if (line.weightedDaysHeld !== null) {
+      const previousWeight = result.dateKnownQuantity - line.dateKnownQuantity;
+      result.weightedDaysHeld = ((result.weightedDaysHeld ?? 0) * previousWeight
+        + line.weightedDaysHeld * line.dateKnownQuantity) / result.dateKnownQuantity;
+    }
+    if (line.minimumDaysHeld !== null) result.minimumDaysHeld = result.minimumDaysHeld === null
+      ? line.minimumDaysHeld : Math.min(result.minimumDaysHeld, line.minimumDaysHeld);
+    if (line.maximumDaysHeld !== null) result.maximumDaysHeld = result.maximumDaysHeld === null
+      ? line.maximumDaysHeld : Math.max(result.maximumDaysHeld, line.maximumDaysHeld);
+  }
+  return result;
+}
+
+export function sumIntakeComparisons(comparisons: IntakeComparison[]): IntakeComparison {
+  const result = empty();
+  let weightedAgeTotal = 0;
+  for (const comparison of comparisons) {
+    result.soldTotal += comparison.soldTotal;
+    result.comparableSoldTotal += comparison.comparableSoldTotal;
+    result.intakeMarketTotal += comparison.intakeMarketTotal;
+    result.orderedQuantity += comparison.orderedQuantity;
+    result.matchedQuantity += comparison.matchedQuantity;
+    result.priceKnownQuantity += comparison.priceKnownQuantity;
+    result.dateKnownQuantity += comparison.dateKnownQuantity;
+    result.recordedPriceQuantity += comparison.recordedPriceQuantity;
+    result.estimatedPriceQuantity += comparison.estimatedPriceQuantity;
+    result.pendingLineCount += comparison.pendingLineCount;
+    result.heldLineCount += comparison.heldLineCount;
+    result.mismatchLineCount += comparison.mismatchLineCount;
+    result.unavailableLineCount += comparison.unavailableLineCount;
+    result.lotCount += comparison.lotCount;
+    if (comparison.weightedDaysHeld !== null) weightedAgeTotal += comparison.weightedDaysHeld * comparison.dateKnownQuantity;
+    if (comparison.minimumDaysHeld !== null) result.minimumDaysHeld = result.minimumDaysHeld === null
+      ? comparison.minimumDaysHeld : Math.min(result.minimumDaysHeld, comparison.minimumDaysHeld);
+    if (comparison.maximumDaysHeld !== null) result.maximumDaysHeld = result.maximumDaysHeld === null
+      ? comparison.maximumDaysHeld : Math.max(result.maximumDaysHeld, comparison.maximumDaysHeld);
+  }
+  result.weightedDaysHeld = result.dateKnownQuantity ? weightedAgeTotal / result.dateKnownQuantity : null;
+  return result;
+}
+
+export function compareOrdersToIntake(orders: TcgPlayerShippingOrder[]): IntakeComparison {
+  const unique = [...new Map(orders.map((order) => [order["Order #"], order])).values()];
+  return sumIntakeComparisons(unique.map(compareOrderToIntake));
+}
+
+export function compareShipmentToIntake(
+  sourceOrders: TcgPlayerShippingOrder[],
+  shipmentToOrderMap: ShipmentToOrderMap,
+  shipmentReference: string,
+): IntakeComparison {
+  const orderNumbers = new Set(getOrderNumbersForShipmentReference(shipmentToOrderMap, shipmentReference));
+  return compareOrdersToIntake(sourceOrders.filter((order) => orderNumbers.has(order["Order #"])));
+}
+
+export function intakeDeltaAmount(comparison: IntakeComparison): number | null {
+  return comparison.priceKnownQuantity ? comparison.comparableSoldTotal - comparison.intakeMarketTotal : null;
+}
+
+export function intakeDeltaPercent(comparison: IntakeComparison): number | null {
+  const amount = intakeDeltaAmount(comparison);
+  return amount === null || comparison.intakeMarketTotal === 0 ? null : amount / comparison.intakeMarketTotal * 100;
+}

--- a/app/features/shipping-export/services/orderMarketComparison.test.ts
+++ b/app/features/shipping-export/services/orderMarketComparison.test.ts
@@ -121,7 +121,7 @@ const testCases: TestCase[] = [
       assert.equal(comparison.soldTotal, 42.5);
       assert.equal(comparison.lineCount, 0);
       assert.equal(getMarketDeltaPercent(comparison), null);
-      assert.equal(describeMarketDelta(comparison), "No market price");
+      assert.equal(describeMarketDelta(comparison), "No current market price");
       assert.equal(describeMarketCoverage(comparison), "No line items");
     },
   },
@@ -142,7 +142,7 @@ const testCases: TestCase[] = [
       assert.equal(comparison.soldTotal, 16);
       assert.equal(comparison.comparableMarketTotal, 16);
       assert.equal(getMarketDeltaAmount(comparison), 0);
-      assert.equal(describeMarketDelta(comparison), "At market");
+      assert.equal(describeMarketDelta(comparison), "At current market");
       assert.equal(describeMarketCoverage(comparison), null);
     },
   },
@@ -170,7 +170,7 @@ const testCases: TestCase[] = [
       assert.equal(comparison.soldTotal, 21);
       assert.equal(comparison.comparableMarketTotal, 20);
       assertClose(getMarketDeltaPercent(comparison), 5);
-      assert.equal(describeMarketDelta(comparison), "5.0% above market");
+      assert.equal(describeMarketDelta(comparison), "5.0% above current market");
     },
   },
   {
@@ -183,7 +183,7 @@ const testCases: TestCase[] = [
       );
 
       assertClose(getMarketDeltaPercent(comparison), -20);
-      assert.equal(describeMarketDelta(comparison), "20.0% below market");
+      assert.equal(describeMarketDelta(comparison), "20.0% below current market");
     },
   },
   {

--- a/app/features/shipping-export/services/orderMarketComparison.ts
+++ b/app/features/shipping-export/services/orderMarketComparison.ts
@@ -135,19 +135,19 @@ export function compareShipmentToMarket(
   );
 }
 
-/** "8.4% above market", "3.1% below market", "At market", or "No market price". */
+/** "8.4% above current market", "3.1% below current market", or unavailable. */
 export function describeMarketDelta(comparison: MarketComparison): string {
   const percent = getMarketDeltaPercent(comparison);
 
   switch (getMarketDeltaTone(percent)) {
     case "unavailable":
-      return "No market price";
+      return "No current market price";
     case "at":
-      return "At market";
+      return "At current market";
     case "above":
-      return `${Math.abs(percent ?? 0).toFixed(1)}% above market`;
+      return `${Math.abs(percent ?? 0).toFixed(1)}% above current market`;
     case "below":
-      return `${Math.abs(percent ?? 0).toFixed(1)}% below market`;
+      return `${Math.abs(percent ?? 0).toFixed(1)}% below current market`;
   }
 }
 

--- a/app/features/shipping-export/services/shippingIntakeHistory.server.integration.test.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.server.integration.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+
+const testUrl = process.env.TEST_DATABASE_URL;
+if (!testUrl || process.env.DATABASE_URL !== testUrl) throw new Error("DATABASE_URL and TEST_DATABASE_URL must match.");
+if (!new URL(testUrl).pathname.replace(/^\/+/, "").startsWith("tcgplayer_fifo_test_")) throw new Error("A disposable tcgplayer_fifo_test_* database is required.");
+
+const { getPool } = await import("~/core/db/database.server");
+const { enrichShippingOrdersWithIntakeHistory } = await import("./shippingIntakeHistory.server");
+const pool = getPool();
+const seller = `shipping-history-${Date.now()}`;
+const sku = 99101;
+const sale = new Date("2026-08-01T12:00:00.000Z");
+
+try {
+  await pool.query(`INSERT INTO products(product_id,product_type_name,rarity_name,sealed,product_name,set_id,set_code,set_name,
+    product_line_id,product_status_id,product_line_name) VALUES(99103,'Card','Rare',false,'Synthetic',99102,'S','Set',99100,1,'Game')
+    ON CONFLICT DO NOTHING`);
+  await pool.query(`INSERT INTO skus(sku,condition,variant,language,product_type_name,rarity_name,sealed,product_name,set_id,set_code,
+    product_id,set_name,product_line_id,product_status_id,product_line_name)
+    VALUES($1,'Near Mint','Normal','English','Card','Rare',false,'Synthetic',99102,'S',99103,'Set',99100,1,'Game') ON CONFLICT DO NOTHING`,[sku]);
+  const order = (await pool.query(`INSERT INTO seller_orders(seller_key,order_number,order_time,lifecycle,provider_status,
+    gross_item_proceeds,source_fingerprint,first_observed_at,last_observed_at,detail_observed_at,latest_source)
+    VALUES($1,'A',$2,'ready_to_ship','Ready to Ship',20,'fp',NOW(),NOW(),NOW(),'tcgplayer_api') RETURNING id`,[seller,sale])).rows[0];
+  await pool.query(`INSERT INTO seller_order_lines(order_id,sku_id,product_name,ordered_quantity,gross_item_proceeds)
+    VALUES($1,$2,'Synthetic',3,20)`,[order.id,String(sku)]);
+  await pool.query(`INSERT INTO seller_order_revisions(order_id,revision_number,source_fingerprint,source,observed_at,order_time,
+    order_time_evidence,provider_status,lifecycle,line_evidence) VALUES($1,1,'fp','tcgplayer_api',NOW(),$2,
+    'detail_canonical','Ready to Ship','ready_to_ship','[]')`,[order.id,sale]);
+  const receipts: number[] = [];
+  for (const [index, value] of [{ quantity: 2, market: 4, days: 60 }, { quantity: 1, market: 6, days: 10 }].entries()) {
+    const requestId = `${seller}-receipt-${index}`;
+    await pool.query(`INSERT INTO inventory_pending_mutations(request_id,mutation_type,sku,requested_quantity,product_line_id,set_id,
+      product_id,quantity_delta,resulting_quantity) VALUES($1,'add',$2,$3,99100,99102,99103,$3,$3)`,[requestId,sku,value.quantity]);
+    const receipt = await pool.query(`INSERT INTO inventory_receipts(request_id,sku,original_quantity,product_line_id,set_id,product_id,
+      seller_key,intake_at,market_value,market_provenance) VALUES($1,$2,$3,99100,99102,99103,$4,$5,$6,'tcgplayer_price_points')
+      RETURNING receipt_id`,[requestId,sku,value.quantity,seller,new Date(sale.getTime() - value.days * 86_400_000),value.market]);
+    receipts.push(receipt.rows[0]!.receipt_id);
+  }
+  const fifo = (await pool.query(`INSERT INTO inventory_fifo_lines(seller_key,order_id,order_line_sku_id,sku,order_time,ordered_quantity,
+    source_order_revision,state,matched_quantity,unmatched_quantity,price_known_quantity,date_known_quantity,intake_market_total,weighted_days_held)
+    VALUES($1,$2,$3,$4,$5,3,1,'allocated',3,0,3,3,14,43.333333) RETURNING id`,[seller,order.id,String(sku),sku,sale])).rows[0];
+  const revision = (await pool.query(`INSERT INTO inventory_fifo_revisions(line_id,revision_number,source_order_revision,order_time,
+    trigger_reason,state,ordered_quantity,matched_quantity,unmatched_quantity,price_known_quantity,date_known_quantity,
+    intake_market_total,weighted_days_held,source_fingerprint) VALUES($1,1,1,$2,'test','allocated',3,3,0,3,3,14,43.333333,'fp') RETURNING id`,
+    [fifo.id,sale])).rows[0];
+  await pool.query(`UPDATE inventory_fifo_lines SET current_revision_id=$2 WHERE id=$1`,[fifo.id,revision.id]);
+  await pool.query(`INSERT INTO inventory_fifo_revision_allocations(revision_id,supply_key,receipt_id,allocated_quantity,available_at)
+    VALUES($1,$2,$3,2,$4),($1,$5,$6,1,$4)`,[revision.id,`receipt:${receipts[0]}`,receipts[0],sale,`receipt:${receipts[1]}`,receipts[1]]);
+
+  const shippingOrder = { "Order #": "A", FirstName: "", LastName: "", Address1: "", Address2: "", City: "", State: "",
+    PostalCode: "", Country: "US", "Order Date": sale.toISOString(), "Product Weight": 0, "Shipping Method": "Standard" as const,
+    "Item Count": 3, "Value Of Products": 20, "Shipping Fee Paid": 0, "Tracking #": "", Carrier: "", products: [
+      { name: "first", quantity: 2, unitPrice: 5, inventorySkuId: String(sku), skuId: sku },
+      { name: "second", quantity: 1, unitPrice: 10, inventorySkuId: String(sku), skuId: sku },
+    ] };
+  const enriched = await enrichShippingOrdersWithIntakeHistory([shippingOrder], seller);
+  const line = enriched[0]!.intakeHistory!.lines[0]!;
+  assert.deepEqual([line.status,line.intakeMarketTotal,line.priceKnownQuantity,line.dateKnownQuantity,line.lots.length],
+    ["current",14,3,3,2]);
+  assert.ok(Math.abs((line.weightedDaysHeld ?? 0) - 43.333333) < 0.000001);
+  assert.equal((await enrichShippingOrdersWithIntakeHistory([shippingOrder], `${seller}-other`))[0]!.intakeHistory!.lines[0]!.status,
+    "unavailable");
+  console.log("PASS shipping intake history reads mixed FIFO lots in one seller-scoped bulk projection");
+} finally {
+  await pool.end();
+}

--- a/app/features/shipping-export/services/shippingIntakeHistory.server.test.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.server.test.ts
@@ -41,10 +41,11 @@ assert.equal(line.lots[0]?.priceProvenance, "recorded");
 const persistedOnly = await enrichShippingOrdersWithIntakeHistory([order()], "seller", allocations as never);
 assert.deepEqual(persistedOnly[0]!.intakeHistory!.lines.map((value) => value.skuId), ["9001"]);
 
+const partialAllocations = async () => (await allocations()).map((row) => ({ ...row, persistedSoldTotal: 15 }));
 const unidentified = await enrichShippingOrdersWithIntakeHistory([order([
   { name: "known", quantity: 3, unitPrice: 5, inventorySkuId: "9001", skuId: 9001 },
   { name: "unknown", quantity: 1, unitPrice: 5 },
-])], "seller", allocations as never);
+])], "seller", partialAllocations as never);
 assert.deepEqual(unidentified[0]!.intakeHistory!.lines.map((value) => [value.skuId, value.orderedQuantity, value.status]),
   [["9001", 3, "current"], ["unidentified", 1, "unavailable"]]);
 
@@ -52,5 +53,9 @@ const overcounted = order([{ name: "too many", quantity: 3, unitPrice: 5, invent
 overcounted["Item Count"] = 2;
 const overcountedResult = await enrichShippingOrdersWithIntakeHistory([overcounted], "seller", allocations as never);
 assert.equal(overcountedResult[0]!.intakeHistory!.lines[0]!.status, "mismatch");
+
+const staleShipping = order([{ name: "stale", quantity: 3, unitPrice: 5, inventorySkuId: "9001", skuId: 9001 }]);
+const staleResult = await enrichShippingOrdersWithIntakeHistory([staleShipping], "seller", allocations as never);
+assert.equal(staleResult[0]!.intakeHistory!.lines[0]!.status, "mismatch");
 
 console.log("PASS shipping intake enrichment uses one SKU aggregate, persisted-order fallback, explicit provenance, and unavailable identity coverage");

--- a/app/features/shipping-export/services/shippingIntakeHistory.server.test.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.server.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { enrichShippingOrdersWithIntakeHistory } from "./shippingIntakeHistory.server";
+import type { TcgPlayerShippingOrder } from "../types/shippingExport";
+
+const sale = new Date("2026-08-01T12:00:00.000Z");
+function order(products?: TcgPlayerShippingOrder["products"]): TcgPlayerShippingOrder {
+  return { "Order #": "A", FirstName: "", LastName: "", Address1: "", Address2: "", City: "", State: "",
+    PostalCode: "", Country: "US", "Order Date": sale.toISOString(), "Product Weight": 0, "Shipping Method": "Standard",
+    "Item Count": products?.reduce((sum, line) => sum + line.quantity, 0) ?? 3, "Value Of Products": 20,
+    "Shipping Fee Paid": 0, "Tracking #": "", Carrier: "", products };
+}
+
+const allocations = async () => [{
+  orderNumber: "A", currentOrderTime: sale, allocatedOrderTime: sale, currentSourceOrderRevision: 1,
+  skuId: "9001", currentOrderedQuantity: 3, state: "allocated", holdReason: null,
+  allocatedOrderedQuantity: 3, matchedQuantity: 3, unmatchedQuantity: 0, priceKnownQuantity: 3,
+  dateKnownQuantity: 3, intakeMarketTotal: 14, weightedDaysHeld: 130 / 3, revisionId: "10",
+  allocatedSourceOrderRevision: 1, replayStatus: null, queueHoldReason: null, allocationPending: false,
+  lots: [
+    { supplyKey: "receipt:1", receiptId: 1, quantity: 2, availableAt: sale.toISOString(), dispositionId: null,
+      quantityCorrectionId: null, receiptKind: "received", intakeAt: new Date(sale.getTime() - 60 * 86_400_000).toISOString(),
+      marketValue: 4, marketProvenance: "tcgplayer_price_points", marketCalculatedAt: sale.toISOString() },
+    { supplyKey: "receipt:2", receiptId: 2, quantity: 1, availableAt: sale.toISOString(), dispositionId: null,
+      quantityCorrectionId: null, receiptKind: "received", intakeAt: new Date(sale.getTime() - 10 * 86_400_000).toISOString(),
+      marketValue: 6, marketProvenance: "estimated_catalog_backfill", marketCalculatedAt: sale.toISOString() },
+  ],
+}];
+
+const enriched = await enrichShippingOrdersWithIntakeHistory([order([
+  { name: "first", quantity: 2, unitPrice: 5, inventorySkuId: "9001", skuId: 9001 },
+  { name: "second", quantity: 1, unitPrice: 10, inventorySkuId: "9001", skuId: 9001 },
+])], "seller", allocations as never);
+const line = enriched[0]!.intakeHistory!.lines[0]!;
+assert.equal(line.intakeMarketTotal, 14);
+assert.ok(Math.abs((line.weightedDaysHeld ?? 0) - 43.3333333333) < 0.000001);
+assert.deepEqual([line.minimumDaysHeld, line.maximumDaysHeld], [10, 60]);
+assert.deepEqual([line.recordedPriceQuantity, line.estimatedPriceQuantity], [2, 1]);
+assert.equal(line.lots[0]?.priceProvenance, "recorded");
+
+const persistedOnly = await enrichShippingOrdersWithIntakeHistory([order()], "seller", allocations as never);
+assert.deepEqual(persistedOnly[0]!.intakeHistory!.lines.map((value) => value.skuId), ["9001"]);
+
+const unidentified = await enrichShippingOrdersWithIntakeHistory([order([
+  { name: "known", quantity: 3, unitPrice: 5, inventorySkuId: "9001", skuId: 9001 },
+  { name: "unknown", quantity: 1, unitPrice: 5 },
+])], "seller", allocations as never);
+assert.deepEqual(unidentified[0]!.intakeHistory!.lines.map((value) => [value.skuId, value.orderedQuantity, value.status]),
+  [["9001", 3, "current"], ["unidentified", 1, "unavailable"]]);
+
+console.log("PASS shipping intake enrichment uses one SKU aggregate, persisted-order fallback, explicit provenance, and unavailable identity coverage");

--- a/app/features/shipping-export/services/shippingIntakeHistory.server.test.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.server.test.ts
@@ -48,4 +48,9 @@ const unidentified = await enrichShippingOrdersWithIntakeHistory([order([
 assert.deepEqual(unidentified[0]!.intakeHistory!.lines.map((value) => [value.skuId, value.orderedQuantity, value.status]),
   [["9001", 3, "current"], ["unidentified", 1, "unavailable"]]);
 
+const overcounted = order([{ name: "too many", quantity: 3, unitPrice: 5, inventorySkuId: "9001", skuId: 9001 }]);
+overcounted["Item Count"] = 2;
+const overcountedResult = await enrichShippingOrdersWithIntakeHistory([overcounted], "seller", allocations as never);
+assert.equal(overcountedResult[0]!.intakeHistory!.lines[0]!.status, "mismatch");
+
 console.log("PASS shipping intake enrichment uses one SKU aggregate, persisted-order fallback, explicit provenance, and unavailable identity coverage");

--- a/app/features/shipping-export/services/shippingIntakeHistory.server.test.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.server.test.ts
@@ -13,6 +13,7 @@ function order(products?: TcgPlayerShippingOrder["products"]): TcgPlayerShipping
 const allocations = async () => [{
   orderNumber: "A", currentOrderTime: sale, allocatedOrderTime: sale, currentSourceOrderRevision: 1,
   skuId: "9001", currentOrderedQuantity: 3, state: "allocated", holdReason: null,
+  persistedSoldTotal: 20,
   allocatedOrderedQuantity: 3, matchedQuantity: 3, unmatchedQuantity: 0, priceKnownQuantity: 3,
   dateKnownQuantity: 3, intakeMarketTotal: 14, weightedDaysHeld: 130 / 3, revisionId: "10",
   allocatedSourceOrderRevision: 1, replayStatus: null, queueHoldReason: null, allocationPending: false,

--- a/app/features/shipping-export/services/shippingIntakeHistory.server.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.server.ts
@@ -1,0 +1,218 @@
+import { inventoryFifoRepository } from "~/core/db";
+import type {
+  OrderLineItem,
+  ShippingIntakeHistoryStatus,
+  ShippingIntakeLineHistory,
+  ShippingIntakeLot,
+  ShippingIntakePriceProvenance,
+  TcgPlayerShippingOrder,
+} from "../types/shippingExport";
+
+type AllocationRow = {
+  orderNumber: string;
+  currentOrderTime: Date;
+  allocatedOrderTime: Date | null;
+  currentSourceOrderRevision: number;
+  skuId: string;
+  currentOrderedQuantity: number;
+  state: string | null;
+  holdReason: string | null;
+  allocatedOrderedQuantity: number | null;
+  matchedQuantity: number | null;
+  unmatchedQuantity: number | null;
+  priceKnownQuantity: number | null;
+  dateKnownQuantity: number | null;
+  intakeMarketTotal: number | null;
+  weightedDaysHeld: number | null;
+  revisionId: string | null;
+  allocatedSourceOrderRevision: number | null;
+  replayStatus: string | null;
+  queueHoldReason: string | null;
+  allocationPending: boolean;
+  lots: Array<{
+    supplyKey: string;
+    receiptId: number;
+    quantity: number;
+    availableAt: string;
+    dispositionId: string | null;
+    quantityCorrectionId: string | null;
+    receiptKind: "opening_balance" | "received";
+    intakeAt: string | null;
+    marketValue: number | null;
+    marketProvenance: string;
+    marketCalculatedAt: string | null;
+  }>;
+};
+
+type FindAllocations = typeof inventoryFifoRepository.findShippingOrderAllocations;
+
+const MAX_ORDERS = 500;
+
+function exactSkuIdentity(line: OrderLineItem): string | null {
+  if (line.inventorySkuId?.trim()) return line.inventorySkuId.trim();
+  return line.skuId === undefined ? null : String(line.skuId);
+}
+
+function groupedShippingLines(order: TcgPlayerShippingOrder) {
+  const grouped = new Map<string, { quantity: number; soldTotal: number }>();
+  for (const line of order.products ?? []) {
+    const skuId = exactSkuIdentity(line);
+    if (!skuId) continue;
+    const previous = grouped.get(skuId) ?? { quantity: 0, soldTotal: 0 };
+    grouped.set(skuId, {
+      quantity: previous.quantity + line.quantity,
+      soldTotal: previous.soldTotal + line.unitPrice * line.quantity,
+    });
+  }
+  return grouped;
+}
+
+function unidentifiedShippingQuantity(order: TcgPlayerShippingOrder): number {
+  if (!order.products?.length) return 0;
+  const productQuantity = order.products.reduce((sum, line) => sum + line.quantity, 0);
+  const unidentified = order.products.filter((line) => !exactSkuIdentity(line)).reduce((sum, line) => sum + line.quantity, 0);
+  return unidentified + Math.max(0, order["Item Count"] - productQuantity);
+}
+
+function priceProvenance(lot: AllocationRow["lots"][number]): ShippingIntakePriceProvenance {
+  if (lot.marketValue === null) return "unknown";
+  return /estimated|modeled|calculated/i.test(lot.marketProvenance) ? "estimated" : "recorded";
+}
+
+function unavailableLine(skuId: string, order: TcgPlayerShippingOrder, quantity: number): ShippingIntakeLineHistory {
+  return {
+    skuId,
+    status: "unavailable",
+    statusReason: "No exact persisted seller-order allocation is available.",
+    allocationRevisionId: null,
+    allocatedSourceOrderRevision: null,
+    currentSourceOrderRevision: 0,
+    orderTime: order["Order Date"],
+    orderedQuantity: quantity,
+    matchedQuantity: 0,
+    unmatchedQuantity: quantity,
+    priceKnownQuantity: 0,
+    dateKnownQuantity: 0,
+    recordedPriceQuantity: 0,
+    estimatedPriceQuantity: 0,
+    intakeMarketTotal: null,
+    weightedDaysHeld: null,
+    minimumDaysHeld: null,
+    maximumDaysHeld: null,
+    lots: [],
+  };
+}
+
+function historyStatus(row: AllocationRow, shippingQuantity: number): {
+  status: ShippingIntakeHistoryStatus;
+  reason?: string;
+} {
+  if (row.currentOrderedQuantity !== shippingQuantity) {
+    return { status: "mismatch", reason: `Shipping has ${shippingQuantity} units; order history has ${row.currentOrderedQuantity}.` };
+  }
+  if (row.state === "held" || row.replayStatus === "held") {
+    return { status: "held", reason: row.queueHoldReason ?? row.holdReason ?? "FIFO allocation needs review." };
+  }
+  if (row.allocationPending || !row.revisionId || row.replayStatus === "pending" || row.replayStatus === "processing") {
+    return { status: "pending", reason: "FIFO allocation is waiting to be refreshed." };
+  }
+  if (row.state === "unsupported") {
+    return { status: "unavailable", reason: "This inventory identity is not a supported standard SKU." };
+  }
+  return { status: "current" };
+}
+
+function currentLineHistory(row: AllocationRow, shippingQuantity: number): ShippingIntakeLineHistory {
+  let state = historyStatus(row, shippingQuantity);
+  const allocationTime = row.allocatedOrderTime ?? row.currentOrderTime;
+  const orderTime = allocationTime.toISOString();
+  const lots: ShippingIntakeLot[] = row.lots.map((lot) => {
+    const intakeAt = lot.intakeAt ? new Date(lot.intakeAt) : null;
+    const daysHeld = intakeAt && intakeAt <= allocationTime
+      ? (allocationTime.getTime() - intakeAt.getTime()) / 86_400_000
+      : null;
+    return {
+      supplyKey: lot.supplyKey,
+      receiptId: lot.receiptId,
+      quantity: lot.quantity,
+      availableAt: new Date(lot.availableAt).toISOString(),
+      sourceKind: lot.dispositionId ? "physical_restock" : lot.quantityCorrectionId ? "quantity_correction" : lot.receiptKind,
+      intakeAt: intakeAt?.toISOString() ?? null,
+      daysHeld,
+      intakeMarketValue: lot.marketValue,
+      priceProvenance: priceProvenance(lot),
+    };
+  });
+  const priceKnownLots = lots.filter((lot) => lot.intakeMarketValue !== null);
+  const dateKnownLots = lots.filter((lot) => lot.daysHeld !== null);
+  const dateValues = dateKnownLots.map((lot) => lot.daysHeld as number);
+  const priceKnownQuantity = priceKnownLots.reduce((sum, lot) => sum + lot.quantity, 0);
+  const dateKnownQuantity = dateKnownLots.reduce((sum, lot) => sum + lot.quantity, 0);
+  const derivedIntakeMarketTotal = priceKnownQuantity
+    ? priceKnownLots.reduce((sum, lot) => sum + (lot.intakeMarketValue as number) * lot.quantity, 0)
+    : null;
+  const recordedPriceQuantity = lots.filter((lot) => lot.priceProvenance === "recorded").reduce((sum, lot) => sum + lot.quantity, 0);
+  const estimatedPriceQuantity = lots.filter((lot) => lot.priceProvenance === "estimated").reduce((sum, lot) => sum + lot.quantity, 0);
+  const aggregateMismatch = lots.reduce((sum, lot) => sum + lot.quantity, 0) !== (row.matchedQuantity ?? 0)
+    || priceKnownQuantity !== (row.priceKnownQuantity ?? 0) || dateKnownQuantity !== (row.dateKnownQuantity ?? 0)
+    || (derivedIntakeMarketTotal === null) !== (row.intakeMarketTotal === null)
+    || (derivedIntakeMarketTotal !== null && Math.round(derivedIntakeMarketTotal * 100) !== Math.round((row.intakeMarketTotal ?? 0) * 100));
+  if (aggregateMismatch) state = { status: "mismatch", reason: "Saved FIFO totals do not match their receipt allocation detail." };
+
+  return {
+    skuId: row.skuId,
+    status: state.status,
+    ...(state.reason ? { statusReason: state.reason } : {}),
+    allocationRevisionId: row.revisionId,
+    allocatedSourceOrderRevision: row.allocatedSourceOrderRevision,
+    currentSourceOrderRevision: row.currentSourceOrderRevision,
+    orderTime,
+    orderedQuantity: shippingQuantity,
+    matchedQuantity: row.matchedQuantity ?? 0,
+    unmatchedQuantity: row.unmatchedQuantity ?? shippingQuantity,
+    priceKnownQuantity: row.priceKnownQuantity ?? 0,
+    dateKnownQuantity: row.dateKnownQuantity ?? 0,
+    recordedPriceQuantity,
+    estimatedPriceQuantity,
+    intakeMarketTotal: row.intakeMarketTotal,
+    weightedDaysHeld: row.weightedDaysHeld,
+    minimumDaysHeld: dateValues.length ? Math.min(...dateValues) : null,
+    maximumDaysHeld: dateValues.length ? Math.max(...dateValues) : null,
+    lots,
+  };
+}
+
+export async function enrichShippingOrdersWithIntakeHistory(
+  orders: TcgPlayerShippingOrder[],
+  sellerKey: string,
+  findAllocations: FindAllocations = inventoryFifoRepository.findShippingOrderAllocations,
+): Promise<TcgPlayerShippingOrder[]> {
+  const uniqueOrders = [...new Map(orders.map((order) => [order["Order #"], order])).values()];
+  if (uniqueOrders.length > MAX_ORDERS) throw new Error(`Intake history is limited to ${MAX_ORDERS} orders per request.`);
+  const rows = await findAllocations(sellerKey, uniqueOrders.map((order) => order["Order #"])) as AllocationRow[];
+  const rowsByOrder = new Map<string, Map<string, AllocationRow>>();
+  for (const row of rows) {
+    const bySku = rowsByOrder.get(row.orderNumber) ?? new Map<string, AllocationRow>();
+    bySku.set(row.skuId, row);
+    rowsByOrder.set(row.orderNumber, bySku);
+  }
+  const refreshedAt = new Date().toISOString();
+  return orders.map((order) => {
+    const grouped = groupedShippingLines(order);
+    const persisted = rowsByOrder.get(order["Order #"]);
+    const lines = grouped.size
+      ? [...grouped.entries()].map(([skuId, values]) => {
+        const row = persisted?.get(skuId);
+        return row ? currentLineHistory(row, values.quantity) : unavailableLine(skuId, order, values.quantity);
+      })
+      : [...(persisted?.values() ?? [])].map((row) => currentLineHistory(row, row.currentOrderedQuantity));
+    const unidentifiedQuantity = unidentifiedShippingQuantity(order);
+    if (unidentifiedQuantity) lines.push(unavailableLine("unidentified", order, unidentifiedQuantity));
+    if (!lines.length && order["Item Count"] > 0) lines.push(unavailableLine("unidentified", order, order["Item Count"]));
+    return { ...order, intakeHistory: { orderNumber: order["Order #"], lines, refreshedAt } };
+  });
+}
+
+export function clearShippingIntakeHistory(orders: TcgPlayerShippingOrder[]): TcgPlayerShippingOrder[] {
+  return orders.map(({ intakeHistory: _history, ...order }) => order);
+}

--- a/app/features/shipping-export/services/shippingIntakeHistory.server.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.server.ts
@@ -1,12 +1,12 @@
 import { inventoryFifoRepository } from "~/core/db";
 import type {
-  OrderLineItem,
   ShippingIntakeHistoryStatus,
   ShippingIntakeLineHistory,
   ShippingIntakeLot,
   ShippingIntakePriceProvenance,
   TcgPlayerShippingOrder,
 } from "../types/shippingExport";
+import { shippingInventorySkuId } from "./shippingOrderIdentity";
 
 type AllocationRow = {
   orderNumber: string;
@@ -15,6 +15,7 @@ type AllocationRow = {
   currentSourceOrderRevision: number;
   skuId: string;
   currentOrderedQuantity: number;
+  persistedSoldTotal: number;
   state: string | null;
   holdReason: string | null;
   allocatedOrderedQuantity: number | null;
@@ -48,15 +49,10 @@ type FindAllocations = typeof inventoryFifoRepository.findShippingOrderAllocatio
 
 const MAX_ORDERS = 500;
 
-function exactSkuIdentity(line: OrderLineItem): string | null {
-  if (line.inventorySkuId?.trim()) return line.inventorySkuId.trim();
-  return line.skuId === undefined ? null : String(line.skuId);
-}
-
 function groupedShippingLines(order: TcgPlayerShippingOrder) {
   const grouped = new Map<string, { quantity: number; soldTotal: number }>();
   for (const line of order.products ?? []) {
-    const skuId = exactSkuIdentity(line);
+    const skuId = shippingInventorySkuId(line);
     if (!skuId) continue;
     const previous = grouped.get(skuId) ?? { quantity: 0, soldTotal: 0 };
     grouped.set(skuId, {
@@ -70,7 +66,7 @@ function groupedShippingLines(order: TcgPlayerShippingOrder) {
 function unidentifiedShippingQuantity(order: TcgPlayerShippingOrder): number {
   if (!order.products?.length) return 0;
   const productQuantity = order.products.reduce((sum, line) => sum + line.quantity, 0);
-  const unidentified = order.products.filter((line) => !exactSkuIdentity(line)).reduce((sum, line) => sum + line.quantity, 0);
+  const unidentified = order.products.filter((line) => !shippingInventorySkuId(line)).reduce((sum, line) => sum + line.quantity, 0);
   return unidentified + Math.max(0, order["Item Count"] - productQuantity);
 }
 
@@ -89,6 +85,7 @@ function unavailableLine(skuId: string, order: TcgPlayerShippingOrder, quantity:
     currentSourceOrderRevision: 0,
     orderTime: order["Order Date"],
     orderedQuantity: quantity,
+    soldTotal: null,
     matchedQuantity: 0,
     unmatchedQuantity: quantity,
     priceKnownQuantity: 0,
@@ -168,6 +165,7 @@ function currentLineHistory(row: AllocationRow, shippingQuantity: number): Shipp
     currentSourceOrderRevision: row.currentSourceOrderRevision,
     orderTime,
     orderedQuantity: shippingQuantity,
+    soldTotal: row.persistedSoldTotal,
     matchedQuantity: row.matchedQuantity ?? 0,
     unmatchedQuantity: row.unmatchedQuantity ?? shippingQuantity,
     priceKnownQuantity: row.priceKnownQuantity ?? 0,
@@ -208,8 +206,23 @@ export async function enrichShippingOrdersWithIntakeHistory(
       : [...(persisted?.values() ?? [])].map((row) => currentLineHistory(row, row.currentOrderedQuantity));
     const unidentifiedQuantity = unidentifiedShippingQuantity(order);
     if (unidentifiedQuantity) lines.push(unavailableLine("unidentified", order, unidentifiedQuantity));
+    if (!order.products?.length) {
+      const persistedQuantity = lines.reduce((sum, line) => sum + line.orderedQuantity, 0);
+      const persistedSoldTotal = lines.reduce((sum, line) => sum + (line.soldTotal ?? 0), 0);
+      if (persistedQuantity < order["Item Count"]) {
+        lines.push(unavailableLine("unidentified", order, order["Item Count"] - persistedQuantity));
+      }
+      if (persistedQuantity > order["Item Count"]
+        || (persistedQuantity === order["Item Count"]
+          && Math.round(persistedSoldTotal * 100) !== Math.round(order["Value Of Products"] * 100))) {
+        for (const line of lines) {
+          line.status = "mismatch";
+          line.statusReason = "Persisted SKU quantities or sale proceeds do not match the shipping order total.";
+        }
+      }
+    }
     if (!lines.length && order["Item Count"] > 0) lines.push(unavailableLine("unidentified", order, order["Item Count"]));
-    return { ...order, intakeHistory: { orderNumber: order["Order #"], lines, refreshedAt } };
+    return { ...order, intakeHistory: { orderNumber: order["Order #"], sellerKey: sellerKey.trim(), lines, refreshedAt } };
   });
 }
 

--- a/app/features/shipping-export/services/shippingIntakeHistory.server.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.server.ts
@@ -206,6 +206,13 @@ export async function enrichShippingOrdersWithIntakeHistory(
       : [...(persisted?.values() ?? [])].map((row) => currentLineHistory(row, row.currentOrderedQuantity));
     const unidentifiedQuantity = unidentifiedShippingQuantity(order);
     if (unidentifiedQuantity) lines.push(unavailableLine("unidentified", order, unidentifiedQuantity));
+    const productQuantity = order.products?.reduce((sum, line) => sum + line.quantity, 0) ?? 0;
+    if (order.products?.length && productQuantity > order["Item Count"]) {
+      for (const line of lines) {
+        line.status = "mismatch";
+        line.statusReason = `Shipping product rows have ${productQuantity} units; the order total has ${order["Item Count"]}.`;
+      }
+    }
     if (!order.products?.length) {
       const persistedQuantity = lines.reduce((sum, line) => sum + line.orderedQuantity, 0);
       const persistedSoldTotal = lines.reduce((sum, line) => sum + (line.soldTotal ?? 0), 0);

--- a/app/features/shipping-export/services/shippingIntakeHistory.server.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.server.ts
@@ -100,12 +100,19 @@ function unavailableLine(skuId: string, order: TcgPlayerShippingOrder, quantity:
   };
 }
 
-function historyStatus(row: AllocationRow, shippingQuantity: number): {
+function historyStatus(row: AllocationRow, shippingQuantity: number, shippingEvidence?: { orderTime: string; soldTotal: number }): {
   status: ShippingIntakeHistoryStatus;
   reason?: string;
 } {
   if (row.currentOrderedQuantity !== shippingQuantity) {
     return { status: "mismatch", reason: `Shipping has ${shippingQuantity} units; order history has ${row.currentOrderedQuantity}.` };
+  }
+  if (shippingEvidence) {
+    const shippingTime = Date.parse(shippingEvidence.orderTime);
+    if (!Number.isFinite(shippingTime) || shippingTime !== row.currentOrderTime.getTime()
+      || Math.round(shippingEvidence.soldTotal * 100) !== Math.round(row.persistedSoldTotal * 100)) {
+      return { status: "mismatch", reason: "Shipping order time or SKU sale proceeds do not match current persisted order history." };
+    }
   }
   if (row.state === "held" || row.replayStatus === "held") {
     return { status: "held", reason: row.queueHoldReason ?? row.holdReason ?? "FIFO allocation needs review." };
@@ -119,8 +126,8 @@ function historyStatus(row: AllocationRow, shippingQuantity: number): {
   return { status: "current" };
 }
 
-function currentLineHistory(row: AllocationRow, shippingQuantity: number): ShippingIntakeLineHistory {
-  let state = historyStatus(row, shippingQuantity);
+function currentLineHistory(row: AllocationRow, shippingQuantity: number, shippingEvidence?: { orderTime: string; soldTotal: number }): ShippingIntakeLineHistory {
+  let state = historyStatus(row, shippingQuantity, shippingEvidence);
   const allocationTime = row.allocatedOrderTime ?? row.currentOrderTime;
   const orderTime = allocationTime.toISOString();
   const lots: ShippingIntakeLot[] = row.lots.map((lot) => {
@@ -201,7 +208,8 @@ export async function enrichShippingOrdersWithIntakeHistory(
     const lines = grouped.size
       ? [...grouped.entries()].map(([skuId, values]) => {
         const row = persisted?.get(skuId);
-        return row ? currentLineHistory(row, values.quantity) : unavailableLine(skuId, order, values.quantity);
+        return row ? currentLineHistory(row, values.quantity, { orderTime: order["Order Date"], soldTotal: values.soldTotal })
+          : unavailableLine(skuId, order, values.quantity);
       })
       : [...(persisted?.values() ?? [])].map((row) => currentLineHistory(row, row.currentOrderedQuantity));
     const unidentifiedQuantity = unidentifiedShippingQuantity(order);

--- a/app/features/shipping-export/services/shippingIntakeHistory.test.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.test.ts
@@ -7,13 +7,13 @@ const source = [{
   State: "", PostalCode: "", Country: "US", "Order Date": "2026-08-01T12:00:00.000Z", "Product Weight": 0,
   "Shipping Method": "Standard", "Item Count": 1, "Value Of Products": 9, "Shipping Fee Paid": 0,
   "Tracking #": "", Carrier: "", products: [{ name: "Card", quantity: 1, unitPrice: 9, skuId: 9001, inventorySkuId: "9001" }],
-  intakeHistory: { orderNumber: "A", refreshedAt: "stale", lines: [] },
+  intakeHistory: { orderNumber: "A", sellerKey: "seller-a", refreshedAt: "stale", lines: [] },
 }] satisfies TcgPlayerShippingOrder[];
 
 let sent: any;
 const refreshed = await refreshShippingIntakeHistory(source, "seller-a", async (_url, init) => {
   sent = JSON.parse(String(init?.body));
-  return new Response(JSON.stringify({ histories: [{ orderNumber: "A", refreshedAt: "fresh", lines: [] }] }),
+  return new Response(JSON.stringify({ histories: [{ orderNumber: "A", sellerKey: "seller-a", refreshedAt: "fresh", lines: [] }] }),
     { status: 200, headers: { "Content-Type": "application/json" } });
 });
 assert.equal(refreshed[0]?.intakeHistory?.refreshedAt, "fresh");

--- a/app/features/shipping-export/services/shippingIntakeHistory.test.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.test.ts
@@ -18,7 +18,7 @@ const refreshed = await refreshShippingIntakeHistory(source, "seller-a", async (
 });
 assert.equal(refreshed[0]?.intakeHistory?.refreshedAt, "fresh");
 assert.deepEqual(sent, { sellerKey: "seller-a", orders: [{ orderNumber: "A", orderDate: "2026-08-01T12:00:00.000Z",
-  itemCount: 1, products: [{ quantity: 1, skuId: 9001, inventorySkuId: "9001" }] }] });
+  itemCount: 1, valueOfProducts: 9, products: [{ quantity: 1, unitPrice: 9, skuId: 9001, inventorySkuId: "9001" }] }] });
 assert.equal(JSON.stringify(sent).includes("Private"), false);
 assert.equal(withoutShippingIntakeHistory(source)[0]?.intakeHistory, undefined);
 

--- a/app/features/shipping-export/services/shippingIntakeHistory.test.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { refreshShippingIntakeHistory, withoutShippingIntakeHistory } from "./shippingIntakeHistory";
+import type { TcgPlayerShippingOrder } from "../types/shippingExport";
+
+const source = [{
+  "Order #": "A", FirstName: "Private", LastName: "Buyer", Address1: "Private address", Address2: "", City: "",
+  State: "", PostalCode: "", Country: "US", "Order Date": "2026-08-01T12:00:00.000Z", "Product Weight": 0,
+  "Shipping Method": "Standard", "Item Count": 1, "Value Of Products": 9, "Shipping Fee Paid": 0,
+  "Tracking #": "", Carrier: "", products: [{ name: "Card", quantity: 1, unitPrice: 9, skuId: 9001, inventorySkuId: "9001" }],
+  intakeHistory: { orderNumber: "A", refreshedAt: "stale", lines: [] },
+}] satisfies TcgPlayerShippingOrder[];
+
+let sent: any;
+const refreshed = await refreshShippingIntakeHistory(source, "seller-a", async (_url, init) => {
+  sent = JSON.parse(String(init?.body));
+  return new Response(JSON.stringify({ histories: [{ orderNumber: "A", refreshedAt: "fresh", lines: [] }] }),
+    { status: 200, headers: { "Content-Type": "application/json" } });
+});
+assert.equal(refreshed[0]?.intakeHistory?.refreshedAt, "fresh");
+assert.deepEqual(sent, { sellerKey: "seller-a", orders: [{ orderNumber: "A", orderDate: "2026-08-01T12:00:00.000Z",
+  itemCount: 1, products: [{ quantity: 1, skuId: 9001, inventorySkuId: "9001" }] }] });
+assert.equal(JSON.stringify(sent).includes("Private"), false);
+assert.equal(withoutShippingIntakeHistory(source)[0]?.intakeHistory, undefined);
+
+console.log("PASS saved shipping history refresh sends only local identity evidence and can remove stale analytics");

--- a/app/features/shipping-export/services/shippingIntakeHistory.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.ts
@@ -34,6 +34,9 @@ export async function refreshShippingIntakeHistory(
     body: JSON.stringify({ sellerKey, orders: orders.map(requestOrder) }),
   });
   const payload = await readJsonResponse<ShippingIntakeHistoryResponse>(response, "Failed to refresh intake history.");
+  if (payload.histories.some((history) => history.sellerKey !== sellerKey.trim())) {
+    throw new Error("Intake history response seller does not match the loaded workflow.");
+  }
   const byOrder = new Map(payload.histories.map((history) => [history.orderNumber, history]));
   return orders.map((order) => ({ ...order, intakeHistory: byOrder.get(order["Order #"]) }));
 }

--- a/app/features/shipping-export/services/shippingIntakeHistory.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.ts
@@ -10,8 +10,10 @@ function requestOrder(order: TcgPlayerShippingOrder): ShippingIntakeHistoryReque
     orderNumber: order["Order #"],
     orderDate: order["Order Date"],
     itemCount: order["Item Count"],
+    valueOfProducts: order["Value Of Products"],
     products: (order.products ?? []).map((line) => ({
       quantity: line.quantity,
+      unitPrice: line.unitPrice,
       ...(line.skuId === undefined ? {} : { skuId: line.skuId }),
       ...(line.inventorySkuId === undefined ? {} : { inventorySkuId: line.inventorySkuId }),
     })),

--- a/app/features/shipping-export/services/shippingIntakeHistory.ts
+++ b/app/features/shipping-export/services/shippingIntakeHistory.ts
@@ -1,0 +1,39 @@
+import { readJsonResponse } from "~/core/utils/readJsonResponse";
+import type {
+  ShippingIntakeHistoryRequestOrder,
+  ShippingIntakeHistoryResponse,
+  TcgPlayerShippingOrder,
+} from "../types/shippingExport";
+
+function requestOrder(order: TcgPlayerShippingOrder): ShippingIntakeHistoryRequestOrder {
+  return {
+    orderNumber: order["Order #"],
+    orderDate: order["Order Date"],
+    itemCount: order["Item Count"],
+    products: (order.products ?? []).map((line) => ({
+      quantity: line.quantity,
+      ...(line.skuId === undefined ? {} : { skuId: line.skuId }),
+      ...(line.inventorySkuId === undefined ? {} : { inventorySkuId: line.inventorySkuId }),
+    })),
+  };
+}
+
+export function withoutShippingIntakeHistory(orders: TcgPlayerShippingOrder[]): TcgPlayerShippingOrder[] {
+  return orders.map(({ intakeHistory: _history, ...order }) => order);
+}
+
+export async function refreshShippingIntakeHistory(
+  orders: TcgPlayerShippingOrder[],
+  sellerKey: string,
+  fetcher: typeof fetch = fetch,
+): Promise<TcgPlayerShippingOrder[]> {
+  if (!orders.length) return orders;
+  const response = await fetcher("/api/shipping-export/intake-history", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sellerKey, orders: orders.map(requestOrder) }),
+  });
+  const payload = await readJsonResponse<ShippingIntakeHistoryResponse>(response, "Failed to refresh intake history.");
+  const byOrder = new Map(payload.histories.map((history) => [history.orderNumber, history]));
+  return orders.map((order) => ({ ...order, intakeHistory: byOrder.get(order["Order #"]) }));
+}

--- a/app/features/shipping-export/services/shippingOrderIdentity.ts
+++ b/app/features/shipping-export/services/shippingOrderIdentity.ts
@@ -1,0 +1,7 @@
+import type { OrderLineItem } from "../types/shippingExport";
+
+/** Exact provider inventory identity used by both ledger attachment and display math. */
+export function shippingInventorySkuId(line: Pick<OrderLineItem, "inventorySkuId" | "skuId">): string | null {
+  if (line.inventorySkuId?.trim()) return line.inventorySkuId.trim();
+  return line.skuId === undefined ? null : String(line.skuId);
+}

--- a/app/features/shipping-export/services/tcgplayerSellerOrders.server.test.ts
+++ b/app/features/shipping-export/services/tcgplayerSellerOrders.server.test.ts
@@ -92,6 +92,7 @@ const testCases: TestCase[] = [
             quantity: 1,
             unitPrice: 10.01,
             skuId: 3191391,
+            inventorySkuId: "3191391",
             productId: 121234,
           },
         ],

--- a/app/features/shipping-export/services/tcgplayerSellerOrders.server.ts
+++ b/app/features/shipping-export/services/tcgplayerSellerOrders.server.ts
@@ -60,6 +60,12 @@ function normalizeOrderStatus(status: string): string {
   return status.trim().replace(/\s+/g, "").toLowerCase();
 }
 
+function canonicalNumericSku(value: string): number | undefined {
+  if (!/^[1-9]\d{0,9}$/.test(value)) return undefined;
+  const sku = Number(value);
+  return Number.isSafeInteger(sku) && sku <= 2_147_483_647 ? sku : undefined;
+}
+
 function getSingleOrderWarnings(order: SellerOrderDetail): string[] {
   const normalizedStatus = normalizeOrderStatus(order.status);
 
@@ -101,7 +107,8 @@ export function mapSellerOrderDetailToShippingOrder(
       name: p.name,
       quantity: p.quantity,
       unitPrice: p.unitPrice,
-      skuId: Number.parseInt(p.skuId, 10) || undefined,
+      skuId: canonicalNumericSku(p.skuId),
+      inventorySkuId: p.skuId,
       productId: Number.parseInt(p.productId, 10) || undefined,
     })),
   };

--- a/app/features/shipping-export/services/tcgplayerSellerOrders.server.ts
+++ b/app/features/shipping-export/services/tcgplayerSellerOrders.server.ts
@@ -103,14 +103,14 @@ export function mapSellerOrderDetailToShippingOrder(
     "Shipping Fee Paid": order.transaction.shippingAmount,
     "Tracking #": order.trackingNumbers?.[0]?.trim() ?? "",
     Carrier: "",
-    products: order.products.map((p) => ({
-      name: p.name,
-      quantity: p.quantity,
-      unitPrice: p.unitPrice,
-      skuId: canonicalNumericSku(p.skuId),
-      inventorySkuId: p.skuId,
-      productId: Number.parseInt(p.productId, 10) || undefined,
-    })),
+    products: order.products.map((p) => {
+      const inventorySkuId = p.skuId.trim();
+      return {
+        name: p.name, quantity: p.quantity, unitPrice: p.unitPrice,
+        skuId: canonicalNumericSku(inventorySkuId), inventorySkuId,
+        productId: Number.parseInt(p.productId, 10) || undefined,
+      };
+    }),
   };
 }
 

--- a/app/features/shipping-export/types/shippingExport.ts
+++ b/app/features/shipping-export/types/shippingExport.ts
@@ -317,7 +317,8 @@ export interface ShippingIntakeHistoryRequestOrder {
   orderNumber: string;
   orderDate: string;
   itemCount: number;
-  products: Array<Pick<OrderLineItem, "quantity" | "skuId" | "inventorySkuId">>;
+  valueOfProducts: number;
+  products: Array<Pick<OrderLineItem, "quantity" | "unitPrice" | "skuId" | "inventorySkuId">>;
 }
 
 export interface ShippingIntakeHistoryResponse {

--- a/app/features/shipping-export/types/shippingExport.ts
+++ b/app/features/shipping-export/types/shippingExport.ts
@@ -57,8 +57,60 @@ export interface OrderLineItem {
   unitPrice: number;
   skuId?: number;
   productId?: number;
+  /** Exact provider inventory identity; only canonical numeric values are FIFO eligible. */
+  inventorySkuId?: string;
   /** Current TCGPlayer market price for the SKU, when one was available at load time. */
   marketPrice?: number;
+}
+
+export type ShippingIntakeHistoryStatus =
+  | "current"
+  | "pending"
+  | "held"
+  | "mismatch"
+  | "unavailable";
+
+export type ShippingIntakePriceProvenance = "recorded" | "estimated" | "unknown";
+
+export interface ShippingIntakeLot {
+  supplyKey: string;
+  receiptId: number;
+  quantity: number;
+  availableAt: string;
+  sourceKind: "opening_balance" | "received" | "physical_restock" | "quantity_correction";
+  intakeAt: string | null;
+  daysHeld: number | null;
+  intakeMarketValue: number | null;
+  priceProvenance: ShippingIntakePriceProvenance;
+}
+
+/** One persisted seller-order SKU aggregate. Provider rows with the same SKU share this history once. */
+export interface ShippingIntakeLineHistory {
+  skuId: string;
+  status: ShippingIntakeHistoryStatus;
+  statusReason?: string;
+  allocationRevisionId: string | null;
+  allocatedSourceOrderRevision: number | null;
+  currentSourceOrderRevision: number;
+  orderTime: string;
+  orderedQuantity: number;
+  matchedQuantity: number;
+  unmatchedQuantity: number;
+  priceKnownQuantity: number;
+  dateKnownQuantity: number;
+  recordedPriceQuantity: number;
+  estimatedPriceQuantity: number;
+  intakeMarketTotal: number | null;
+  weightedDaysHeld: number | null;
+  minimumDaysHeld: number | null;
+  maximumDaysHeld: number | null;
+  lots: ShippingIntakeLot[];
+}
+
+export interface ShippingOrderIntakeHistory {
+  orderNumber: string;
+  lines: ShippingIntakeLineHistory[];
+  refreshedAt: string;
 }
 
 export interface TcgPlayerShippingOrder {
@@ -80,6 +132,7 @@ export interface TcgPlayerShippingOrder {
   "Tracking #": string;
   Carrier: string;
   products?: OrderLineItem[];
+  intakeHistory?: ShippingOrderIntakeHistory;
 }
 
 export type OutboundWorkflowStep =
@@ -255,6 +308,17 @@ export interface ShippingLiveOrderLoadResponse {
   orders: TcgPlayerShippingOrder[];
   warnings?: string[];
   historyCoverage?: import("~/features/seller-order-history/types/sellerOrderHistory").SellerOrderCoverage;
+}
+
+export interface ShippingIntakeHistoryRequestOrder {
+  orderNumber: string;
+  orderDate: string;
+  itemCount: number;
+  products: Array<Pick<OrderLineItem, "quantity" | "skuId" | "inventorySkuId">>;
+}
+
+export interface ShippingIntakeHistoryResponse {
+  histories: ShippingOrderIntakeHistory[];
 }
 
 export interface ShippingPostageBatchLabelRequestItem {

--- a/app/features/shipping-export/types/shippingExport.ts
+++ b/app/features/shipping-export/types/shippingExport.ts
@@ -94,6 +94,8 @@ export interface ShippingIntakeLineHistory {
   currentSourceOrderRevision: number;
   orderTime: string;
   orderedQuantity: number;
+  /** Persisted aggregate sale proceeds for this exact SKU, used when shipping has no product rows. */
+  soldTotal: number | null;
   matchedQuantity: number;
   unmatchedQuantity: number;
   priceKnownQuantity: number;
@@ -109,6 +111,7 @@ export interface ShippingIntakeLineHistory {
 
 export interface ShippingOrderIntakeHistory {
   orderNumber: string;
+  sellerKey: string;
   lines: ShippingIntakeLineHistory[];
   refreshedAt: string;
 }

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -2,6 +2,7 @@ import { type RouteConfig, index } from "@react-router/dev/routes";
 
 export default [
   { path: "/api/inventory-fifo", file: "features/inventory-fifo/routes/api.inventory-fifo.ts" },
+  { path: "/api/shipping-export/intake-history", file: "features/shipping-export/routes/api.shipping-export-intake-history.ts" },
   { path: "/api/inventory-opening-balance", file: "features/inventory-opening-balance/routes/api.inventory-opening-balance.ts" },
   {
     path: "/api/seller-order-history",

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -43,6 +43,7 @@ import "../features/shipping-export/components/steps/PullSheetStep.test";
 import "../features/shipping-export/components/steps/ApplyTrackingStep.test";
 import "../features/shipping-export/components/steps/NotifyStep.test";
 import "../features/shipping-export/components/OrderMarketSummary.test";
+import "../features/shipping-export/components/IntakeHistorySummary.test";
 import "../features/shipping-export/routes/api.shipping-export-batch-labels.test";
 import "../features/shipping-export/routes/api.shipping-export-packing-slips-export.test";
 import "../features/shipping-export/routes/api.shipping-export-postage-lookups.test";
@@ -51,6 +52,7 @@ import "../features/shipping-export/routes/api.shipping-export-pull-sheet-export
 import "../features/shipping-export/routes/api.shipping-export-tcgplayer-tracking.test";
 import "../features/shipping-export/routes/api.shipping-export-tcgplayer-shipped-messages.test";
 import "../features/shipping-export/routes/api.shipping-export-tcgplayer-orders.test";
+import "../features/shipping-export/routes/api.shipping-export-intake-history.test";
 import "../features/shipping-export/services/easyPostPostage.server.test";
 import "../features/shipping-export/services/shippingExportUtils.test";
 import "../features/shipping-export/services/savedShippingWorkflow.test";
@@ -60,6 +62,9 @@ import "../features/shipping-export/services/tcgplayerShippedMessages.server.tes
 import "../features/shipping-export/services/tcgplayerSellerOrders.server.test";
 import "../features/shipping-export/services/orderMarketPrices.server.test";
 import "../features/shipping-export/services/orderMarketComparison.test";
+import "../features/shipping-export/services/orderIntakeComparison.test";
+import "../features/shipping-export/services/shippingIntakeHistory.server.test";
+import "../features/shipping-export/services/shippingIntakeHistory.test";
 import "../features/pull-sheet/utils/pullSheetItems.test";
 import "../features/product-price-matrix/services/productPriceMatrix.server.test";
 import "../features/product-price-matrix/services/conditionLadder.test";

--- a/docs/shipping-intake-history.md
+++ b/docs/shipping-intake-history.md
@@ -6,7 +6,7 @@ Age is frozen from each receipt's intake time to the persisted order time. The p
 
 The server attaches history only when seller, order number, exact raw SKU, aggregate SKU quantity, allocation source revision, and persisted FIFO totals agree. Repeated provider rows for a SKU share one SKU aggregate. Pending, held, mismatched, unsupported, and unidentified quantities remain visible and do not contribute stale intake totals. Combined shipments de-duplicate external order numbers.
 
-`POST /api/shipping-export/intake-history` refreshes up to 500 saved orders using only order number, order date, item count, raw SKU identity, and quantity. It is bound to the seller saved in Shipping Configuration. Saved workflows refresh locally on restore, window focus, and every five minutes. A failed refresh removes the saved analytics and leaves shipping operations available.
+`POST /api/shipping-export/intake-history` refreshes up to 500 saved orders using only order number, order date, item count, product value, raw SKU identity, quantity, and unit price. It sends no buyer, address, card-name, or tracking data and is bound to the seller saved in Shipping Configuration. Saved workflows refresh locally on restore, window focus, and every five minutes. A failed refresh removes the saved analytics and leaves shipping operations available.
 
 The guarded repository integration requires an explicit disposable database:
 

--- a/docs/shipping-intake-history.md
+++ b/docs/shipping-intake-history.md
@@ -1,0 +1,19 @@
+# Shipping intake history
+
+Shipping order loads keep today's TCG market comparison separate from the market snapshot recorded when inventory was received. Intake market is the sum of the FIFO receipt segments whose prices are known; sold value is compared only for the same covered unit count and is not labeled profit. A recorded zero-dollar snapshot remains known. Price and intake-date coverage are counted independently.
+
+Age is frozen from each receipt's intake time to the persisted order time. The primary age is quantity weighted across date-known units, with the shortest and longest lot ages shown beside it. Receipt detail also identifies dated physical returns and quantity corrections by their later availability time.
+
+The server attaches history only when seller, order number, exact raw SKU, aggregate SKU quantity, allocation source revision, and persisted FIFO totals agree. Repeated provider rows for a SKU share one SKU aggregate. Pending, held, mismatched, unsupported, and unidentified quantities remain visible and do not contribute stale intake totals. Combined shipments de-duplicate external order numbers.
+
+`POST /api/shipping-export/intake-history` refreshes up to 500 saved orders using only order number, order date, item count, raw SKU identity, and quantity. It is bound to the seller saved in Shipping Configuration. Saved workflows refresh locally on restore, window focus, and every five minutes. A failed refresh removes the saved analytics and leaves shipping operations available.
+
+The guarded repository integration requires an explicit disposable database:
+
+```powershell
+$env:TEST_DATABASE_URL='postgresql://postgres:postgres@localhost:5433/tcgplayer_fifo_test_shipping_history'
+$env:DATABASE_URL=$env:TEST_DATABASE_URL
+npx tsx app/features/shipping-export/services/shippingIntakeHistory.server.integration.test.ts
+```
+
+The test refuses to load the database module unless both variables match and the database name begins with `tcgplayer_fifo_test_`.


### PR DESCRIPTION
Shipping now enriches loaded seller orders from the persisted FIFO projection in one bounded local query. Current market and intake market stay explicitly separate; sold versus intake market is calculated only across price-covered units and is never labeled profit. Weighted age is fixed at the order time, price/date/match coverage remain independent, known zero values stay known, and receipt details include original intake plus later return/correction availability.

The same compact history appears in the order-load summary, pull sheet, postage shipments, and both packing layouts. Packing cards and fallback rows show exact-SKU totals without duplicating repeated provider rows; unequal repeated-row sale prices use the SKU-weighted sale value. Combined shipments de-duplicate order numbers. Pending, held, mismatched, unsupported, and unidentified evidence stays visible without contributing stale analytics.

Normal seller-order loads enrich fail-open. Saved workflows retain history, then refresh through a configured-seller local endpoint on restore, focus, and every five minutes. Refreshes carry only order/SKU/quantity/sale evidence, use source and request-generation fences, and clear stale analytics on failure while leaving shipping usable.

Validation:
- `npm test`
- `npm run typecheck`
- `npm run build`
- fresh migrations 001–039 on a disposable `tcgplayer_fifo_test_*` database
- guarded real-SQL mixed-lot and seller-isolation integration
- focused comparison, enrichment, route, saved-refresh, accessible disclosure, pull-sheet, and both packing-layout checks
- independent 500-order bulk projection and browser checks for mixed lots, combined shipments, partial coverage, outage restore, narrow layout, current-vs-intake labels, and keyboard disclosure

No customer-facing documents, marketplace mutations, or production writes are included.

Closes #60
