### PR TITLE
Add inventory history rollout diagnostics and recovery runbook

### DIFF
--- a/app/core/db/index.server.ts
+++ b/app/core/db/index.server.ts
@@ -11,6 +11,7 @@ export { continuousPricingRepository } from "./repositories/continuousPricing.se
 export { httpConfigRepository } from "./repositories/httpConfig.server";
 export { inventoryBatchesRepository } from "./repositories/inventoryBatches.server";
 export { inventoryFifoRepository } from "./repositories/inventoryFifo.server";
+export { inventoryHistoryDiagnosticsRepository } from "./repositories/inventoryHistoryDiagnostics.server";
 export { inventoryOpeningBalancesRepository } from "./repositories/inventoryOpeningBalances.server";
 export { inventoryBatchPricingJobsRepository } from "./repositories/inventoryBatchPricingJobs.server";
 export { inventoryPublicationsRepository } from "./repositories/inventoryPublications.server";

--- a/app/core/db/repositories/inventoryHistoryDiagnostics.server.ts
+++ b/app/core/db/repositories/inventoryHistoryDiagnostics.server.ts
@@ -1,0 +1,125 @@
+import type { InventoryHistoryDiagnostics } from "~/features/inventory-history/types/inventoryHistoryDiagnostics";
+import { queryOne } from "../database.server";
+import { sellerOrderHistoryRepository } from "./sellerOrderHistory.server";
+
+type DiagnosticRow = {
+  openingRunId: string | null;
+  openingCutoffAt: Date | null;
+  openingAppliedAt: Date | null;
+  validationObservationId: string | null;
+  unsupportedPositiveItemCount: number;
+  unsupportedPositiveQuantity: number;
+  queuePending: number;
+  queueProcessing: number;
+  queueHeld: number;
+  linesAllocated: number;
+  linesPending: number;
+  linesHeld: number;
+  linesUnsupported: number;
+  orderedQuantity: number;
+  matchedQuantity: number;
+  unmatchedQuantity: number;
+  priceUnavailableQuantity: number;
+  dateUnavailableQuantity: number;
+  unresolvedDifferenceCount: number;
+  unresolvedDifferenceSkuCount: number;
+  unresolvedDifferenceQuantity: number;
+  receiptCount: number;
+  receivedQuantity: number;
+  missingMarketSnapshotQuantity: number;
+  missingIntakeDateQuantity: number;
+  publicationsPlanned: number;
+  publicationsActive: number;
+  publicationsAmbiguous: number;
+  publicationsFailed: number;
+  publicationsRetried: number;
+  oldestPlannedAt: Date | null;
+  lastPublishedAt: Date | null;
+};
+
+const count = (value: number | null | undefined) => value ?? 0;
+const iso = (value: Date | null | undefined) => value?.toISOString() ?? null;
+
+export const inventoryHistoryDiagnosticsRepository = {
+  async get(sellerKey: string): Promise<InventoryHistoryDiagnostics> {
+    const seller = sellerKey.trim();
+    if (!seller) throw new Error("Seller key is required.");
+    const [orderCoverage, row] = await Promise.all([
+      sellerOrderHistoryRepository.getCoverage(seller),
+      queryOne<DiagnosticRow>(`WITH
+        opening AS (
+          SELECT run.id::text AS "openingRunId",run.cutoff_at AS "openingCutoffAt",
+            run.applied_at AS "openingAppliedAt",run.validation_observation_id::text AS "validationObservationId",
+            COALESCE(validation.unsupported_positive_item_count,0)::int AS "unsupportedPositiveItemCount",
+            COALESCE(validation.unsupported_positive_quantity,0)::int AS "unsupportedPositiveQuantity"
+          FROM inventory_opening_balance_runs run
+          LEFT JOIN inventory_complete_observations validation ON validation.id=run.validation_observation_id
+          WHERE run.seller_key=$1 AND run.status='applied' LIMIT 1
+        ), queue AS (
+          SELECT COUNT(*) FILTER (WHERE status='pending')::int AS "queuePending",
+            COUNT(*) FILTER (WHERE status='processing')::int AS "queueProcessing",
+            COUNT(*) FILTER (WHERE status='held')::int AS "queueHeld"
+          FROM inventory_fifo_replay_queue WHERE seller_key=$1
+        ), fifo AS (
+          SELECT COUNT(*) FILTER (WHERE state='allocated')::int AS "linesAllocated",
+            COUNT(*) FILTER (WHERE state='pending')::int AS "linesPending",
+            COUNT(*) FILTER (WHERE state='held')::int AS "linesHeld",
+            COUNT(*) FILTER (WHERE state='unsupported')::int AS "linesUnsupported",
+            COALESCE(SUM(ordered_quantity),0)::int AS "orderedQuantity",
+            COALESCE(SUM(matched_quantity),0)::int AS "matchedQuantity",
+            COALESCE(SUM(unmatched_quantity),0)::int AS "unmatchedQuantity",
+            COALESCE(SUM(matched_quantity-price_known_quantity),0)::int AS "priceUnavailableQuantity",
+            COALESCE(SUM(matched_quantity-date_known_quantity),0)::int AS "dateUnavailableQuantity"
+          FROM inventory_fifo_lines WHERE seller_key=$1
+        ), differences AS (
+          SELECT COUNT(*)::int AS "unresolvedDifferenceCount",COUNT(DISTINCT sku)::int AS "unresolvedDifferenceSkuCount",
+            COALESCE(SUM(ABS(quantity_delta)),0)::int AS "unresolvedDifferenceQuantity"
+          FROM inventory_observation_differences WHERE seller_key=$1 AND status='unresolved'
+        ), receipts AS (
+          SELECT COUNT(*)::int AS "receiptCount",COALESCE(SUM(original_quantity),0)::int AS "receivedQuantity",
+            COALESCE(SUM(original_quantity) FILTER (WHERE market_value IS NULL),0)::int AS "missingMarketSnapshotQuantity",
+            COALESCE(SUM(original_quantity) FILTER (WHERE intake_at IS NULL),0)::int AS "missingIntakeDateQuantity"
+          FROM inventory_receipts WHERE seller_key=$1 AND receipt_kind='received'
+        ), publications AS (
+          SELECT COUNT(*) FILTER (WHERE status='planned')::int AS "publicationsPlanned",
+            COUNT(*) FILTER (WHERE status IN ('staging','staged','publishing'))::int AS "publicationsActive",
+            COUNT(*) FILTER (WHERE status='ambiguous')::int AS "publicationsAmbiguous",
+            COUNT(*) FILTER (WHERE status='failed')::int AS "publicationsFailed",
+            COUNT(*) FILTER (WHERE attempt_count>1)::int AS "publicationsRetried",
+            MIN(created_at) FILTER (WHERE status='planned') AS "oldestPlannedAt",
+            MAX(published_at) AS "lastPublishedAt"
+          FROM inventory_publications WHERE seller_key=$1
+        )
+        SELECT opening.*,queue.*,fifo.*,differences.*,receipts.*,publications.*
+        FROM queue CROSS JOIN fifo CROSS JOIN differences CROSS JOIN receipts CROSS JOIN publications
+        LEFT JOIN opening ON true`, [seller]),
+    ]);
+    if (!row) throw new Error("Inventory history diagnostics could not be read.");
+    return {
+      sellerKey: seller,
+      generatedAt: new Date().toISOString(),
+      orderCoverage,
+      openingBalance: {
+        status: row.openingRunId ? "applied" : "not_applied",
+        runId: row.openingRunId,
+        cutoffAt: iso(row.openingCutoffAt),
+        appliedAt: iso(row.openingAppliedAt),
+        validationObservationId: row.validationObservationId,
+        unsupportedPositiveItemCount: count(row.unsupportedPositiveItemCount),
+        unsupportedPositiveQuantity: count(row.unsupportedPositiveQuantity),
+      },
+      fifo: {
+        queue: { pending: count(row.queuePending), processing: count(row.queueProcessing), held: count(row.queueHeld) },
+        lines: { allocated: count(row.linesAllocated), pending: count(row.linesPending), held: count(row.linesHeld), unsupported: count(row.linesUnsupported) },
+        orderedQuantity: count(row.orderedQuantity), matchedQuantity: count(row.matchedQuantity),
+        unmatchedQuantity: count(row.unmatchedQuantity), priceUnavailableQuantity: count(row.priceUnavailableQuantity),
+        dateUnavailableQuantity: count(row.dateUnavailableQuantity),
+      },
+      stockDifferences: { unresolvedCount: count(row.unresolvedDifferenceCount), affectedSkuCount: count(row.unresolvedDifferenceSkuCount), absoluteQuantity: count(row.unresolvedDifferenceQuantity) },
+      receivedLots: { receiptCount: count(row.receiptCount), receivedQuantity: count(row.receivedQuantity),
+        missingMarketSnapshotQuantity: count(row.missingMarketSnapshotQuantity), missingIntakeDateQuantity: count(row.missingIntakeDateQuantity) },
+      publications: { planned: count(row.publicationsPlanned), active: count(row.publicationsActive), ambiguous: count(row.publicationsAmbiguous),
+        failed: count(row.publicationsFailed), retried: count(row.publicationsRetried), oldestPlannedAt: iso(row.oldestPlannedAt), lastPublishedAt: iso(row.lastPublishedAt) },
+    };
+  },
+};

--- a/app/core/db/repositories/inventoryHistoryDiagnostics.server.ts
+++ b/app/core/db/repositories/inventoryHistoryDiagnostics.server.ts
@@ -20,10 +20,13 @@ type DiagnosticRow = {
   linesUnsupported: number;
   linesExcludedPreCutoff: number;
   linesRemoved: number;
+  queuedLinesPending: number;
+  queuedLinesProcessing: number;
+  queuedLinesHeld: number;
   settledOrderedQuantity: number;
   settledMatchedQuantity: number;
   settledUnmatchedQuantity: number;
-  pendingQuantity: number;
+  pendingOrProcessingQuantity: number;
   heldQuantity: number;
   priceUnavailableQuantity: number;
   dateUnavailableQuantity: number;
@@ -77,14 +80,19 @@ export const inventoryHistoryDiagnosticsRepository = {
             COUNT(*) FILTER (WHERE state='unsupported')::int AS "linesUnsupported",
             COUNT(*) FILTER (WHERE state='excluded_pre_cutoff')::int AS "linesExcludedPreCutoff",
             COUNT(*) FILTER (WHERE state='removed')::int AS "linesRemoved",
-            COALESCE(SUM(ordered_quantity) FILTER (WHERE state IN ('allocated','partial','unmatched')),0)::int AS "settledOrderedQuantity",
-            COALESCE(SUM(matched_quantity) FILTER (WHERE state IN ('allocated','partial','unmatched')),0)::int AS "settledMatchedQuantity",
-            COALESCE(SUM(unmatched_quantity) FILTER (WHERE state IN ('allocated','partial','unmatched')),0)::int AS "settledUnmatchedQuantity",
-            COALESCE(SUM(ordered_quantity) FILTER (WHERE state='pending'),0)::int AS "pendingQuantity",
-            COALESCE(SUM(ordered_quantity) FILTER (WHERE state='held'),0)::int AS "heldQuantity",
-            COALESCE(SUM(matched_quantity-price_known_quantity) FILTER (WHERE state IN ('allocated','partial','unmatched')),0)::int AS "priceUnavailableQuantity",
-            COALESCE(SUM(matched_quantity-date_known_quantity) FILTER (WHERE state IN ('allocated','partial','unmatched')),0)::int AS "dateUnavailableQuantity"
-          FROM inventory_fifo_lines WHERE seller_key=$1
+            COUNT(*) FILTER (WHERE replay.status='pending' AND line.state NOT IN ('excluded_pre_cutoff','removed','unsupported'))::int AS "queuedLinesPending",
+            COUNT(*) FILTER (WHERE replay.status='processing' AND line.state NOT IN ('excluded_pre_cutoff','removed','unsupported'))::int AS "queuedLinesProcessing",
+            COUNT(*) FILTER (WHERE replay.status='held' AND line.state NOT IN ('excluded_pre_cutoff','removed','unsupported'))::int AS "queuedLinesHeld",
+            COALESCE(SUM(line.ordered_quantity) FILTER (WHERE replay.status IS NULL AND line.state IN ('allocated','partial','unmatched')),0)::int AS "settledOrderedQuantity",
+            COALESCE(SUM(line.matched_quantity) FILTER (WHERE replay.status IS NULL AND line.state IN ('allocated','partial','unmatched')),0)::int AS "settledMatchedQuantity",
+            COALESCE(SUM(line.unmatched_quantity) FILTER (WHERE replay.status IS NULL AND line.state IN ('allocated','partial','unmatched')),0)::int AS "settledUnmatchedQuantity",
+            COALESCE(SUM(line.ordered_quantity) FILTER (WHERE (replay.status IN ('pending','processing') AND line.state NOT IN ('excluded_pre_cutoff','removed','unsupported')) OR (replay.status IS NULL AND line.state='pending')),0)::int AS "pendingOrProcessingQuantity",
+            COALESCE(SUM(line.ordered_quantity) FILTER (WHERE (replay.status='held' AND line.state NOT IN ('excluded_pre_cutoff','removed','unsupported')) OR (replay.status IS NULL AND line.state='held')),0)::int AS "heldQuantity",
+            COALESCE(SUM(line.matched_quantity-line.price_known_quantity) FILTER (WHERE replay.status IS NULL AND line.state IN ('allocated','partial','unmatched')),0)::int AS "priceUnavailableQuantity",
+            COALESCE(SUM(line.matched_quantity-line.date_known_quantity) FILTER (WHERE replay.status IS NULL AND line.state IN ('allocated','partial','unmatched')),0)::int AS "dateUnavailableQuantity"
+          FROM inventory_fifo_lines line
+          LEFT JOIN inventory_fifo_replay_queue replay ON replay.seller_key=line.seller_key AND replay.sku=line.sku
+          WHERE line.seller_key=$1
         ), differences AS (
           SELECT COUNT(*)::int AS "observedDifferenceCount",
             COUNT(*) FILTER (WHERE status='unresolved')::int AS "unacknowledgedDifferenceCount",
@@ -130,8 +138,10 @@ export const inventoryHistoryDiagnosticsRepository = {
         lines: { allocated: count(row.linesAllocated), partial: count(row.linesPartial), unmatched: count(row.linesUnmatched),
           pending: count(row.linesPending), held: count(row.linesHeld), unsupported: count(row.linesUnsupported),
           excludedPreCutoff: count(row.linesExcludedPreCutoff), removed: count(row.linesRemoved) },
+        queuedLineProjections: { pending: count(row.queuedLinesPending), processing: count(row.queuedLinesProcessing),
+          held: count(row.queuedLinesHeld) },
         settledOrderedQuantity: count(row.settledOrderedQuantity), settledMatchedQuantity: count(row.settledMatchedQuantity),
-        settledUnmatchedQuantity: count(row.settledUnmatchedQuantity), pendingQuantity: count(row.pendingQuantity),
+        settledUnmatchedQuantity: count(row.settledUnmatchedQuantity), pendingOrProcessingQuantity: count(row.pendingOrProcessingQuantity),
         heldQuantity: count(row.heldQuantity), priceUnavailableQuantity: count(row.priceUnavailableQuantity),
         dateUnavailableQuantity: count(row.dateUnavailableQuantity),
       },

--- a/app/core/db/repositories/inventoryHistoryDiagnostics.server.ts
+++ b/app/core/db/repositories/inventoryHistoryDiagnostics.server.ts
@@ -13,15 +13,23 @@ type DiagnosticRow = {
   queueProcessing: number;
   queueHeld: number;
   linesAllocated: number;
+  linesPartial: number;
+  linesUnmatched: number;
   linesPending: number;
   linesHeld: number;
   linesUnsupported: number;
-  orderedQuantity: number;
-  matchedQuantity: number;
-  unmatchedQuantity: number;
+  linesExcludedPreCutoff: number;
+  linesRemoved: number;
+  settledOrderedQuantity: number;
+  settledMatchedQuantity: number;
+  settledUnmatchedQuantity: number;
+  pendingQuantity: number;
+  heldQuantity: number;
   priceUnavailableQuantity: number;
   dateUnavailableQuantity: number;
-  unresolvedDifferenceCount: number;
+  observedDifferenceCount: number;
+  unacknowledgedDifferenceCount: number;
+  acknowledgedDifferenceCount: number;
   unresolvedDifferenceSkuCount: number;
   unresolvedDifferenceQuantity: number;
   receiptCount: number;
@@ -62,19 +70,28 @@ export const inventoryHistoryDiagnosticsRepository = {
           FROM inventory_fifo_replay_queue WHERE seller_key=$1
         ), fifo AS (
           SELECT COUNT(*) FILTER (WHERE state='allocated')::int AS "linesAllocated",
+            COUNT(*) FILTER (WHERE state='partial')::int AS "linesPartial",
+            COUNT(*) FILTER (WHERE state='unmatched')::int AS "linesUnmatched",
             COUNT(*) FILTER (WHERE state='pending')::int AS "linesPending",
             COUNT(*) FILTER (WHERE state='held')::int AS "linesHeld",
             COUNT(*) FILTER (WHERE state='unsupported')::int AS "linesUnsupported",
-            COALESCE(SUM(ordered_quantity),0)::int AS "orderedQuantity",
-            COALESCE(SUM(matched_quantity),0)::int AS "matchedQuantity",
-            COALESCE(SUM(unmatched_quantity),0)::int AS "unmatchedQuantity",
-            COALESCE(SUM(matched_quantity-price_known_quantity),0)::int AS "priceUnavailableQuantity",
-            COALESCE(SUM(matched_quantity-date_known_quantity),0)::int AS "dateUnavailableQuantity"
+            COUNT(*) FILTER (WHERE state='excluded_pre_cutoff')::int AS "linesExcludedPreCutoff",
+            COUNT(*) FILTER (WHERE state='removed')::int AS "linesRemoved",
+            COALESCE(SUM(ordered_quantity) FILTER (WHERE state IN ('allocated','partial','unmatched')),0)::int AS "settledOrderedQuantity",
+            COALESCE(SUM(matched_quantity) FILTER (WHERE state IN ('allocated','partial','unmatched')),0)::int AS "settledMatchedQuantity",
+            COALESCE(SUM(unmatched_quantity) FILTER (WHERE state IN ('allocated','partial','unmatched')),0)::int AS "settledUnmatchedQuantity",
+            COALESCE(SUM(ordered_quantity) FILTER (WHERE state='pending'),0)::int AS "pendingQuantity",
+            COALESCE(SUM(ordered_quantity) FILTER (WHERE state='held'),0)::int AS "heldQuantity",
+            COALESCE(SUM(matched_quantity-price_known_quantity) FILTER (WHERE state IN ('allocated','partial','unmatched')),0)::int AS "priceUnavailableQuantity",
+            COALESCE(SUM(matched_quantity-date_known_quantity) FILTER (WHERE state IN ('allocated','partial','unmatched')),0)::int AS "dateUnavailableQuantity"
           FROM inventory_fifo_lines WHERE seller_key=$1
         ), differences AS (
-          SELECT COUNT(*)::int AS "unresolvedDifferenceCount",COUNT(DISTINCT sku)::int AS "unresolvedDifferenceSkuCount",
+          SELECT COUNT(*)::int AS "observedDifferenceCount",
+            COUNT(*) FILTER (WHERE status='unresolved')::int AS "unacknowledgedDifferenceCount",
+            COUNT(*) FILTER (WHERE status='acknowledged')::int AS "acknowledgedDifferenceCount",
+            COUNT(DISTINCT sku)::int AS "unresolvedDifferenceSkuCount",
             COALESCE(SUM(ABS(quantity_delta)),0)::int AS "unresolvedDifferenceQuantity"
-          FROM inventory_observation_differences WHERE seller_key=$1 AND status='unresolved'
+          FROM inventory_observation_differences WHERE seller_key=$1
         ), receipts AS (
           SELECT COUNT(*)::int AS "receiptCount",COALESCE(SUM(original_quantity),0)::int AS "receivedQuantity",
             COALESCE(SUM(original_quantity) FILTER (WHERE market_value IS NULL),0)::int AS "missingMarketSnapshotQuantity",
@@ -110,12 +127,17 @@ export const inventoryHistoryDiagnosticsRepository = {
       },
       fifo: {
         queue: { pending: count(row.queuePending), processing: count(row.queueProcessing), held: count(row.queueHeld) },
-        lines: { allocated: count(row.linesAllocated), pending: count(row.linesPending), held: count(row.linesHeld), unsupported: count(row.linesUnsupported) },
-        orderedQuantity: count(row.orderedQuantity), matchedQuantity: count(row.matchedQuantity),
-        unmatchedQuantity: count(row.unmatchedQuantity), priceUnavailableQuantity: count(row.priceUnavailableQuantity),
+        lines: { allocated: count(row.linesAllocated), partial: count(row.linesPartial), unmatched: count(row.linesUnmatched),
+          pending: count(row.linesPending), held: count(row.linesHeld), unsupported: count(row.linesUnsupported),
+          excludedPreCutoff: count(row.linesExcludedPreCutoff), removed: count(row.linesRemoved) },
+        settledOrderedQuantity: count(row.settledOrderedQuantity), settledMatchedQuantity: count(row.settledMatchedQuantity),
+        settledUnmatchedQuantity: count(row.settledUnmatchedQuantity), pendingQuantity: count(row.pendingQuantity),
+        heldQuantity: count(row.heldQuantity), priceUnavailableQuantity: count(row.priceUnavailableQuantity),
         dateUnavailableQuantity: count(row.dateUnavailableQuantity),
       },
-      stockDifferences: { unresolvedCount: count(row.unresolvedDifferenceCount), affectedSkuCount: count(row.unresolvedDifferenceSkuCount), absoluteQuantity: count(row.unresolvedDifferenceQuantity) },
+      stockDifferences: { observedCount: count(row.observedDifferenceCount),
+        unacknowledgedCount: count(row.unacknowledgedDifferenceCount), acknowledgedCount: count(row.acknowledgedDifferenceCount),
+        affectedSkuCount: count(row.unresolvedDifferenceSkuCount), absoluteQuantity: count(row.unresolvedDifferenceQuantity) },
       receivedLots: { receiptCount: count(row.receiptCount), receivedQuantity: count(row.receivedQuantity),
         missingMarketSnapshotQuantity: count(row.missingMarketSnapshotQuantity), missingIntakeDateQuantity: count(row.missingIntakeDateQuantity) },
       publications: { planned: count(row.publicationsPlanned), active: count(row.publicationsActive), ambiguous: count(row.publicationsAmbiguous),

--- a/app/features/inventory-history/routes/api.inventory-history-diagnostics.server.ts
+++ b/app/features/inventory-history/routes/api.inventory-history-diagnostics.server.ts
@@ -1,0 +1,18 @@
+import { data } from "react-router";
+import { inventoryHistoryDiagnosticsRepository } from "~/core/db";
+import { getShippingExportConfig } from "~/features/shipping-export/config/shippingExportConfig.server";
+
+export function createInventoryHistoryDiagnosticsLoader(dependencies = {
+  getConfig: getShippingExportConfig,
+  getDiagnostics: inventoryHistoryDiagnosticsRepository.get,
+}) {
+  return async () => {
+    try {
+      const sellerKey = (await dependencies.getConfig()).defaultSellerKey.trim();
+      if (!sellerKey) return data({ error: "A default shipping seller is required." }, { status: 409 });
+      return data({ diagnostics: await dependencies.getDiagnostics(sellerKey) });
+    } catch (error) {
+      return data({ error: String(error) }, { status: 500 });
+    }
+  };
+}

--- a/app/features/inventory-history/routes/api.inventory-history-diagnostics.test.ts
+++ b/app/features/inventory-history/routes/api.inventory-history-diagnostics.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { createInventoryHistoryDiagnosticsLoader } from "./api.inventory-history-diagnostics.server";
+
+const diagnostic = { sellerKey: "seller-a", generatedAt: "2026-09-08T00:00:00Z" };
+const loader = createInventoryHistoryDiagnosticsLoader({
+  getConfig: async () => ({ defaultSellerKey: " seller-a " }) as never,
+  getDiagnostics: async (sellerKey) => ({ ...diagnostic, sellerKey }) as never,
+});
+const response = await loader();
+assert.equal(response.init?.status, undefined);
+assert.deepEqual(response.data, { diagnostics: diagnostic });
+
+const missing = await createInventoryHistoryDiagnosticsLoader({
+  getConfig: async () => ({ defaultSellerKey: "" }) as never,
+  getDiagnostics: async () => { throw new Error("should not run"); },
+})();
+assert.equal(missing.init?.status, 409);
+
+console.log("PASS inventory history diagnostics are bound to the configured seller");

--- a/app/features/inventory-history/routes/api.inventory-history-diagnostics.ts
+++ b/app/features/inventory-history/routes/api.inventory-history-diagnostics.ts
@@ -1,0 +1,3 @@
+import { createInventoryHistoryDiagnosticsLoader } from "./api.inventory-history-diagnostics.server";
+
+export const loader = createInventoryHistoryDiagnosticsLoader();

--- a/app/features/inventory-history/services/inventoryHistoryRollout.server.integration.test.ts
+++ b/app/features/inventory-history/services/inventoryHistoryRollout.server.integration.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+
+const testUrl = process.env.TEST_DATABASE_URL;
+if (!testUrl || process.env.DATABASE_URL !== testUrl) {
+  throw new Error("DATABASE_URL and TEST_DATABASE_URL must match before the rollout integration test.");
+}
+if (!new URL(testUrl).pathname.replace(/^\/+/, "").startsWith("tcgplayer_fifo_test_")) {
+  throw new Error("The rollout integration test requires a disposable tcgplayer_fifo_test_* database.");
+}
+
+const { getPool } = await import("~/core/db/database.server");
+const { pendingInventoryRepository } = await import("~/core/db/repositories/pendingInventory.server");
+const { inventoryBatchesRepository } = await import("~/core/db/repositories/inventoryBatches.server");
+const { inventoryPublicationsRepository } = await import("~/core/db/repositories/inventoryPublications.server");
+const { inventoryOpeningBalancesRepository } = await import("~/core/db/repositories/inventoryOpeningBalances.server");
+const { inventoryFifoRepository } = await import("~/core/db/repositories/inventoryFifo.server");
+const { inventoryHistoryDiagnosticsRepository } = await import("~/core/db/repositories/inventoryHistoryDiagnostics.server");
+const { sellerOrderHistoryRepository } = await import("~/core/db/repositories/sellerOrderHistory.server");
+const { quantityFingerprint, supportedQuantityFingerprint } = await import("~/features/inventory-opening-balance/domain/inventoryObservation");
+const { fingerprintSellerOrder } = await import("~/features/seller-order-history/domain/sellerOrderObservation");
+const { enrichShippingOrdersWithIntakeHistory } = await import("~/features/shipping-export/services/shippingIntakeHistory.server");
+const { compareOrderToIntake } = await import("~/features/shipping-export/services/orderIntakeComparison");
+const { attachMarketPricesToOrders } = await import("~/features/shipping-export/services/orderMarketPrices.server");
+
+const pool = getPool();
+const suffix = Date.now();
+const seller = `rollout-${suffix}`;
+const sku = 9_610_001;
+const productId = 9_610_002;
+const setId = 9_610_003;
+const productLineId = 9_610_004;
+const now = Date.now();
+const openingCutoff = new Date(now - 120_000);
+const validationCutoff = new Date(now - 30_000);
+const publishedAt = new Date(now + 30_000);
+const soldAt = new Date(now + 60_000);
+
+async function completeObservation(requestId: string, cutoffAt: Date) {
+  const items = [{ inventoryKey: String(sku), identityKind: "standard_sku" as const, sku, quantity: 0,
+    productLine: "Synthetic", setName: "Rollout Set", productName: "Rollout Card", condition: "Near Mint", variant: "Normal" }];
+  const claim = await inventoryOpeningBalancesRepository.beginObservationCapture({ requestId, sellerKey: seller });
+  if (claim.state !== "claimed") throw new Error("Expected a new observation claim.");
+  return inventoryOpeningBalancesRepository.recordObservation({
+    requestId, sellerKey: seller, claimToken: claim.claimToken, status: "complete",
+    beforeIdentityDeclarationCount: 2, afterIdentityDeclarationCount: 2,
+    startedAt: new Date(cutoffAt.getTime() - 2_000), cutoffAt,
+    quantityFingerprint: quantityFingerprint(items), supportedQuantityFingerprint: supportedQuantityFingerprint(items),
+    firstContentFingerprint: `${requestId}-a`, secondContentFingerprint: `${requestId}-b`, items,
+  });
+}
+
+async function addCoverage(after: Date) {
+  await pool.query(`INSERT INTO seller_order_sync_runs
+    (seller_key,source,status,search_range,started_at,finished_at,next_offset,expected_total,pages_completed,orders_observed,details_recorded,
+     observed_from,observed_through,gaps)
+    VALUES ($1,'tcgplayer_api','complete','LastThreeMonths',$2,$3,0,0,1,0,0,NULL,NULL,'[]')`,
+  [seller, after, new Date(after.getTime() + 1_000)]);
+}
+
+try {
+  await pool.query(`INSERT INTO products
+    (product_id,product_type_name,rarity_name,sealed,product_name,set_id,set_code,set_name,product_line_id,product_status_id,product_line_name)
+    VALUES ($1,'Card','Rare',false,'Rollout Card',$2,'R','Rollout Set',$3,1,'Synthetic')`, [productId, setId, productLineId]);
+  await pool.query(`INSERT INTO skus
+    (sku,condition,variant,language,product_type_name,rarity_name,sealed,product_name,set_id,set_code,product_id,set_name,
+     product_line_id,product_status_id,product_line_name)
+    VALUES ($1,'Near Mint','Normal','English','Card','Rare',false,'Rollout Card',$2,'R',$3,'Rollout Set',$4,1,'Synthetic')`,
+  [sku, setId, productId, productLineId]);
+
+  const openingObservation = await completeObservation(`${seller}-opening-observation`, openingCutoff);
+  await addCoverage(openingCutoff);
+  const preview = await inventoryOpeningBalancesRepository.preview({
+    requestId: `${seller}-opening-preview`, sellerKey: seller, observationId: openingObservation.id,
+  });
+  assert.equal(preview.status, "previewed");
+  assert.equal(preview.totalQuantity, 0);
+  const validation = await completeObservation(`${seller}-opening-validation`, validationCutoff);
+  await addCoverage(validationCutoff);
+  const applyInput = { runId: preview.id, expectedFingerprint: preview.evidenceFingerprint, sellerKey: seller,
+    requestId: `${seller}-opening-apply`, validationObservationId: validation.id };
+  assert.equal((await inventoryOpeningBalancesRepository.apply(applyInput)).status, "applied");
+  assert.equal((await inventoryOpeningBalancesRepository.apply(applyInput)).status, "applied");
+
+  const metadata = { productLineId, setId, productId };
+  const addFirst = { type: "add" as const, requestId: `${seller}-receipt-a`, sku, quantity: 2, metadata,
+    intakeAt: new Date(soldAt.getTime() - 60 * 86_400_000),
+    market: { marketValue: 4, observedAt: new Date(), calculatedAt: new Date(), provenance: "tcgplayer_price_points" as const } };
+  const first = await pendingInventoryRepository.mutate(addFirst);
+  assert.equal(first.quantity, 2);
+  assert.equal((await pendingInventoryRepository.mutate(addFirst)).repeated, true);
+  await pendingInventoryRepository.mutate({ type: "add", requestId: `${seller}-receipt-b`, sku, quantity: 1, metadata,
+    intakeAt: new Date(soldAt.getTime() - 10 * 86_400_000),
+    market: { marketValue: 6, observedAt: new Date(), calculatedAt: new Date(), provenance: "tcgplayer_price_points" } });
+  const batch = await inventoryBatchesRepository.createFromPendingInventory(`${seller}-batch`);
+  assert.ok(batch);
+  assert.equal((await inventoryBatchesRepository.createFromPendingInventory(`${seller}-batch`))?.batchNumber, batch.batchNumber);
+
+  const planInput = { planningKey: `${seller}-publication`, batchNumber: batch.batchNumber,
+    method: "staged_delta" as const, sourceType: "pending_inventory" as const, sellerKey: seller,
+    items: [{ candidateKey: `${seller}-candidate`, inventoryDeltaKey: `${seller}-delta`, batchNumber: batch.batchNumber,
+      sku, productId, productLine: "Synthetic", setName: "Rollout Set", productName: "Rollout Card", condition: "Near Mint",
+      desiredPrice: 8, quantityDelta: 3, pricedAt: new Date(now) }] };
+  const planned = await inventoryPublicationsRepository.createOrFindPlanned(planInput);
+  assert.equal((await inventoryPublicationsRepository.createOrFindPlanned(planInput)).created, false);
+  await pool.query(`UPDATE inventory_publications SET status='publishing' WHERE id=$1`, [planned.publication.id]);
+  const publicationItemId = Number(planned.publication.items[0]?.id);
+  const outcome = { itemId: publicationItemId, status: "published" as const, confirmedAt: publishedAt,
+    confirmationEvidence: { source: "synthetic-rollout", confirmation: "confirmed-positive-delta" } };
+  await inventoryPublicationsRepository.saveItemOutcomes(Number(planned.publication.id), [outcome]);
+  await inventoryPublicationsRepository.saveItemOutcomes(Number(planned.publication.id), [outcome]);
+  await pool.query(`UPDATE inventory_publications SET status='published',published_at=$2,completed_at=$2 WHERE id=$1`,
+    [planned.publication.id, publishedAt]);
+
+  const orderBase = { sellerKey: seller, orderNumber: `${seller}-order`, orderTime: soldAt.toISOString(),
+    providerStatus: "Ready to Ship", lifecycle: "ready_to_ship" as const, orderChannel: "TcgMarketplace",
+    orderFulfillment: "Normal", grossItemProceeds: 24, refunds: [], source: "tcgplayer_api" as const,
+    lines: [{ name: "Rollout Card", unitPrice: 8, extendedPrice: 24, quantity: 3, productId: String(productId), skuId: String(sku) }] };
+  const order = { ...orderBase, observedAt: new Date(now + 70_000).toISOString(), fingerprint: fingerprintSellerOrder(orderBase) };
+  assert.equal((await sellerOrderHistoryRepository.recordObservation(order)).changed, true);
+  assert.equal((await sellerOrderHistoryRepository.recordObservation(order)).changed, false);
+  const replay = await inventoryFifoRepository.processNextReplay(seller);
+  assert.equal(replay?.status, "complete");
+  assert.equal(await inventoryFifoRepository.processNextReplay(seller), null);
+
+  const shippingOrder = { "Order #": order.orderNumber, FirstName: "", LastName: "", Address1: "", Address2: "", City: "",
+    State: "", PostalCode: "", Country: "US", "Order Date": soldAt.toISOString(), "Product Weight": 0,
+    "Shipping Method": "Standard" as const, "Item Count": 3, "Value Of Products": 24, "Shipping Fee Paid": 0,
+    "Tracking #": "", Carrier: "", products: [{ name: "Rollout Card", quantity: 3, unitPrice: 8, skuId: sku, inventorySkuId: String(sku) }] };
+  const enriched = (await enrichShippingOrdersWithIntakeHistory([shippingOrder], seller))[0]!;
+  const comparison = compareOrderToIntake(enriched);
+  assert.deepEqual([comparison.orderedQuantity, comparison.matchedQuantity, comparison.priceKnownQuantity, comparison.dateKnownQuantity], [3, 3, 3, 3]);
+  assert.equal(comparison.intakeMarketTotal, 14);
+  assert.ok(Math.abs((comparison.weightedDaysHeld ?? 0) - 43.333333) < 0.000001);
+  const failedMarket = await attachMarketPricesToOrders([enriched], async () => { throw new Error("synthetic market outage"); });
+  assert.match(failedMarket.warning ?? "", /market comparisons are unavailable/i);
+  assert.equal(compareOrderToIntake(failedMarket.orders[0]!).intakeMarketTotal, 14);
+
+  const conservation = await pool.query(`SELECT
+    (SELECT COALESCE(SUM(original_quantity),0)::int FROM inventory_receipts WHERE seller_key=$1 AND receipt_kind='received') AS received,
+    (SELECT COALESCE(SUM(allocation.allocated_quantity),0)::int FROM inventory_fifo_revision_allocations allocation
+      JOIN inventory_fifo_lines line ON line.current_revision_id=allocation.revision_id WHERE line.seller_key=$1) AS allocated`, [seller]);
+  assert.deepEqual(conservation.rows[0], { received: 3, allocated: 3 });
+  const diagnostics = await inventoryHistoryDiagnosticsRepository.get(seller);
+  assert.equal(diagnostics.openingBalance.status, "applied");
+  assert.equal(diagnostics.orderCoverage.status, "complete");
+  assert.equal(diagnostics.fifo.matchedQuantity, 3);
+  assert.equal(diagnostics.fifo.unmatchedQuantity, 0);
+  assert.equal(diagnostics.receivedLots.missingMarketSnapshotQuantity, 0);
+  assert.equal(diagnostics.publications.failed, 0);
+
+  console.log("PASS rollout flow conserves three received units and reports $14 intake market, 43.333 days held, idempotent recovery, and market fail-open");
+} finally {
+  await pool.query(`DELETE FROM inventory_fifo_revision_allocations WHERE revision_id IN
+    (SELECT revision.id FROM inventory_fifo_revisions revision JOIN inventory_fifo_lines line ON line.id=revision.line_id WHERE line.seller_key=$1)`, [seller]);
+  await pool.query(`UPDATE inventory_fifo_lines SET current_revision_id=NULL WHERE seller_key=$1`, [seller]);
+  await pool.query(`DELETE FROM inventory_fifo_revisions WHERE line_id IN (SELECT id FROM inventory_fifo_lines WHERE seller_key=$1)`, [seller]);
+  await pool.query(`DELETE FROM inventory_fifo_lines WHERE seller_key=$1`, [seller]);
+  await pool.query(`DELETE FROM inventory_fifo_replay_queue WHERE seller_key=$1`, [seller]);
+  await pool.query(`DELETE FROM seller_orders WHERE seller_key=$1`, [seller]);
+  await pool.query(`DELETE FROM seller_order_sync_runs WHERE seller_key=$1`, [seller]);
+  await pool.query(`DELETE FROM inventory_publication_receipt_links WHERE publication_item_id IN
+    (SELECT item.id FROM inventory_publication_items item JOIN inventory_publications publication ON publication.id=item.publication_id WHERE publication.seller_key=$1)`, [seller]);
+  await pool.query(`DELETE FROM inventory_publication_items WHERE publication_id IN (SELECT id FROM inventory_publications WHERE seller_key=$1)`, [seller]);
+  await pool.query(`DELETE FROM inventory_publications WHERE seller_key=$1`, [seller]);
+  await pool.query(`DELETE FROM inventory_receipt_batch_links WHERE receipt_id IN (SELECT receipt_id FROM inventory_receipts WHERE request_id LIKE $1)`, [`${seller}%`]);
+  await pool.query(`DELETE FROM inventory_receipts WHERE request_id LIKE $1`, [`${seller}%`]);
+  await pool.query(`DELETE FROM inventory_pending_mutations WHERE request_id LIKE $1`, [`${seller}%`]);
+  await pool.query(`DELETE FROM inventory_batch_intake_requests WHERE request_id LIKE $1`, [`${seller}%`]);
+  await pool.query(`DELETE FROM inventory_batches WHERE source_request_id LIKE $1`, [`${seller}%`]);
+  await pool.query(`DELETE FROM inventory_opening_balance_items WHERE run_id IN (SELECT id FROM inventory_opening_balance_runs WHERE seller_key=$1)`, [seller]);
+  await pool.query(`DELETE FROM inventory_opening_balance_runs WHERE seller_key=$1`, [seller]);
+  await pool.query(`DELETE FROM inventory_observation_differences WHERE seller_key=$1`, [seller]);
+  await pool.query(`DELETE FROM inventory_complete_observation_items WHERE observation_id IN (SELECT id FROM inventory_complete_observations WHERE seller_key=$1)`, [seller]);
+  await pool.query(`DELETE FROM inventory_complete_observation_requests WHERE seller_key=$1`, [seller]);
+  await pool.query(`DELETE FROM inventory_complete_observations WHERE seller_key=$1`, [seller]);
+  await pool.query(`DELETE FROM pending_inventory WHERE sku=$1`, [sku]);
+  await pool.query(`DELETE FROM skus WHERE sku=$1`, [sku]);
+  await pool.query(`DELETE FROM products WHERE product_id=$1`, [productId]);
+  await pool.end();
+}

--- a/app/features/inventory-history/services/inventoryHistoryRollout.server.integration.test.ts
+++ b/app/features/inventory-history/services/inventoryHistoryRollout.server.integration.test.ts
@@ -164,7 +164,19 @@ try {
   assert.equal(diagnostics.receivedLots.missingMarketSnapshotQuantity, 0);
   assert.equal(diagnostics.publications.failed, 0);
 
-  console.log("PASS rollout flow conserves three received units and reports $14 intake market, 43.333 days held, idempotent recovery, and market fail-open");
+  await pool.query(`INSERT INTO inventory_fifo_replay_queue (seller_key,sku,affected_from,status,generation)
+    VALUES ($1,$2,$3,'pending',1)`, [seller, sku, soldAt]);
+  const pendingDiagnostics = await inventoryHistoryDiagnosticsRepository.get(seller);
+  assert.equal(pendingDiagnostics.fifo.settledOrderedQuantity, 0);
+  assert.equal(pendingDiagnostics.fifo.pendingOrProcessingQuantity, 3);
+  assert.equal(pendingDiagnostics.fifo.queuedLineProjections.pending, 1);
+  await pool.query(`UPDATE inventory_fifo_replay_queue SET status='held',hold_reason='synthetic_review' WHERE seller_key=$1 AND sku=$2`, [seller, sku]);
+  const heldDiagnostics = await inventoryHistoryDiagnosticsRepository.get(seller);
+  assert.equal(heldDiagnostics.fifo.settledOrderedQuantity, 0);
+  assert.equal(heldDiagnostics.fifo.heldQuantity, 3);
+  assert.equal(heldDiagnostics.fifo.queuedLineProjections.held, 1);
+
+  console.log("PASS rollout flow conserves three received units and reports $14 intake market, 43.333 days held, replay freshness, idempotent recovery, and market fail-open");
 } finally {
   await pool.query(`DELETE FROM inventory_fifo_revision_allocations WHERE revision_id IN
     (SELECT revision.id FROM inventory_fifo_revisions revision JOIN inventory_fifo_lines line ON line.id=revision.line_id WHERE line.seller_key=$1)`, [seller]);

--- a/app/features/inventory-history/services/inventoryHistoryRollout.server.integration.test.ts
+++ b/app/features/inventory-history/services/inventoryHistoryRollout.server.integration.test.ts
@@ -111,6 +111,14 @@ try {
   await pool.query(`UPDATE inventory_publications SET status='published',published_at=$2,completed_at=$2 WHERE id=$1`,
     [planned.publication.id, publishedAt]);
 
+  const historicalBase = { sellerKey: seller, orderNumber: `${seller}-historical`,
+    orderTime: new Date(openingCutoff.getTime() - 1).toISOString(), providerStatus: "Completed - Paid",
+    lifecycle: "completed_paid" as const, orderChannel: "TcgMarketplace", orderFulfillment: "Normal",
+    grossItemProceeds: 56, refunds: [], source: "tcgplayer_api" as const,
+    lines: [{ name: "Rollout Card", unitPrice: 8, extendedPrice: 56, quantity: 7, productId: String(productId), skuId: String(sku) }] };
+  await sellerOrderHistoryRepository.recordObservation({ ...historicalBase,
+    observedAt: new Date(now + 65_000).toISOString(), fingerprint: fingerprintSellerOrder(historicalBase) });
+
   const orderBase = { sellerKey: seller, orderNumber: `${seller}-order`, orderTime: soldAt.toISOString(),
     providerStatus: "Ready to Ship", lifecycle: "ready_to_ship" as const, orderChannel: "TcgMarketplace",
     orderFulfillment: "Normal", grossItemProceeds: 24, refunds: [], source: "tcgplayer_api" as const,
@@ -135,16 +143,24 @@ try {
   assert.match(failedMarket.warning ?? "", /market comparisons are unavailable/i);
   assert.equal(compareOrderToIntake(failedMarket.orders[0]!).intakeMarketTotal, 14);
 
-  const conservation = await pool.query(`SELECT
-    (SELECT COALESCE(SUM(original_quantity),0)::int FROM inventory_receipts WHERE seller_key=$1 AND receipt_kind='received') AS received,
-    (SELECT COALESCE(SUM(allocation.allocated_quantity),0)::int FROM inventory_fifo_revision_allocations allocation
-      JOIN inventory_fifo_lines line ON line.current_revision_id=allocation.revision_id WHERE line.seller_key=$1) AS allocated`, [seller]);
-  assert.deepEqual(conservation.rows[0], { received: 3, allocated: 3 });
+  const conservation = await pool.query(`WITH quantities AS (
+    SELECT
+      (SELECT COALESCE(SUM(original_quantity),0)::int FROM inventory_receipts
+        WHERE seller_key=$1 AND receipt_kind='received') AS received,
+      (SELECT COALESCE(SUM(adjustment.quantity_delta),0)::int FROM inventory_receipt_adjustments adjustment
+        JOIN inventory_receipts receipt ON receipt.receipt_id=adjustment.receipt_id
+        WHERE receipt.seller_key=$1 AND receipt.receipt_kind='received') AS adjusted,
+      (SELECT COALESCE(SUM(allocation.allocated_quantity),0)::int FROM inventory_fifo_revision_allocations allocation
+        JOIN inventory_fifo_lines line ON line.current_revision_id=allocation.revision_id WHERE line.seller_key=$1) AS allocated
+  ) SELECT received,adjusted,allocated,(received+adjusted-allocated)::int AS remaining FROM quantities`, [seller]);
+  assert.deepEqual(conservation.rows[0], { received: 3, adjusted: 0, allocated: 3, remaining: 0 });
   const diagnostics = await inventoryHistoryDiagnosticsRepository.get(seller);
   assert.equal(diagnostics.openingBalance.status, "applied");
   assert.equal(diagnostics.orderCoverage.status, "complete");
-  assert.equal(diagnostics.fifo.matchedQuantity, 3);
-  assert.equal(diagnostics.fifo.unmatchedQuantity, 0);
+  assert.equal(diagnostics.fifo.settledMatchedQuantity, 3);
+  assert.equal(diagnostics.fifo.settledUnmatchedQuantity, 0);
+  assert.equal(diagnostics.fifo.settledOrderedQuantity, 3);
+  assert.equal(diagnostics.fifo.lines.excludedPreCutoff, 1);
   assert.equal(diagnostics.receivedLots.missingMarketSnapshotQuantity, 0);
   assert.equal(diagnostics.publications.failed, 0);
 

--- a/app/features/inventory-history/services/inventoryHistoryWorkerPolicy.test.ts
+++ b/app/features/inventory-history/services/inventoryHistoryWorkerPolicy.test.ts
@@ -1,0 +1,9 @@
+import assert from "node:assert/strict";
+import { inventoryHistoryWorkerEnabled } from "./inventoryHistoryWorkerPolicy";
+
+assert.equal(inventoryHistoryWorkerEnabled(undefined), true);
+assert.equal(inventoryHistoryWorkerEnabled("true"), true);
+assert.equal(inventoryHistoryWorkerEnabled(" false "), false);
+assert.equal(inventoryHistoryWorkerEnabled("0"), false);
+
+console.log("PASS inventory history worker defaults on and supports an explicit operational pause");

--- a/app/features/inventory-history/services/inventoryHistoryWorkerPolicy.ts
+++ b/app/features/inventory-history/services/inventoryHistoryWorkerPolicy.ts
@@ -1,0 +1,3 @@
+export function inventoryHistoryWorkerEnabled(value = process.env.INVENTORY_HISTORY_WORKER_ENABLED): boolean {
+  return !["0", "false", "off", "disabled"].includes(value?.trim().toLowerCase() ?? "");
+}

--- a/app/features/inventory-history/types/inventoryHistoryDiagnostics.ts
+++ b/app/features/inventory-history/types/inventoryHistoryDiagnostics.ts
@@ -1,0 +1,45 @@
+import type { SellerOrderCoverage } from "~/features/seller-order-history/types/sellerOrderHistory";
+
+export interface InventoryHistoryDiagnostics {
+  sellerKey: string;
+  generatedAt: string;
+  orderCoverage: SellerOrderCoverage;
+  openingBalance: {
+    status: "applied" | "not_applied";
+    runId: string | null;
+    cutoffAt: string | null;
+    appliedAt: string | null;
+    validationObservationId: string | null;
+    unsupportedPositiveItemCount: number;
+    unsupportedPositiveQuantity: number;
+  };
+  fifo: {
+    queue: { pending: number; processing: number; held: number };
+    lines: { allocated: number; pending: number; held: number; unsupported: number };
+    orderedQuantity: number;
+    matchedQuantity: number;
+    unmatchedQuantity: number;
+    priceUnavailableQuantity: number;
+    dateUnavailableQuantity: number;
+  };
+  stockDifferences: {
+    unresolvedCount: number;
+    affectedSkuCount: number;
+    absoluteQuantity: number;
+  };
+  receivedLots: {
+    receiptCount: number;
+    receivedQuantity: number;
+    missingMarketSnapshotQuantity: number;
+    missingIntakeDateQuantity: number;
+  };
+  publications: {
+    planned: number;
+    active: number;
+    ambiguous: number;
+    failed: number;
+    retried: number;
+    oldestPlannedAt: string | null;
+    lastPublishedAt: string | null;
+  };
+}

--- a/app/features/inventory-history/types/inventoryHistoryDiagnostics.ts
+++ b/app/features/inventory-history/types/inventoryHistoryDiagnostics.ts
@@ -15,15 +15,28 @@ export interface InventoryHistoryDiagnostics {
   };
   fifo: {
     queue: { pending: number; processing: number; held: number };
-    lines: { allocated: number; pending: number; held: number; unsupported: number };
-    orderedQuantity: number;
-    matchedQuantity: number;
-    unmatchedQuantity: number;
+    lines: {
+      allocated: number;
+      partial: number;
+      unmatched: number;
+      pending: number;
+      held: number;
+      unsupported: number;
+      excludedPreCutoff: number;
+      removed: number;
+    };
+    settledOrderedQuantity: number;
+    settledMatchedQuantity: number;
+    settledUnmatchedQuantity: number;
+    pendingQuantity: number;
+    heldQuantity: number;
     priceUnavailableQuantity: number;
     dateUnavailableQuantity: number;
   };
   stockDifferences: {
-    unresolvedCount: number;
+    observedCount: number;
+    unacknowledgedCount: number;
+    acknowledgedCount: number;
     affectedSkuCount: number;
     absoluteQuantity: number;
   };

--- a/app/features/inventory-history/types/inventoryHistoryDiagnostics.ts
+++ b/app/features/inventory-history/types/inventoryHistoryDiagnostics.ts
@@ -25,10 +25,11 @@ export interface InventoryHistoryDiagnostics {
       excludedPreCutoff: number;
       removed: number;
     };
+    queuedLineProjections: { pending: number; processing: number; held: number };
     settledOrderedQuantity: number;
     settledMatchedQuantity: number;
     settledUnmatchedQuantity: number;
-    pendingQuantity: number;
+    pendingOrProcessingQuantity: number;
     heldQuantity: number;
     priceUnavailableQuantity: number;
     dateUnavailableQuantity: number;

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -146,6 +146,10 @@ export default [
     file: "features/inventory-publication/routes/api.inventory-publication-health.ts",
   },
   {
+    path: "/api/inventory-history-diagnostics",
+    file: "features/inventory-history/routes/api.inventory-history-diagnostics.ts",
+  },
+  {
     path: "/api/convert-to-pricer-sku",
     file: "features/file-upload/routes/api.convert-to-pricer-sku.ts",
   },

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -1,6 +1,7 @@
 import "../core/clients/baseDomainClient.server.test";
 import "../integrations/tcgplayer/client/get-price-points.server.test";
 import "../features/inventory-history/domain/receiptBalances.test";
+import "../features/inventory-history/routes/api.inventory-history-diagnostics.test";
 import "../features/inventory-opening-balance/domain/inventoryObservation.test";
 import "../features/inventory-opening-balance/services/applyInventoryOpeningBalance.test";
 import "../features/inventory-fifo/domain/allocateInventoryFifo.test";

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -2,6 +2,7 @@ import "../core/clients/baseDomainClient.server.test";
 import "../integrations/tcgplayer/client/get-price-points.server.test";
 import "../features/inventory-history/domain/receiptBalances.test";
 import "../features/inventory-history/routes/api.inventory-history-diagnostics.test";
+import "../features/inventory-history/services/inventoryHistoryWorkerPolicy.test";
 import "../features/inventory-opening-balance/domain/inventoryObservation.test";
 import "../features/inventory-opening-balance/services/applyInventoryOpeningBalance.test";
 import "../features/inventory-fifo/domain/allocateInventoryFifo.test";

--- a/app/workers/seller-order-history-worker.server.ts
+++ b/app/workers/seller-order-history-worker.server.ts
@@ -1,14 +1,22 @@
 import { getShippingExportConfig } from "../features/shipping-export/config/shippingExportConfig.server";
 import { synchronizeSellerOrders } from "../features/seller-order-history/services/synchronizeSellerOrders.server";
 import { inventoryFifoRepository } from "../core/db/index.server";
+import { inventoryHistoryWorkerEnabled } from "../features/inventory-history/services/inventoryHistoryWorkerPolicy";
 
 let stopping = false;
 let nextHistorySyncAt=0;
 
 async function run(): Promise<void> {
   console.log(`[seller-order-history-worker] starting pid=${process.pid}`);
+  if (!inventoryHistoryWorkerEnabled()) {
+    console.log("[seller-order-history-worker] synchronization and FIFO replay are paused by configuration");
+  }
   while (!stopping) {
     let delayMs = 60_000;
+    if (!inventoryHistoryWorkerEnabled()) {
+      await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
+      continue;
+    }
     let sellerKey="";
     try{sellerKey=(await getShippingExportConfig()).defaultSellerKey.trim();}
     catch(error){console.error("[seller-order-history-worker] seller configuration failed:",String(error));}

--- a/docs/inventory-history-rollout.md
+++ b/docs/inventory-history-rollout.md
@@ -89,8 +89,8 @@ Treat these as separate rollout axes:
 
 - `orderCoverage.status` must be `complete` with no gaps for the protected cutover. `observedFrom` and `observedThrough` state the observed window; they do not promise older coverage.
 - `openingBalance.status` must be `applied` before forward allocation is trusted. Preserve the run, validation observation, cutoff, and unsupported counts.
-- `fifo.queue.pending` and `processing` should drain. `held`, line holds, unmatched quantity, and unsupported identities remain visible until evidence resolves them.
-- `stockDifferences` reports unresolved seller-export movements. An acknowledgement alone does not alter the number.
+- `fifo.queue.pending` and `processing` should drain. `held`, line holds, `settledUnmatchedQuantity`, and unsupported identities remain visible until evidence resolves them. Settled quantity and price/date coverage include only allocated, partial, and unmatched forward lines. Pending and held quantities are separate because their saved projections are not current. `lines.excludedPreCutoff` is historical demand already separated by the opening boundary.
+- `stockDifferences.observedCount` reports all captured seller-export quantity changes, with review status split into unacknowledged and acknowledged counts. Acknowledgement changes only that review status: the observation remains in these totals, changes no stock, and does not clear a FIFO discrepancy hold.
 - `receivedLots.missingMarketSnapshotQuantity` and `missingIntakeDateQuantity` are independent. Known market value USD 0 remains known.
 - `publications.active` should return to zero. Compare ambiguous, failed, and retried counts with the pre-rollout baseline and inspect changes.
 
@@ -98,15 +98,19 @@ Archive a sanitized diagnostics response and the browser/latency observations wi
 
 ## Disable and rollback
 
-If forward capture or reconciliation is unhealthy, stop the rollout before applying an opening balance. Leave the database and its evidence tables in place. The receipt projection remains compatible with the prior inventory workflow.
+If forward capture or reconciliation is unhealthy, pause the history worker by setting `INVENTORY_HISTORY_WORKER_ENABLED=false` in the application environment and restarting the current application image. The worker process remains healthy but performs neither external order synchronization nor local FIFO replay. Current market and shipping operations remain available, and existing history is read-only. Leave the database and its evidence tables in place.
 
-After an opening balance is applied, never down-migrate or delete opening receipts, order revisions, publication links, FIFO revisions, dispositions, corrections, or observations. To restore the prior user experience, stop the current containers and start the recorded prior application image against the migrated database. This disables the new display and synchronization code while preserving additive evidence for investigation and a later retry. Confirm Inventory Manager and shipping load before resuming operations. Do not restore an old database backup over newer postage, order, inventory, or publication activity.
+Before an opening balance is applied, reverting the application image is safe only if no receipt, publication, order-history, or inventory-observation evidence was recorded after the rollback point and relevant inventory writes remain paused. Otherwise keep the current image and repair forward.
+
+After an opening balance is applied, keep the current receipt-aware writers. Never run an older Inventory Manager, batch, or publication writer against the cut-over seller, and never down-migrate or delete opening receipts, order revisions, publication links, FIFO revisions, dispositions, corrections, or observations. Pause the worker, keep inventory receipt/publication writes paused, and repair forward with the current image. Shipping remains usable without history enrichment. Do not restore an old database backup over newer postage, order, inventory, or publication activity.
 
 When resuming, deploy the current image, verify diagnostics, continue the existing order scan/checkpoint, and replay the existing FIFO queue. Reuse committed operation request IDs so recovery returns the existing result. Create new request IDs only for new evidence or intent.
 
+After the defined rollback window, securely remove raw database dumps and sanitized clones according to the application's backup policy. Retain only the backup hash and allowlisted, sanitized verification results. The final deployment record must identify the commit and image digest, confirm the seller-order-history worker started after deployment and after one restart, and show that its latest scan timestamp advanced.
+
 ## Repository acceptance test
 
-The cross-slice scenario refuses to load the database pool unless both URLs are identical and the database name starts with `tcgplayer_fifo_test_`. It applies a zero-stock opening boundary, receives two lots, batches and confirms them live, records one sale, replays FIFO, enriches shipping, and verifies three units conserved with a USD 14 intake market total and 43.333333 weighted days held. It repeats durable operations and injects a current-market failure.
+The cross-slice scenario refuses to load the database pool unless both URLs are identical and the database name starts with `tcgplayer_fifo_test_`. It applies a zero-stock opening boundary, receives two lots, batches and confirms them live, records one sale, replays FIFO, enriches shipping, and verifies received 3 + adjusted 0 = allocated 3 + remaining 0 with a USD 14 intake market total and 43.333333 weighted days held. It repeats durable operations and injects a current-market failure.
 
 ```powershell
 $env:TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/tcgplayer_fifo_test_rollout_61'

--- a/docs/inventory-history-rollout.md
+++ b/docs/inventory-history-rollout.md
@@ -1,0 +1,118 @@
+# Inventory history rollout and recovery
+
+This runbook enables the receipt, publication, seller-order, opening-balance, FIFO, and shipping-history slices for one configured seller. It is a forward cutover. It preserves older evidence without claiming purchase dates, intake values, marketplace coverage, or stock movements that the application did not observe.
+
+The read-only `GET /api/inventory-history-diagnostics` endpoint is bound to the default shipping seller. It reports the latest order scan, applied opening cutoff, replay queue, held and unmatched quantities, unresolved inventory observations, missing received-lot snapshots, and publication failures/retries. Counts are evidence, not inferred stock corrections. A zero is a measured zero; unavailable dates and prices have their own quantities.
+
+## Before changing the running application
+
+1. Record the running image ID, application version, database size, current migration number, and the existing counts for pending inventory, batches, publications, postage purchases, and shipping workflows. Existing failures are the baseline and must not be attributed to this rollout.
+2. Take a PostgreSQL custom-format backup and record its SHA-256 hash. Restore it into an isolated database whose name starts with `tcgplayer_fifo_test_`; remove or replace seller credentials in the clone before starting the application.
+3. Apply migrations through `039_add_inventory_fifo_allocations.sql` to the clone twice. The second pass must be a no-op. Compare preexisting table counts and fingerprints using the columns that existed before the migrations.
+4. Start the production build against only the sanitized clone. Verify Inventory Manager, Pending Inventory Pricer, Shipping, and the application root. Never use live Seller Portal cookies with the clone.
+5. Keep the prior application image available. Do not prepare down migrations: receipt, order, opening, allocation, and correction rows are durable evidence.
+
+## Rollout order
+
+Keep the same request ID when retrying one operation. A different intent needs a new request ID.
+
+### 1. Forward receipt and publication capture
+
+Deploy migrations and the new application before receiving more inventory. Inventory Manager additions create immutable receipt lots. A typed decrease is a correction; deliberately receiving more copies is a new addition. A failed market lookup does not block receipt capture and records the market snapshot as unavailable.
+
+Publish received units through the normal staged-delta batch workflow. The receipt becomes FIFO supply only after a positive quantity delta is confirmed live for the configured seller. A price-only publication creates no units. If a publication is ambiguous, inspect its saved item result and use the existing confirmation repair with the original seller, quantity, timestamp, and evidence. Never repeat the remote move merely because local persistence failed.
+
+Check diagnostics. `receivedLots.missingMarketSnapshotQuantity` and `missingIntakeDateQuantity` describe received units only; opening quantities are deliberately excluded. `publications.failed` may include pre-rollout baseline failures. Investigate changes from the recorded baseline.
+
+### 2. Seller-order catch-up
+
+The seller-order worker performs bounded LastThreeMonths scans and drains FIFO independently. Check coverage:
+
+```powershell
+Invoke-RestMethod 'http://localhost:3001/api/seller-order-history'
+```
+
+Request one bounded pass when needed:
+
+```powershell
+$body = @{ action = 'catch_up' } | ConvertTo-Json
+Invoke-RestMethod 'http://localhost:3001/api/seller-order-history' -Method Post -ContentType 'application/json' -Body $body
+```
+
+Proceed only when the latest API coverage is `complete`, `gaps` is empty, and `completedAt` is after the inventory observation that it must protect. Complete means the observed mutable API window was scanned; it does not establish atomic or older-history coverage. Use the documented bounded CSV import when an order is outside verified API coverage. Imports contain sanitized order/SKU/time/status/amount evidence and never override newer API-owned current state.
+
+### 3. Capture, preview, and apply the opening balance
+
+Follow [Inventory opening balance](inventory-opening-balance.md). Capture a stable, seller-validated Live export, let order coverage finish after its cutoff, then preview. Review standard-SKU quantities, unsupported custom identities, capture limitations, and every unresolved difference. The export is sellable inventory and excludes reserved Ready to Ship units; do not subtract those orders again.
+
+Apply the reviewed preview using its exact fingerprint. Apply performs a fresh two-export validation and requires another complete order scan after that validation. If it returns a coverage error, let the worker complete and retry the same apply request. An uncommitted retry takes new external evidence. A committed retry returns the same local result without rereading or adding stock.
+
+The cutoff is half-open: activity before the cutoff remains historical; orders and confirmed publication receipts at or after it enter forward FIFO. Opening quantities have unknown purchase date and price. Unsupported `C-*` listing identities remain visible but unavailable to standard-SKU FIFO.
+
+### 4. Drain FIFO and inspect holds
+
+Read the combined operational view:
+
+```powershell
+Invoke-RestMethod 'http://localhost:3001/api/inventory-history-diagnostics'
+```
+
+Use `POST /api/inventory-fifo` with `{"action":"replay"}` to perform one configured-seller replay while investigating. The normal worker drains the queue without this manual action. Do not call replay repeatedly against a hold.
+
+List holds in bounded pages:
+
+```json
+{"action":"list_holds","afterSku":0,"limit":100}
+```
+
+For an affected order, use `find_order`, then page `list_revisions`. A replay is ready for shipping comparison when its queue has no pending/processing row and the current line is allocated, partial, excluded, or explicitly held. `unmatchedQuantity` is a shortage; it must not be replaced with zero-cost supply.
+
+An acknowledged opening-observation difference remains an audit acknowledgement and does not move stock or clear a FIFO hold. Reconcile the physical cause with one of the following evidenced operations:
+
+- A never-fulfilled canceled line may use `unfulfilled_cancellation` only after the ledger proves it was canceled and never shipped.
+- A physical return uses `physical_restock` with the exact saved supply keys, receipt IDs, quantities, and the time it became available again.
+- A refund alone is financial evidence and never restores inventory.
+- A provider quantity decrease holds its previous allocation. Use `record_quantity_correction` with the newer source revision, exact newest active allocation segments, evidence, and a confirmed availability time. It does not release a unit at the original sale time.
+- If later order evidence contradicts a disposition or correction, keep the hold. Do not overwrite the original evidence; use the documented correction/supersession operation only when the newer revision proves the premise.
+
+Late orders and order revisions enqueue the earliest affected seller/SKU suffix. Let replay finish before trusting a saved shipping comparison.
+
+### 5. Enable shipping comparisons
+
+Load or restore a shipping workflow and verify the compact intake summaries at load, pull sheet, packing, and postage. Check a mixed-lot order, partial price/date coverage, an opening lot, a merged shipment, and receipt detail disclosure. Intake market is the immutable receipt snapshot; current market is a separate live lookup. Days held is fixed at the sale and does not grow when the screen refreshes.
+
+If the local history endpoint, FIFO projection, or current-market lookup fails, shipping stays available. The UI removes stale intake analytics and labels history unavailable. A current-market failure leaves intake history intact; a history failure leaves current-market-only shipping intact.
+
+## Diagnostic gates
+
+Treat these as separate rollout axes:
+
+- `orderCoverage.status` must be `complete` with no gaps for the protected cutover. `observedFrom` and `observedThrough` state the observed window; they do not promise older coverage.
+- `openingBalance.status` must be `applied` before forward allocation is trusted. Preserve the run, validation observation, cutoff, and unsupported counts.
+- `fifo.queue.pending` and `processing` should drain. `held`, line holds, unmatched quantity, and unsupported identities remain visible until evidence resolves them.
+- `stockDifferences` reports unresolved seller-export movements. An acknowledgement alone does not alter the number.
+- `receivedLots.missingMarketSnapshotQuantity` and `missingIntakeDateQuantity` are independent. Known market value USD 0 remains known.
+- `publications.active` should return to zero. Compare ambiguous, failed, and retried counts with the pre-rollout baseline and inspect changes.
+
+Archive a sanitized diagnostics response and the browser/latency observations with deployment evidence. Do not archive raw Seller Portal exports, order payloads, cookies, buyer details, addresses, tracking data, or provider error objects.
+
+## Disable and rollback
+
+If forward capture or reconciliation is unhealthy, stop the rollout before applying an opening balance. Leave the database and its evidence tables in place. The receipt projection remains compatible with the prior inventory workflow.
+
+After an opening balance is applied, never down-migrate or delete opening receipts, order revisions, publication links, FIFO revisions, dispositions, corrections, or observations. To restore the prior user experience, stop the current containers and start the recorded prior application image against the migrated database. This disables the new display and synchronization code while preserving additive evidence for investigation and a later retry. Confirm Inventory Manager and shipping load before resuming operations. Do not restore an old database backup over newer postage, order, inventory, or publication activity.
+
+When resuming, deploy the current image, verify diagnostics, continue the existing order scan/checkpoint, and replay the existing FIFO queue. Reuse committed operation request IDs so recovery returns the existing result. Create new request IDs only for new evidence or intent.
+
+## Repository acceptance test
+
+The cross-slice scenario refuses to load the database pool unless both URLs are identical and the database name starts with `tcgplayer_fifo_test_`. It applies a zero-stock opening boundary, receives two lots, batches and confirms them live, records one sale, replays FIFO, enriches shipping, and verifies three units conserved with a USD 14 intake market total and 43.333333 weighted days held. It repeats durable operations and injects a current-market failure.
+
+```powershell
+$env:TEST_DATABASE_URL = 'postgresql://postgres:postgres@localhost:5433/tcgplayer_fifo_test_rollout_61'
+$env:DATABASE_URL = $env:TEST_DATABASE_URL
+npm run db:migrate
+npx tsx app/features/inventory-history/services/inventoryHistoryRollout.server.integration.test.ts
+```
+
+Run `npm test`, `npm run typecheck`, and `npm run build` as the final repository checks. Production rollout, live API coverage, browser evidence, backup/restore evidence, and deployment health must be recorded on issue #61 after they are actually observed; a merged change does not complete those checks.

--- a/docs/inventory-history-rollout.md
+++ b/docs/inventory-history-rollout.md
@@ -89,7 +89,7 @@ Treat these as separate rollout axes:
 
 - `orderCoverage.status` must be `complete` with no gaps for the protected cutover. `observedFrom` and `observedThrough` state the observed window; they do not promise older coverage.
 - `openingBalance.status` must be `applied` before forward allocation is trusted. Preserve the run, validation observation, cutoff, and unsupported counts.
-- `fifo.queue.pending` and `processing` should drain. `held`, line holds, `settledUnmatchedQuantity`, and unsupported identities remain visible until evidence resolves them. Settled quantity and price/date coverage include only allocated, partial, and unmatched forward lines. Pending and held quantities are separate because their saved projections are not current. `lines.excludedPreCutoff` is historical demand already separated by the opening boundary.
+- `fifo.queue.pending` and `processing` should drain. `held`, line holds, `settledUnmatchedQuantity`, and unsupported identities remain visible until evidence resolves them. Settled quantity and price/date coverage include only allocated, partial, and unmatched forward lines whose SKU has no replay row. `pendingOrProcessingQuantity`, `heldQuantity`, and `queuedLineProjections` expose saved lines made stale by queue work. `lines.excludedPreCutoff` is historical demand already separated by the opening boundary.
 - `stockDifferences.observedCount` reports all captured seller-export quantity changes, with review status split into unacknowledged and acknowledged counts. Acknowledgement changes only that review status: the observation remains in these totals, changes no stock, and does not clear a FIFO discrepancy hold.
 - `receivedLots.missingMarketSnapshotQuantity` and `missingIntakeDateQuantity` are independent. Known market value USD 0 remains known.
 - `publications.active` should return to zero. Compare ambiguous, failed, and retried counts with the pre-rollout baseline and inspect changes.
@@ -98,7 +98,7 @@ Archive a sanitized diagnostics response and the browser/latency observations wi
 
 ## Disable and rollback
 
-If forward capture or reconciliation is unhealthy, pause the history worker by setting `INVENTORY_HISTORY_WORKER_ENABLED=false` in the application environment and restarting the current application image. The worker process remains healthy but performs neither external order synchronization nor local FIFO replay. Current market and shipping operations remain available, and existing history is read-only. Leave the database and its evidence tables in place.
+If forward capture or reconciliation is unhealthy, pause the history worker by setting `INVENTORY_HISTORY_WORKER_ENABLED=false` in the application environment and restarting the current application image. The worker process remains healthy but performs neither external order synchronization nor local FIFO replay. This flag does not disable manual seller-history, opening-balance, or FIFO actions and does not disable Inventory Manager or publication writers; operators must stop those actions separately. Current market and shipping operations remain available, and existing history reads remain available. Leave the database and its evidence tables in place.
 
 Before an opening balance is applied, reverting the application image is safe only if no receipt, publication, order-history, or inventory-observation evidence was recorded after the rollback point and relevant inventory writes remain paused. Otherwise keep the current image and repair forward.
 


### PR DESCRIPTION
The inventory-history slices now have one configured-seller operational read and one repeatable cross-slice acceptance path. `GET /api/inventory-history-diagnostics` reports seller-order coverage, opening evidence, every FIFO state with settled, replay-pending, and held projections kept separate, observed inventory changes, missing received-lot snapshots, and publication failures/retries without converting unavailable evidence to zero. `INVENTORY_HISTORY_WORKER_ENABLED=false` pauses automatic seller synchronization and FIFO replay while keeping the current application available; manual mutation paths remain separately controlled.

The rollout runbook orders forward receipt capture, seller-history catch-up, opening capture/preview/fresh apply, FIFO replay and correction handling, shipping verification, and evidence-preserving recovery. It prohibits old inventory writers after cutover and records the required deployment image, worker restart, scan advancement, and backup cleanup checks.

The guarded database scenario uses the real repositories from opening through shipping. It proves received 3 + adjusted 0 = allocated 3 + remaining 0, a USD 14 intake market total, 43.333333 days held, pre-cutoff demand excluded from forward shortage, queued projections removed from settled coverage, exact retry behavior, and current-market failure leaving intake history usable.

Validation on `38e8ae178822f86b488869f51557aa6062c0c9c8`:
- `npm test`
- `npm run typecheck`
- `npm run build` (application and workers)
- fresh migrations 001–039 on `tcgplayer_fifo_test_rollout_61_agent`
- `npx tsx app/features/inventory-history/services/inventoryHistoryRollout.server.integration.test.ts`

Actual backup/restore, live coverage, browser, deployment, and production health evidence remain deployment responsibilities and must be recorded before issue completion.

Refs #61
