### PR TITLE
Show observed inventory selling history

### DIFF
--- a/app/core/db/index.server.ts
+++ b/app/core/db/index.server.ts
@@ -16,6 +16,7 @@ export { inventoryOpeningBalancesRepository } from "./repositories/inventoryOpen
 export { inventoryBatchPricingJobsRepository } from "./repositories/inventoryBatchPricingJobs.server";
 export { inventoryPublicationsRepository } from "./repositories/inventoryPublications.server";
 export { inventoryPublicationSettingsRepository } from "./repositories/inventoryPublicationSettings.server";
+export { inventorySellingHistoryRepository } from "./repositories/inventorySellingHistory.server";
 export { inventoryStrategyRepository } from "./repositories/inventoryStrategy.server";
 export { pendingInventoryRepository } from "./repositories/pendingInventory.server";
 export { pricingConfigRepository } from "./repositories/pricingConfig.server";

--- a/app/core/db/repositories/inventoryPublicationReceipts.server.integration.test.ts
+++ b/app/core/db/repositories/inventoryPublicationReceipts.server.integration.test.ts
@@ -59,6 +59,21 @@ function publicationItem(
     desiredPrice: 4.25,
     quantityDelta: quantity,
     pricedAt: new Date("2026-08-10T11:00:00.000Z"),
+    forecastEvidence: {
+      source: "publication_candidate" as const,
+      schemaVersion: 2,
+      pricingModelVersion: "integration-model-v2",
+      pricedAt: "2026-08-10T11:00:00.000Z",
+      decision: {
+        method: "target-horizon" as const,
+        selectedPrice: 4.25,
+        targetHorizonDays: 30,
+        estimatedMedianSellDays: 24,
+        constraint: "none" as const,
+        basis: "modeled" as const,
+        forecastStatus: "interpolated" as const,
+      },
+    },
   };
 }
 
@@ -86,6 +101,10 @@ try {
   const repeated = await inventoryPublicationsRepository.createOrFindPlanned(params);
   assert.equal(repeated.created, false);
   assert.equal(repeated.publication.sellerKey, sellerKey);
+  assert.equal(
+    repeated.publication.items[0].forecastEvidence?.decision?.estimatedMedianSellDays,
+    24,
+  );
   await assert.rejects(
     inventoryPublicationsRepository.createOrFindPlanned({
       ...params,
@@ -290,6 +309,12 @@ try {
       { sku: skuA, quantity: 5, liveAt: confirmedAtA.toISOString() },
       { sku: skuB, quantity: 4, liveAt: confirmedAtB.toISOString() },
     ],
+  );
+  assert.equal(
+    (await inventoryPublicationsRepository.findById(publicationId))?.items[0]
+      .forecastEvidence?.decision?.estimatedMedianSellDays,
+    24,
+    "activation retries never replace the publication-time forecast",
   );
 
   const priceOnly = await inventoryPublicationsRepository.createOrFindPlanned({

--- a/app/core/db/repositories/inventoryPublications.server.ts
+++ b/app/core/db/repositories/inventoryPublications.server.ts
@@ -21,6 +21,17 @@ import { inventoryFifoRepository } from "./inventoryFifo.server";
 type InventoryPublicationRow = Omit<InventoryPublication, "items">;
 type InventoryPublicationItemRow = InventoryPublicationItem;
 
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
 function safeDatabaseId(value: number | string | null, name: string): number | null {
   if (value === null) return null;
   const id = Number(value);
@@ -105,6 +116,8 @@ const publicationItemSelect = `SELECT
   desired_absolute_quantity AS "desiredAbsoluteQuantity",
   priced_at AS "pricedAt",
   eligibility_reasons AS "eligibilityReasons",
+  forecast_evidence AS "forecastEvidence",
+  forecast_evidence_provenance AS "forecastEvidenceProvenance",
   status,
   error_code AS "errorCode",
   error_message AS "errorMessage",
@@ -321,6 +334,7 @@ function plannedPublicationIdentity(
       desiredAbsoluteQuantity: item.desiredAbsoluteQuantity,
       pricedAt: item.pricedAt.toISOString(),
       eligibilityReasons: item.eligibilityReasons,
+      forecastEvidence: canonicalJson(item.forecastEvidence),
     })),
   });
 }
@@ -351,11 +365,60 @@ function requestedPublicationIdentity(
       desiredAbsoluteQuantity: item.desiredAbsoluteQuantity ?? null,
       pricedAt: item.pricedAt.toISOString(),
       eligibilityReasons: item.eligibilityReasons ?? [],
+      forecastEvidence: canonicalJson(item.forecastEvidence ?? null),
     })),
   });
 }
 
 export const inventoryPublicationsRepository = {
+  async backfillSupportedForecastEvidence(
+    sellerKey: string,
+    limit = 500,
+  ): Promise<number> {
+    const seller = sellerKey.trim();
+    if (!seller) throw new Error("Seller key is required for forecast evidence backfill.");
+    if (!Number.isInteger(limit) || limit < 1 || limit > 1_000) {
+      throw new Error("Forecast evidence backfill limit must be between 1 and 1000.");
+    }
+    const rows = await query<{ id: number }>(
+      `WITH supported AS (
+        SELECT item.id,result.pricing_details_json
+        FROM inventory_publication_items item
+        JOIN inventory_publications publication ON publication.id=item.publication_id
+        JOIN inventory_batch_results result
+          ON result.batch_number=item.batch_number AND result.sku=item.sku
+          AND result.priced_at=item.priced_at
+        WHERE publication.seller_key=$1
+          AND item.forecast_evidence IS NULL AND item.status='published'
+          AND result.result_status='successful'
+          AND result.pricing_details_json IS NOT NULL
+          AND item.candidate_key='pricing-result:'||result.batch_number::text||':'||
+            result.sku::text||':'||to_char(result.priced_at AT TIME ZONE 'UTC',
+              'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+          AND jsonb_typeof(result.pricing_details_json->'schemaVersion')='number'
+          AND result.pricing_details_json->>'pricedAt'=to_char(
+            result.priced_at AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+          AND result.pricing_details_json->>'marketplacePrice' ~ '^[0-9]+(\.[0-9]+)?$'
+          AND (result.pricing_details_json->>'marketplacePrice')::numeric(12,2)=item.desired_price
+        ORDER BY item.id LIMIT $2
+      )
+      UPDATE inventory_publication_items item SET
+        forecast_evidence=jsonb_strip_nulls(jsonb_build_object(
+          'source','historical_pricing_result_exact_match',
+          'schemaVersion',supported.pricing_details_json->'schemaVersion',
+          'pricingModelVersion',supported.pricing_details_json->'pricingModelVersion',
+          'pricedAt',supported.pricing_details_json->'pricedAt',
+          'policy',supported.pricing_details_json->'policy',
+          'decision',supported.pricing_details_json->'decision',
+          'buyerChoiceForecast',supported.pricing_details_json->'buyerChoiceForecast',
+          'conditionRateForecast',supported.pricing_details_json->'conditionRateForecast',
+          'estimatedTimeToSellDays',supported.pricing_details_json->'estimatedTimeToSellDays')),
+        forecast_evidence_provenance='recorded',updated_at=NOW()
+      FROM supported WHERE item.id=supported.id RETURNING item.id`,
+      [seller, limit],
+    );
+    return rows.length;
+  },
   async findById(
     publicationId: number,
     executor?: Queryable,
@@ -524,7 +587,7 @@ export const inventoryPublicationsRepository = {
         return { publication: existing, created: false };
       }
 
-      const placeholders = createValuesPlaceholders(params.items.length, 18);
+      const placeholders = createValuesPlaceholders(params.items.length, 20);
       const values = params.items.flatMap((item) => [
         inserted.id,
         item.candidateKey,
@@ -543,6 +606,8 @@ export const inventoryPublicationsRepository = {
         item.desiredAbsoluteQuantity ?? null,
         item.pricedAt,
         item.eligibilityReasons ?? [],
+        item.forecastEvidence ? asJson(item.forecastEvidence) : null,
+        item.forecastEvidence ? "recorded" : "unknown",
         item.status ?? "planned",
       ]);
 
@@ -565,6 +630,8 @@ export const inventoryPublicationsRepository = {
           desired_absolute_quantity,
           priced_at,
           eligibility_reasons,
+          forecast_evidence,
+          forecast_evidence_provenance,
           status
         ) VALUES ${placeholders}`,
         values,

--- a/app/core/db/repositories/inventoryPublications.server.ts
+++ b/app/core/db/repositories/inventoryPublications.server.ts
@@ -179,6 +179,14 @@ function validateCreateParams(params: CreateInventoryPublication): void {
     if (!Number.isFinite(item.desiredPrice) || item.desiredPrice <= 0) {
       throw new RangeError(`${prefix}.desiredPrice must be positive.`);
     }
+    if (
+      item.forecastEvidence &&
+      item.forecastEvidence.source !== "publication_candidate"
+    ) {
+      throw new RangeError(
+        `${prefix}.forecastEvidence must come from the publication candidate.`,
+      );
+    }
 
     const inventoryDeltaKey = item.inventoryDeltaKey?.trim() || null;
     if (item.quantityDelta === 0 && inventoryDeltaKey) {
@@ -334,7 +342,12 @@ function plannedPublicationIdentity(
       desiredAbsoluteQuantity: item.desiredAbsoluteQuantity,
       pricedAt: item.pricedAt.toISOString(),
       eligibilityReasons: item.eligibilityReasons,
-      forecastEvidence: canonicalJson(item.forecastEvidence),
+      forecastEvidence: canonicalJson(
+        item.forecastEvidence?.source ===
+          "historical_pricing_result_exact_match"
+          ? null
+          : item.forecastEvidence,
+      ),
     })),
   });
 }
@@ -390,6 +403,7 @@ export const inventoryPublicationsRepository = {
           AND result.priced_at=item.priced_at
         WHERE publication.seller_key=$1
           AND item.forecast_evidence IS NULL AND item.status='published'
+          AND item.quantity_delta>0
           AND result.result_status='successful'
           AND result.pricing_details_json IS NOT NULL
           AND item.candidate_key='pricing-result:'||result.batch_number::text||':'||

--- a/app/core/db/repositories/inventorySellingHistory.server.integration.test.ts
+++ b/app/core/db/repositories/inventorySellingHistory.server.integration.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+
+const testDatabaseUrl = process.env.TEST_DATABASE_URL;
+if (!testDatabaseUrl) throw new Error("TEST_DATABASE_URL is required.");
+const testDatabaseName = new URL(testDatabaseUrl).pathname.replace(/^\/+/, "");
+if (!testDatabaseName.startsWith("tcgplayer_strategy_test_")) {
+  throw new Error("Inventory selling history tests require tcgplayer_strategy_test_*.");
+}
+process.env.DATABASE_URL = testDatabaseUrl;
+
+const { execute, getPool, queryOne } = await import("../database.server");
+const { inventoryPublicationsRepository } = await import(
+  "./inventoryPublications.server"
+);
+
+const prefix = `strategy-history-${Date.now()}`;
+const sellerKey = `${prefix}-seller`;
+const pricedAt = new Date("2026-07-10T12:00:00.000Z");
+
+async function createBatchResult(
+  sku: number,
+  marketplacePrice: number,
+  forecastDays: number,
+) {
+  const batch = await queryOne<{ batchNumber: number }>(
+    `INSERT INTO inventory_batches (status,source_type,source_label)
+    VALUES ('priced','seller',$1) RETURNING batch_number AS "batchNumber"`,
+    [sellerKey],
+  );
+  assert.ok(batch);
+  await execute(
+    `INSERT INTO inventory_batch_results
+      (batch_number,sku,result_status,row_json,pricing_details_json,priced_at)
+    VALUES ($1,$2,'successful','{}',$3::jsonb,$4)`,
+    [
+      batch.batchNumber,
+      sku,
+      JSON.stringify({
+        schemaVersion: 2,
+        pricingModelVersion: "test-model-v2",
+        pricedAt: pricedAt.toISOString(),
+        marketplacePrice,
+        policy: { method: "target-horizon", horizonDays: 30 },
+        decision: {
+          method: "target-horizon",
+          selectedPrice: marketplacePrice,
+          targetHorizonDays: 30,
+          estimatedMedianSellDays: forecastDays,
+          constraint: "none",
+          basis: "modeled",
+          forecastStatus: "interpolated",
+        },
+      }),
+      pricedAt,
+    ],
+  );
+  return batch.batchNumber;
+}
+
+async function createLegacyPublication(
+  batchNumber: number,
+  sku: number,
+  desiredPrice: number,
+) {
+  const result = await inventoryPublicationsRepository.createOrFindPlanned({
+    planningKey: `${prefix}:${sku}`,
+    batchNumber,
+    method: "staged_delta",
+    sourceType: "seller",
+    sellerKey,
+    items: [{
+      candidateKey: `pricing-result:${batchNumber}:${sku}:${pricedAt.toISOString()}`,
+      inventoryDeltaKey: `${prefix}:delta:${sku}`,
+      batchNumber,
+      sku,
+      productId: sku,
+      productLine: "Pokemon",
+      setName: "Test",
+      productName: `Card ${sku}`,
+      condition: "Near Mint",
+      desiredPrice,
+      quantityDelta: 1,
+      pricedAt,
+    }],
+  });
+  const publicationId = result.publication.id;
+  const itemId = result.publication.items[0].id;
+  await execute(
+    `UPDATE inventory_publications SET status='publishing' WHERE id=$1`,
+    [publicationId],
+  );
+  await inventoryPublicationsRepository.saveItemOutcomes(publicationId, [
+    { itemId, status: "published", confirmedAt: pricedAt },
+  ]);
+  return { publicationId, itemId };
+}
+
+try {
+  const exactBatch = await createBatchResult(9_640_101, 24.99, 28);
+  const exact = await createLegacyPublication(exactBatch, 9_640_101, 24.99);
+  const mismatchBatch = await createBatchResult(9_640_102, 12.5, 45);
+  const mismatch = await createLegacyPublication(mismatchBatch, 9_640_102, 12.51);
+
+  assert.equal(
+    await inventoryPublicationsRepository.backfillSupportedForecastEvidence(
+      `${sellerKey}-other`,
+      1,
+    ),
+    0,
+  );
+  assert.equal(await inventoryPublicationsRepository.backfillSupportedForecastEvidence(sellerKey, 1), 1);
+  assert.equal(await inventoryPublicationsRepository.backfillSupportedForecastEvidence(sellerKey, 1), 0);
+  const exactItem = (await inventoryPublicationsRepository.findById(exact.publicationId))!.items[0];
+  assert.equal(exactItem.forecastEvidenceProvenance, "recorded");
+  assert.equal(exactItem.forecastEvidence?.source, "historical_pricing_result_exact_match");
+  assert.equal(exactItem.forecastEvidence?.decision?.estimatedMedianSellDays, 28);
+  const mismatchItem = (await inventoryPublicationsRepository.findById(mismatch.publicationId))!.items[0];
+  assert.equal(mismatchItem.forecastEvidence, null);
+  assert.equal(mismatchItem.forecastEvidenceProvenance, "unknown");
+
+  await execute(
+    `UPDATE inventory_batch_results SET pricing_details_json=jsonb_set(
+      pricing_details_json,'{decision,estimatedMedianSellDays}','3'::jsonb)
+    WHERE batch_number=$1 AND sku=$2`,
+    [exactBatch, 9_640_101],
+  );
+  assert.equal(await inventoryPublicationsRepository.backfillSupportedForecastEvidence(sellerKey, 10), 0);
+  const immutable = (await inventoryPublicationsRepository.findById(exact.publicationId))!.items[0];
+  assert.equal(immutable.forecastEvidence?.decision?.estimatedMedianSellDays, 28);
+  await assert.rejects(
+    inventoryPublicationsRepository.backfillSupportedForecastEvidence(sellerKey, 0),
+    /limit must be between 1 and 1000/,
+  );
+  console.log("PASS publication forecast backfill is exact, bounded, and immutable");
+} finally {
+  await getPool().end();
+}

--- a/app/core/db/repositories/inventorySellingHistory.server.integration.test.ts
+++ b/app/core/db/repositories/inventorySellingHistory.server.integration.test.ts
@@ -12,6 +12,12 @@ const { execute, getPool, queryOne } = await import("../database.server");
 const { inventoryPublicationsRepository } = await import(
   "./inventoryPublications.server"
 );
+const { inventorySellingHistoryRepository } = await import(
+  "./inventorySellingHistory.server"
+);
+type CreateInventoryPublication = import(
+  "~/features/inventory-publication/types/inventoryPublication"
+).CreateInventoryPublication;
 
 const prefix = `strategy-history-${Date.now()}`;
 const sellerKey = `${prefix}-seller`;
@@ -61,8 +67,9 @@ async function createLegacyPublication(
   batchNumber: number,
   sku: number,
   desiredPrice: number,
+  quantityDelta = 1,
 ) {
-  const result = await inventoryPublicationsRepository.createOrFindPlanned({
+  const params: CreateInventoryPublication = {
     planningKey: `${prefix}:${sku}`,
     batchNumber,
     method: "staged_delta",
@@ -70,7 +77,7 @@ async function createLegacyPublication(
     sellerKey,
     items: [{
       candidateKey: `pricing-result:${batchNumber}:${sku}:${pricedAt.toISOString()}`,
-      inventoryDeltaKey: `${prefix}:delta:${sku}`,
+      inventoryDeltaKey: quantityDelta === 0 ? null : `${prefix}:delta:${sku}`,
       batchNumber,
       sku,
       productId: sku,
@@ -79,10 +86,11 @@ async function createLegacyPublication(
       productName: `Card ${sku}`,
       condition: "Near Mint",
       desiredPrice,
-      quantityDelta: 1,
+      quantityDelta,
       pricedAt,
     }],
-  });
+  };
+  const result = await inventoryPublicationsRepository.createOrFindPlanned(params);
   const publicationId = result.publication.id;
   const itemId = result.publication.items[0].id;
   await execute(
@@ -92,7 +100,7 @@ async function createLegacyPublication(
   await inventoryPublicationsRepository.saveItemOutcomes(publicationId, [
     { itemId, status: "published", confirmedAt: pricedAt },
   ]);
-  return { publicationId, itemId };
+  return { publicationId, itemId, params };
 }
 
 try {
@@ -100,6 +108,13 @@ try {
   const exact = await createLegacyPublication(exactBatch, 9_640_101, 24.99);
   const mismatchBatch = await createBatchResult(9_640_102, 12.5, 45);
   const mismatch = await createLegacyPublication(mismatchBatch, 9_640_102, 12.51);
+  const repricingBatch = await createBatchResult(9_640_103, 9.99, 18);
+  const repricing = await createLegacyPublication(
+    repricingBatch,
+    9_640_103,
+    9.99,
+    0,
+  );
 
   assert.equal(
     await inventoryPublicationsRepository.backfillSupportedForecastEvidence(
@@ -114,9 +129,31 @@ try {
   assert.equal(exactItem.forecastEvidenceProvenance, "recorded");
   assert.equal(exactItem.forecastEvidence?.source, "historical_pricing_result_exact_match");
   assert.equal(exactItem.forecastEvidence?.decision?.estimatedMedianSellDays, 28);
+  assert.equal(
+    (await inventoryPublicationsRepository.createOrFindPlanned(exact.params)).created,
+    false,
+    "an omitted legacy forecast remains the request identity after backfill",
+  );
+  await assert.rejects(
+    inventoryPublicationsRepository.createOrFindPlanned({
+      ...exact.params,
+      items: exact.params.items.map((item) => ({
+        ...item,
+        forecastEvidence: {
+          source: "publication_candidate" as const,
+          schemaVersion: 2,
+          pricedAt: pricedAt.toISOString(),
+          pricingModelVersion: "different-supplied-model",
+        },
+      })),
+    }),
+    /different planning inputs/,
+  );
   const mismatchItem = (await inventoryPublicationsRepository.findById(mismatch.publicationId))!.items[0];
   assert.equal(mismatchItem.forecastEvidence, null);
   assert.equal(mismatchItem.forecastEvidenceProvenance, "unknown");
+  const repricingItem = (await inventoryPublicationsRepository.findById(repricing.publicationId))!.items[0];
+  assert.equal(repricingItem.forecastEvidence, null);
 
   await execute(
     `UPDATE inventory_batch_results SET pricing_details_json=jsonb_set(
@@ -131,6 +168,20 @@ try {
     inventoryPublicationsRepository.backfillSupportedForecastEvidence(sellerKey, 0),
     /limit must be between 1 and 1000/,
   );
+  await execute(
+    `INSERT INTO inventory_fifo_replay_queue
+      (seller_key,sku,affected_from,status,generation,hold_reason)
+    VALUES
+      ($1,9640201,$2,'held',1,'unexplained_inventory_difference:1:observed_-1:expected_-1'),
+      ($1,9640202,$2,'held',1,'unexplained_inventory_difference:2:observed_-2:expected_-1')`,
+    [sellerKey, pricedAt],
+  );
+  const historyEvidence = await inventorySellingHistoryRepository.findEvidence(
+    sellerKey,
+    { windowDays: 180, productLine: null },
+  );
+  assert.equal(historyEvidence.unresolvedRemoval.quantity, 1);
+  assert.deepEqual(historyEvidence.unresolvedRemoval.affectedSkus, [9_640_202]);
   console.log("PASS publication forecast backfill is exact, bounded, and immutable");
 } finally {
   await getPool().end();

--- a/app/core/db/repositories/inventorySellingHistory.server.ts
+++ b/app/core/db/repositories/inventorySellingHistory.server.ts
@@ -1,0 +1,296 @@
+import type {
+  SellingHistoryEpisodeEvidence,
+  SellingHistoryOutcomeEvidence,
+  SellingHistorySourceEvidence,
+  SellingHistoryScope,
+} from "~/features/inventory-strategy/types/inventorySellingHistory";
+import { query, queryOne } from "../database.server";
+import { sellerOrderHistoryRepository } from "./sellerOrderHistory.server";
+
+export const INVENTORY_SELLING_HISTORY_EPISODE_LIMIT = 20_000;
+export const INVENTORY_SELLING_HISTORY_OUTCOME_LIMIT = 40_000;
+
+type CountedEpisode = Omit<SellingHistoryEpisodeEvidence, "listedAt"> & {
+  listedAt: Date | null;
+  totalCount: number;
+};
+
+type CountedOutcome = Omit<SellingHistoryOutcomeEvidence, "happenedAt"> & {
+  happenedAt: Date;
+  totalCount: number;
+};
+
+const toEpisode = ({ totalCount: _totalCount, ...row }: CountedEpisode) => ({
+  ...row,
+  listedAt: row.listedAt?.toISOString() ?? null,
+});
+
+const toOutcome = ({ totalCount: _totalCount, ...row }: CountedOutcome) => ({
+  ...row,
+  happenedAt: row.happenedAt.toISOString(),
+});
+
+export const inventorySellingHistoryRepository = {
+  async findEvidence(
+    sellerKey: string,
+    scope: SellingHistoryScope,
+  ): Promise<SellingHistorySourceEvidence> {
+    const seller = sellerKey.trim();
+    if (!seller) throw new Error("Seller key is required.");
+
+    const [orderCoverage, observation] = await Promise.all([
+      sellerOrderHistoryRepository.getCoverage(seller),
+      queryOne<{ cutoffAt: Date }>(
+        `SELECT cutoff_at AS "cutoffAt"
+        FROM inventory_complete_observations
+        WHERE seller_key=$1 AND status='complete'
+        ORDER BY cutoff_at DESC,id DESC LIMIT 1`,
+        [seller],
+      ),
+    ]);
+
+    const asOf = orderCoverage.completedAt
+      ? new Date(orderCoverage.completedAt)
+      : new Date();
+    const analysisFrom = new Date(
+      asOf.getTime() - scope.windowDays * 86_400_000,
+    );
+
+    const [episodes, outcomes, productLineRows, projection, unresolvedRemoval] = await Promise.all([
+      query<CountedEpisode>(
+        `WITH all_episodes AS (
+          SELECT 'receipt:'||receipt.receipt_id::text AS "episodeKey",
+            receipt.receipt_id AS "receiptId",receipt.sku,
+            COALESCE(item.product_line,catalog.product_line_name,'Unknown') AS "productLine",
+            COALESCE(item.product_name,catalog.product_name,'SKU '||receipt.sku::text) AS "productName",
+            'confirmed_publication'::text AS kind,link.planned_quantity AS quantity,
+            link.live_at AS "listedAt",item.forecast_evidence AS "forecastEvidence",
+            item.forecast_evidence_provenance AS "forecastEvidenceProvenance"
+          FROM inventory_publication_receipt_links link
+          JOIN inventory_receipts receipt ON receipt.receipt_id=link.receipt_id
+          JOIN inventory_publication_items item ON item.id=link.publication_item_id
+          LEFT JOIN skus catalog ON catalog.sku=receipt.sku
+          WHERE link.target_seller_key=$1 AND link.live_at >= $2 AND link.live_at <= $3
+          UNION ALL
+          SELECT 'restock:'||disposition.id::text||':'||mapping.source_supply_key,
+            receipt.receipt_id,disposition.sku,
+            COALESCE(item.product_line,catalog.product_line_name,'Unknown'),
+            COALESCE(item.product_name,catalog.product_name,'SKU '||disposition.sku::text),
+            'physical_restock',mapping.quantity,NULL,NULL,'unknown'
+          FROM inventory_stock_dispositions disposition
+          JOIN inventory_stock_disposition_receipts mapping ON mapping.disposition_id=disposition.id
+          JOIN inventory_receipts receipt ON receipt.receipt_id=mapping.receipt_id
+          LEFT JOIN inventory_publication_receipt_links link ON link.receipt_id=receipt.receipt_id
+          LEFT JOIN inventory_publication_items item ON item.id=link.publication_item_id
+          LEFT JOIN skus catalog ON catalog.sku=receipt.sku
+          WHERE disposition.seller_key=$1 AND disposition.available_at >= $2
+            AND disposition.available_at <= $3
+          UNION ALL
+          SELECT 'quantity-correction:'||correction.id::text||':'||mapping.source_supply_key,
+            receipt.receipt_id,correction.sku,
+            COALESCE(item.product_line,catalog.product_line_name,'Unknown'),
+            COALESCE(item.product_name,catalog.product_name,'SKU '||correction.sku::text),
+            'order_quantity_correction',mapping.quantity,NULL,NULL,'unknown'
+          FROM inventory_order_quantity_corrections correction
+          JOIN inventory_order_quantity_correction_allocations mapping ON mapping.correction_id=correction.id
+          JOIN inventory_receipts receipt ON receipt.receipt_id=mapping.receipt_id
+          LEFT JOIN inventory_publication_receipt_links link ON link.receipt_id=receipt.receipt_id
+          LEFT JOIN inventory_publication_items item ON item.id=link.publication_item_id
+          LEFT JOIN skus catalog ON catalog.sku=receipt.sku
+          WHERE correction.seller_key=$1 AND correction.available_at >= $2
+            AND correction.available_at <= $3
+        ), episodes AS (
+          SELECT * FROM all_episodes
+          WHERE $4::text IS NULL OR "productLine"=$4
+        )
+        SELECT episodes.*,COUNT(*) OVER()::int AS "totalCount"
+        FROM episodes ORDER BY "listedAt" NULLS LAST,"episodeKey"
+        LIMIT $5`,
+        [seller, analysisFrom, asOf, scope.productLine, INVENTORY_SELLING_HISTORY_EPISODE_LIMIT],
+      ),
+      query<CountedOutcome>(
+        `WITH episode_keys AS (
+          SELECT 'receipt:'||link.receipt_id::text AS key
+          FROM inventory_publication_receipt_links link
+          JOIN inventory_publication_items item ON item.id=link.publication_item_id
+          WHERE link.target_seller_key=$1 AND link.live_at >= $2 AND link.live_at <= $3
+            AND ($4::text IS NULL OR item.product_line=$4)
+          UNION ALL
+          SELECT 'restock:'||disposition.id::text||':'||mapping.source_supply_key
+          FROM inventory_stock_dispositions disposition
+          JOIN inventory_stock_disposition_receipts mapping ON mapping.disposition_id=disposition.id
+          JOIN inventory_receipts receipt ON receipt.receipt_id=mapping.receipt_id
+          LEFT JOIN inventory_publication_receipt_links link ON link.receipt_id=receipt.receipt_id
+          LEFT JOIN inventory_publication_items item ON item.id=link.publication_item_id
+          LEFT JOIN skus catalog ON catalog.sku=receipt.sku
+          WHERE disposition.seller_key=$1 AND disposition.available_at >= $2
+            AND disposition.available_at <= $3
+            AND ($4::text IS NULL OR COALESCE(item.product_line,catalog.product_line_name,'Unknown')=$4)
+          UNION ALL
+          SELECT 'quantity-correction:'||correction.id::text||':'||mapping.source_supply_key
+          FROM inventory_order_quantity_corrections correction
+          JOIN inventory_order_quantity_correction_allocations mapping ON mapping.correction_id=correction.id
+          JOIN inventory_receipts receipt ON receipt.receipt_id=mapping.receipt_id
+          LEFT JOIN inventory_publication_receipt_links link ON link.receipt_id=receipt.receipt_id
+          LEFT JOIN inventory_publication_items item ON item.id=link.publication_item_id
+          LEFT JOIN skus catalog ON catalog.sku=receipt.sku
+          WHERE correction.seller_key=$1 AND correction.available_at >= $2
+            AND correction.available_at <= $3
+            AND ($4::text IS NULL OR COALESCE(item.product_line,catalog.product_line_name,'Unknown')=$4)
+        ), outcomes AS (
+          SELECT allocation.supply_key AS "episodeKey",
+            CASE WHEN orders.lifecycle='canceled' THEN 'removed' ELSE 'sale' END::text AS kind,
+            allocation.allocated_quantity AS quantity,orders.order_time AS "happenedAt",
+            orders.order_number AS "orderNumber",line.id::text AS "orderLineId",
+            CASE WHEN orders.lifecycle='canceled' THEN 'cancellation' ELSE 'seller_order' END::text AS source
+          FROM inventory_fifo_lines line
+          JOIN seller_orders orders ON orders.id=line.order_id
+          JOIN inventory_fifo_revision_allocations allocation
+            ON allocation.revision_id=line.current_revision_id
+          JOIN episode_keys episode ON episode.key=allocation.supply_key
+          LEFT JOIN inventory_fifo_replay_queue replay
+            ON replay.seller_key=line.seller_key AND replay.sku=line.sku
+          WHERE line.seller_key=$1 AND replay.seller_key IS NULL
+            AND orders.order_time >= $2 AND orders.order_time <= $3
+            AND line.state IN ('allocated','partial','unmatched')
+            AND orders.lifecycle IN ('processing','ready_to_ship','shipped_in_transit',
+              'shipped_delivered','completed_paid','canceled')
+          UNION ALL
+          SELECT mapping.source_supply_key,'removed',mapping.quantity,correction.available_at,
+            orders.order_number,line.id::text,'quantity_correction'
+          FROM inventory_order_quantity_corrections correction
+          JOIN inventory_order_quantity_correction_allocations mapping
+            ON mapping.correction_id=correction.id
+          JOIN episode_keys episode ON episode.key=mapping.source_supply_key
+          JOIN seller_orders orders ON orders.id=correction.order_id
+          LEFT JOIN inventory_fifo_lines line ON line.order_id=correction.order_id
+            AND line.order_line_sku_id=correction.order_line_sku_id
+          WHERE correction.seller_key=$1 AND correction.available_at >= $2
+            AND correction.available_at <= $3
+        )
+        SELECT outcomes.*,COUNT(*) OVER()::int AS "totalCount"
+        FROM outcomes ORDER BY "happenedAt","episodeKey" LIMIT $5`,
+        [seller, analysisFrom, asOf, scope.productLine, INVENTORY_SELLING_HISTORY_OUTCOME_LIMIT],
+      ),
+      query<{ productLine: string }>(
+        `SELECT DISTINCT item.product_line AS "productLine"
+        FROM inventory_publication_receipt_links link
+        JOIN inventory_publication_items item ON item.id=link.publication_item_id
+        WHERE link.target_seller_key=$1 AND link.live_at IS NOT NULL
+          AND link.live_at >= $2 AND link.live_at <= $3
+        ORDER BY item.product_line LIMIT 100`,
+        [seller, new Date(asOf.getTime() - 730 * 86_400_000), asOf],
+      ),
+      queryOne<{ pendingQuantity: number; heldQuantity: number; affectedSkus: number[]; openingUnknownQuantity: number; legacyUnlinkedQuantity: number; legacyUnlinkedForecastQuantity: number; olderPublicationQuantity: number; awaitingCutoffQuantity: number }>(
+        `SELECT
+          COALESCE(SUM(line.ordered_quantity) FILTER (
+            WHERE replay.status IN ('pending','processing') OR
+              (replay.status IS NULL AND line.state='pending')),0)::int AS "pendingQuantity",
+          COALESCE(SUM(line.ordered_quantity) FILTER (
+            WHERE replay.status='held' OR
+              (replay.status IS NULL AND line.state='held')),0)::int AS "heldQuantity"
+          ,COALESCE(array_agg(DISTINCT line.sku) FILTER (
+            WHERE line.sku IS NOT NULL AND (replay.seller_key IS NOT NULL OR
+              line.state IN ('pending','held'))),'{}') AS "affectedSkus",
+          (SELECT COALESCE(SUM(receipt.original_quantity),0)::int
+            FROM inventory_receipts receipt
+            JOIN inventory_opening_balance_runs opening
+              ON opening.id=receipt.opening_balance_run_id AND opening.status='applied'
+            LEFT JOIN skus opening_catalog ON opening_catalog.sku=receipt.sku
+            WHERE receipt.seller_key=$1 AND receipt.receipt_kind='opening_balance'
+              AND ($4::text IS NULL OR COALESCE(opening_catalog.product_line_name,'Unknown')=$4)) AS "openingUnknownQuantity"
+          ,(SELECT COALESCE(SUM(item.quantity_delta),0)::int
+            FROM inventory_publication_items item
+            JOIN inventory_publications publication ON publication.id=item.publication_id
+            WHERE publication.seller_key=$1 AND item.status='published' AND item.quantity_delta>0
+              AND ($4::text IS NULL OR item.product_line=$4)
+              AND NOT EXISTS (SELECT 1 FROM inventory_publication_receipt_links link
+                WHERE link.publication_item_id=item.id)) AS "legacyUnlinkedQuantity"
+          ,(SELECT COALESCE(SUM(item.quantity_delta),0)::int
+            FROM inventory_publication_items item
+            JOIN inventory_publications publication ON publication.id=item.publication_id
+            WHERE publication.seller_key=$1 AND item.status='published' AND item.quantity_delta>0
+              AND ($4::text IS NULL OR item.product_line=$4)
+              AND item.forecast_evidence IS NOT NULL
+              AND NOT EXISTS (SELECT 1 FROM inventory_publication_receipt_links link
+                WHERE link.publication_item_id=item.id)) AS "legacyUnlinkedForecastQuantity",
+          (SELECT COALESCE(SUM(link.planned_quantity),0)::int
+            FROM inventory_publication_receipt_links link
+            JOIN inventory_publication_items item ON item.id=link.publication_item_id
+            WHERE link.target_seller_key=$1 AND link.live_at<$2
+              AND ($4::text IS NULL OR item.product_line=$4)) AS "olderPublicationQuantity",
+          (SELECT COALESCE(SUM(awaiting.quantity),0)::int FROM (
+            SELECT link.planned_quantity AS quantity,item.product_line AS "productLine"
+            FROM inventory_publication_receipt_links link
+            JOIN inventory_publication_items item ON item.id=link.publication_item_id
+            WHERE link.target_seller_key=$1 AND link.live_at>$3
+            UNION ALL
+            SELECT mapping.quantity,COALESCE(item.product_line,catalog.product_line_name,'Unknown')
+            FROM inventory_stock_dispositions disposition
+            JOIN inventory_stock_disposition_receipts mapping ON mapping.disposition_id=disposition.id
+            JOIN inventory_receipts receipt ON receipt.receipt_id=mapping.receipt_id
+            LEFT JOIN inventory_publication_receipt_links link ON link.receipt_id=receipt.receipt_id
+            LEFT JOIN inventory_publication_items item ON item.id=link.publication_item_id
+            LEFT JOIN skus catalog ON catalog.sku=receipt.sku
+            WHERE disposition.seller_key=$1 AND disposition.available_at>$3
+            UNION ALL
+            SELECT mapping.quantity,COALESCE(item.product_line,catalog.product_line_name,'Unknown')
+            FROM inventory_order_quantity_corrections correction
+            JOIN inventory_order_quantity_correction_allocations mapping ON mapping.correction_id=correction.id
+            JOIN inventory_receipts receipt ON receipt.receipt_id=mapping.receipt_id
+            LEFT JOIN inventory_publication_receipt_links link ON link.receipt_id=receipt.receipt_id
+            LEFT JOIN inventory_publication_items item ON item.id=link.publication_item_id
+            LEFT JOIN skus catalog ON catalog.sku=receipt.sku
+            WHERE correction.seller_key=$1 AND correction.available_at>$3
+          ) awaiting WHERE $4::text IS NULL OR awaiting."productLine"=$4) AS "awaitingCutoffQuantity"
+        FROM inventory_fifo_lines line
+        LEFT JOIN inventory_fifo_replay_queue replay
+          ON replay.seller_key=line.seller_key AND replay.sku=line.sku
+        LEFT JOIN skus line_catalog ON line_catalog.sku=line.sku
+        WHERE line.seller_key=$1
+          AND ($4::text IS NULL OR COALESCE(line_catalog.product_line_name,'Unknown')=$4)`,
+        [seller, analysisFrom, asOf, scope.productLine],
+      ),
+      queryOne<{ quantity: number; affectedSkus: number[] }>(
+        `SELECT COALESCE(SUM(ABS(difference.quantity_delta)),0)::int AS quantity,
+          COALESCE(array_agg(DISTINCT difference.sku) FILTER (WHERE difference.sku IS NOT NULL),'{}') AS "affectedSkus"
+        FROM inventory_observation_differences difference
+        JOIN inventory_complete_observations observation ON observation.id=difference.observation_id
+        JOIN inventory_opening_balance_runs opening
+          ON opening.seller_key=difference.seller_key AND opening.status='applied'
+        LEFT JOIN skus catalog ON catalog.sku=difference.sku
+        WHERE difference.seller_key=$1 AND difference.quantity_delta<0
+          AND observation.cutoff_at>opening.cutoff_at
+          AND difference.status IN ('unresolved','acknowledged')
+          AND ($2::text IS NULL OR COALESCE(catalog.product_line_name,'Unknown')=$2)`,
+        [seller, scope.productLine],
+      ),
+    ]);
+
+    return {
+      sellerKey: seller,
+      scope,
+      availableProductLines: productLineRows.map((row) => row.productLine),
+      analysisFrom: analysisFrom.toISOString(),
+      inventoryObservedAt: observation?.cutoffAt.toISOString() ?? null,
+      orderCoverage,
+      episodes: episodes.map(toEpisode),
+      episodeCount: episodes[0]?.totalCount ?? 0,
+      outcomes: outcomes.map(toOutcome),
+      outcomeCount: outcomes[0]?.totalCount ?? 0,
+      projection: {
+        pendingQuantity: projection?.pendingQuantity ?? 0,
+        heldQuantity: projection?.heldQuantity ?? 0,
+        affectedSkus: projection?.affectedSkus ?? [],
+      },
+      openingUnknownQuantity: projection?.openingUnknownQuantity ?? 0,
+      legacyUnlinked: {
+        quantity: projection?.legacyUnlinkedQuantity ?? 0,
+        forecastQuantity: projection?.legacyUnlinkedForecastQuantity ?? 0,
+      },
+      olderPublicationQuantity: projection?.olderPublicationQuantity ?? 0,
+      awaitingCutoffQuantity: projection?.awaitingCutoffQuantity ?? 0,
+      unresolvedRemoval: unresolvedRemoval ?? { quantity: 0, affectedSkus: [] },
+    };
+  },
+};

--- a/app/core/db/repositories/inventorySellingHistory.server.ts
+++ b/app/core/db/repositories/inventorySellingHistory.server.ts
@@ -252,17 +252,21 @@ export const inventorySellingHistoryRepository = {
         [seller, analysisFrom, asOf, scope.productLine],
       ),
       queryOne<{ quantity: number; affectedSkus: number[] }>(
-        `SELECT COALESCE(SUM(ABS(difference.quantity_delta)),0)::int AS quantity,
-          COALESCE(array_agg(DISTINCT difference.sku) FILTER (WHERE difference.sku IS NOT NULL),'{}') AS "affectedSkus"
-        FROM inventory_observation_differences difference
-        JOIN inventory_complete_observations observation ON observation.id=difference.observation_id
-        JOIN inventory_opening_balance_runs opening
-          ON opening.seller_key=difference.seller_key AND opening.status='applied'
-        LEFT JOIN skus catalog ON catalog.sku=difference.sku
-        WHERE difference.seller_key=$1 AND difference.quantity_delta<0
-          AND observation.cutoff_at>opening.cutoff_at
-          AND difference.status IN ('unresolved','acknowledged')
-          AND ($2::text IS NULL OR COALESCE(catalog.product_line_name,'Unknown')=$2)`,
+        `WITH held AS (
+          SELECT replay.sku,
+            substring(replay.hold_reason FROM 'observed_(-?[0-9]+)')::int AS observed,
+            substring(replay.hold_reason FROM 'expected_(-?[0-9]+)')::int AS expected
+          FROM inventory_fifo_replay_queue replay
+          LEFT JOIN skus catalog ON catalog.sku=replay.sku
+          WHERE replay.seller_key=$1 AND replay.status='held'
+            AND replay.hold_reason ~ '^unexplained_inventory_difference:[0-9]+:observed_-?[0-9]+:expected_-?[0-9]+$'
+            AND ($2::text IS NULL OR COALESCE(catalog.product_line_name,'Unknown')=$2)
+        ), removals AS (
+          SELECT sku,GREATEST(expected-observed,0)::int AS quantity FROM held
+        )
+        SELECT COALESCE(SUM(quantity),0)::int AS quantity,
+          COALESCE(array_agg(DISTINCT sku) FILTER (WHERE quantity>0),'{}') AS "affectedSkus"
+        FROM removals`,
         [seller, scope.productLine],
       ),
     ]);

--- a/app/features/inventory-publication/services/inventoryBatchPublication.server.test.ts
+++ b/app/features/inventory-publication/services/inventoryBatchPublication.server.test.ts
@@ -15,6 +15,7 @@ import {
   planInventoryBatchPublication,
   planInventoryBatchPublications,
   previewInventoryBatchPublication,
+  snapshotPublicationForecastEvidence,
 } from "./inventoryBatchPublication.server";
 
 type TestCase = {
@@ -24,6 +25,41 @@ type TestCase = {
 
 const NOW = new Date("2026-08-05T12:00:00.000Z");
 const PRICED_AT = new Date("2026-08-05T11:30:00.000Z");
+
+assert.deepEqual(
+  snapshotPublicationForecastEvidence({
+    schemaVersion: 2,
+    pricedAt: PRICED_AT.toISOString(),
+    pricingModelVersion: "model-v2",
+    marketplacePrice: 24.99,
+    decision: {
+      method: "target-horizon",
+      selectedPrice: 24.99,
+      targetHorizonDays: 30,
+      estimatedMedianSellDays: 28,
+      constraint: "none",
+      basis: "modeled",
+      forecastStatus: "interpolated",
+    },
+  }),
+  {
+    source: "publication_candidate",
+    schemaVersion: 2,
+    pricedAt: PRICED_AT.toISOString(),
+    pricingModelVersion: "model-v2",
+    decision: {
+      method: "target-horizon",
+      selectedPrice: 24.99,
+      targetHorizonDays: 30,
+      estimatedMedianSellDays: 28,
+      constraint: "none",
+      basis: "modeled",
+      forecastStatus: "interpolated",
+    },
+  },
+  "publication evidence keeps only the supplied forecast and version fields",
+);
+assert.equal(snapshotPublicationForecastEvidence(null), null);
 
 function createRow(): TcgPlayerListing {
   return {
@@ -175,6 +211,8 @@ function createPublication(
       desiredAbsoluteQuantity: item.desiredAbsoluteQuantity ?? null,
       pricedAt: item.pricedAt,
       eligibilityReasons: item.eligibilityReasons ?? [],
+      forecastEvidence: item.forecastEvidence ?? null,
+      forecastEvidenceProvenance: item.forecastEvidence ? "recorded" : "unknown",
       status: item.status ?? "planned",
       errorCode: null,
       errorMessage: null,

--- a/app/features/inventory-publication/services/inventoryBatchPublication.server.ts
+++ b/app/features/inventory-publication/services/inventoryBatchPublication.server.ts
@@ -8,6 +8,7 @@ import type {
   InventoryBatchItem,
   InventoryBatchResult,
 } from "~/features/pending-inventory/types/inventoryBatch";
+import type { PersistedPricingDetails } from "~/core/types/pricing";
 import {
   createInventoryDeltaKey,
   createPricingCandidateKey,
@@ -20,6 +21,7 @@ import {
   type InventoryPublicationEligibilityReason,
   type InventoryPublicationItemStatus,
   type InventoryPublicationPolicy,
+  type InventoryPublicationForecastEvidence,
   type InventoryPublicationSourceType,
 } from "../types/inventoryPublication";
 
@@ -40,6 +42,32 @@ export interface InventoryBatchPublicationPreviewItem {
   reasons: InventoryPublicationEligibilityReason[];
   candidateKey: string;
   inventoryDeltaKey: string | null;
+  forecastEvidence: InventoryPublicationForecastEvidence | null;
+}
+
+export function snapshotPublicationForecastEvidence(
+  details: PersistedPricingDetails | null,
+): InventoryPublicationForecastEvidence | null {
+  if (!details) return null;
+  return {
+    source: "publication_candidate",
+    schemaVersion: details.schemaVersion,
+    pricedAt: details.pricedAt,
+    ...(details.pricingModelVersion
+      ? { pricingModelVersion: details.pricingModelVersion }
+      : {}),
+    ...(details.policy ? { policy: details.policy } : {}),
+    ...(details.decision ? { decision: details.decision } : {}),
+    ...(details.buyerChoiceForecast
+      ? { buyerChoiceForecast: details.buyerChoiceForecast }
+      : {}),
+    ...(details.conditionRateForecast
+      ? { conditionRateForecast: details.conditionRateForecast }
+      : {}),
+    ...(details.estimatedTimeToSellDays !== undefined
+      ? { estimatedTimeToSellDays: details.estimatedTimeToSellDays }
+      : {}),
+  };
 }
 
 export interface InventoryBatchPublicationPreview {
@@ -253,6 +281,7 @@ function createPublicationParams(
       desiredPrice: item.desiredPrice,
       quantityDelta: item.quantityDelta,
       pricedAt: item.pricedAt,
+      forecastEvidence: item.forecastEvidence,
       eligibilityReasons: [],
       status: "planned",
     })),
@@ -412,6 +441,9 @@ export async function previewInventoryBatchPublication(
       reasons,
       candidateKey,
       inventoryDeltaKey,
+      forecastEvidence: snapshotPublicationForecastEvidence(
+        result.pricingDetails,
+      ),
     };
   });
 

--- a/app/features/inventory-publication/services/inventoryPublicationWorker.test.ts
+++ b/app/features/inventory-publication/services/inventoryPublicationWorker.test.ts
@@ -41,6 +41,8 @@ function createItem(
     desiredAbsoluteQuantity: null,
     pricedAt: NOW,
     eligibilityReasons: [],
+    forecastEvidence: null,
+    forecastEvidenceProvenance: "unknown",
     status: "planned",
     errorCode: null,
     errorMessage: null,

--- a/app/features/inventory-publication/types/inventoryPublication.ts
+++ b/app/features/inventory-publication/types/inventoryPublication.ts
@@ -1,3 +1,4 @@
+import type { PersistedPricingDetails } from "../../../core/types/pricing";
 import type { PricingDecision } from "../../../core/types/pricingPolicy";
 
 export type InventoryPublicationSourceType =
@@ -123,6 +124,8 @@ export interface InventoryPublicationItem {
   desiredAbsoluteQuantity: number | null;
   pricedAt: Date;
   eligibilityReasons: InventoryPublicationEligibilityReason[];
+  forecastEvidence: InventoryPublicationForecastEvidence | null;
+  forecastEvidenceProvenance: "recorded" | "estimated" | "unknown";
   status: InventoryPublicationItemStatus;
   errorCode: string | null;
   errorMessage: string | null;
@@ -174,8 +177,24 @@ export interface CreateInventoryPublicationItem {
   desiredAbsoluteQuantity?: number | null;
   pricedAt: Date;
   eligibilityReasons?: InventoryPublicationEligibilityReason[];
+  forecastEvidence?: InventoryPublicationForecastEvidence | null;
   status?: InventoryPublicationItemStatus;
 }
+
+/** Forecast fields that were actually present on the pricing candidate. */
+export type InventoryPublicationForecastEvidence = Pick<
+  PersistedPricingDetails,
+  | "schemaVersion"
+  | "pricingModelVersion"
+  | "pricedAt"
+  | "policy"
+  | "decision"
+  | "buyerChoiceForecast"
+  | "conditionRateForecast"
+  | "estimatedTimeToSellDays"
+> & {
+  source: "publication_candidate" | "historical_pricing_result_exact_match";
+};
 
 export interface CreateInventoryPublication {
   planningKey: string;
@@ -228,6 +247,7 @@ export interface InventoryBatchPublicationPreviewItem {
   reasons: InventoryPublicationEligibilityReason[];
   candidateKey: string;
   inventoryDeltaKey: string | null;
+  forecastEvidence: InventoryPublicationForecastEvidence | null;
 }
 
 export interface InventoryBatchPublicationPreview {

--- a/app/features/inventory-strategy/components/InventorySellingHistory.test.tsx
+++ b/app/features/inventory-strategy/components/InventorySellingHistory.test.tsx
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router";
+import { InventorySellingHistory } from "./InventorySellingHistory";
+import type { InventorySellingHistoryReport } from "../types/inventorySellingHistory";
+
+const orderCoverage = {
+  sellerKey: "seller",
+  source: "tcgplayer_api" as const,
+  status: "incomplete" as const,
+  observedThrough: "2026-09-01T00:00:00.000Z",
+  lastAttemptAt: "2026-09-02T00:00:00.000Z",
+  ordersObserved: 8,
+  detailsRecorded: 8,
+  gaps: ["August import pending"],
+};
+
+const summary = {
+  cohortQuantity: 10,
+  knownListedDateQuantity: 8,
+  unknownListedDateQuantity: 2,
+  soldQuantity: 2,
+  soldWithKnownListedDateQuantity: 2,
+  remainingWithKnownAgeQuantity: 6,
+  remainingWithUncertainPresenceQuantity: 1,
+  removedQuantity: 1,
+  soldOnlyAverageDays: 12.5,
+  medianDaysToSale: null,
+  p90DaysToSale: null,
+  percentileStatus: "not_reached" as const,
+  sellThrough: [
+    { days: 7, eligibleQuantity: 8, soldQuantity: 1, rate: 0.125, status: "exact" as const },
+    { days: 30, eligibleQuantity: 4, soldQuantity: 2, rate: 0.5, status: "exact" as const },
+    { days: 60, eligibleQuantity: 0, soldQuantity: 0, rate: null, status: "exact" as const },
+    { days: 90, eligibleQuantity: 0, soldQuantity: 0, rate: null, status: "exact" as const },
+  ],
+};
+
+const ready: InventorySellingHistoryReport = {
+  status: "ready",
+  sellerKey: "seller",
+  scope: { windowDays: 180, productLine: "Pokémon" },
+  availableProductLines: ["Magic", "Pokémon"],
+  analysisFrom: "2026-07-01T00:00:00.000Z",
+  asOf: "2026-09-03T00:00:00.000Z",
+  orderCoverage,
+  overall: summary,
+  productLines: [{ ...summary, productLine: "Pokémon" }],
+  details: [{
+    episodeKey: "publication:1",
+    receiptId: 12,
+    sku: 44,
+    productLine: "Pokémon",
+    productName: "Pikachu",
+    kind: "confirmed_publication",
+    quantity: 3,
+    listedAt: "2026-08-01T00:00:00.000Z",
+    soldQuantity: 2,
+    removedQuantity: 0,
+    ledgerRemainingQuantity: 1,
+    remainingAgeDays: 33,
+    presenceUncertain: false,
+    forecastEvidenceProvenance: "recorded",
+    forecastEvidence: null,
+    orders: [{ orderNumber: "1001", quantity: 2, soldAt: "2026-08-14T00:00:00.000Z", listedDays: 13 }],
+  }],
+  detailTotal: 3,
+  detailPage: 1,
+  detailPageCount: 1,
+  coverage: {
+    pendingProjectionQuantity: 1,
+    heldProjectionQuantity: 2,
+    unresolvedRemovalQuantity: 1,
+    affectedRemovalSkus: 1,
+    openingUnknownQuantity: 2,
+    legacyUnlinkedQuantity: 0,
+    legacyUnlinkedForecastQuantity: 0,
+    olderPublicationQuantity: 3,
+    awaitingCutoffQuantity: 2,
+  },
+};
+
+function render(report: InventorySellingHistoryReport, entry = "/inventory-strategy?historyPage=2&other=kept") {
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={[entry]}>
+      <InventorySellingHistory report={report} />
+    </MemoryRouter>,
+  );
+}
+
+const success = render(ready);
+assert.match(success, /Observed listing exposure/);
+assert.match(success, /Sold-only average/);
+assert.match(success, /it is not an expected wait for all inventory/);
+assert.match(success, /Unavailable: not reached/);
+assert.match(success, /Age-eligible sell-through/);
+assert.match(success, /showing 1 of 3/);
+assert.match(success, /original opening quantity with unknown listed date/);
+assert.match(success, /History gaps: August import pending/);
+assert.match(success, /Order 1001/);
+assert.match(success, /History window/);
+assert.match(success, /Last 180 days/);
+assert.match(success, /Pokémon/);
+assert.match(success, /older publication excluded by window/);
+assert.match(success, /awaiting cutoff/);
+assert.doesNotMatch(success, /profit|cost basis|intake-to-sale days held/i);
+
+const openingOnly = render({
+  ...ready,
+  overall: {
+    ...summary,
+    cohortQuantity: 7,
+    knownListedDateQuantity: 0,
+    unknownListedDateQuantity: 7,
+    soldQuantity: 0,
+    soldWithKnownListedDateQuantity: 0,
+    remainingWithKnownAgeQuantity: 0,
+    remainingWithUncertainPresenceQuantity: 0,
+    removedQuantity: 0,
+    sellThrough: summary.sellThrough.map((horizon) => ({
+      ...horizon,
+      eligibleQuantity: 0,
+      soldQuantity: 0,
+      rate: null,
+    })),
+  },
+  productLines: [],
+  details: [],
+  detailTotal: 0,
+  coverage: {
+    ...ready.coverage,
+    openingUnknownQuantity: 7,
+    legacyUnlinkedQuantity: 4,
+    legacyUnlinkedForecastQuantity: 3,
+  },
+});
+const openingText = openingOnly.replace(/<[^>]*>/g, "");
+assert.match(openingText, /Ledger expected remaining7 units/);
+assert.match(openingText, /0 units with known age · 0 units uncertain presence · 7 units unknown listed date/);
+assert.match(openingText, /7 units original opening quantity with unknown listed date/);
+assert.match(openingText, /4 units legacy unlinked · 3 units with preserved forecast evidence/);
+
+const unsettled = render({
+  ...ready,
+  overall: {
+    ...summary,
+    sellThrough: summary.sellThrough.map((horizon) =>
+      horizon.days === 30
+        ? { ...horizon, rate: null, status: "unsettled_outcomes" as const }
+        : horizon,
+    ),
+  },
+});
+assert.match(unsettled.replace(/<[^>]*>/g, ""), /Unavailable: unsettled outcomes/);
+
+const paginated = render({ ...ready, detailPageCount: 2 });
+assert.match(paginated, /pagination navigation/);
+assert.match(paginated, /page 2/i);
+
+const empty = render({ ...ready, overall: { ...summary, cohortQuantity: 0 }, productLines: [], details: [], detailTotal: 0 });
+assert.match(empty, /No published listing cohorts are available/);
+
+const unavailable = render({
+  status: "unavailable",
+  sellerKey: "seller",
+  scope: { windowDays: 730, productLine: null },
+  availableProductLines: ["Magic", "Pokémon"],
+  reason: "history_bounds_exceeded",
+  orderCoverage,
+});
+assert.match(unavailable, /Selling history is unavailable: history bounds exceeded/);
+assert.match(unavailable, /Order history: incomplete/);
+assert.match(unavailable, /History window/);
+assert.match(unavailable, /Last 730 days/);
+
+console.log("PASS inventory selling history presents available, empty, unavailable, and bounded detail states");

--- a/app/features/inventory-strategy/components/InventorySellingHistory.tsx
+++ b/app/features/inventory-strategy/components/InventorySellingHistory.tsx
@@ -1,0 +1,393 @@
+import {
+  Box,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Pagination,
+  Paper,
+  Select,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { useSearchParams } from "react-router";
+import {
+  SELLING_HISTORY_WINDOWS,
+  type InventorySellingHistoryReport,
+  type SellingHistorySummary,
+} from "../types/inventorySellingHistory";
+
+function quantity(value: number): string {
+  return value.toLocaleString();
+}
+
+function unitLabel(value: number): string {
+  return `${quantity(value)} ${value === 1 ? "unit" : "units"}`;
+}
+
+function days(value: number | null): string {
+  return value === null ? "Unavailable" : `${value.toFixed(1)} days`;
+}
+
+function date(value: string | null | undefined): string {
+  return value ? new Date(value).toLocaleString() : "Unknown";
+}
+
+function range(value: string | undefined): string | null {
+  return value ? value.replaceAll("_", " ") : null;
+}
+
+function statusLabel(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+function Stat({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <Box>
+      <Typography variant="body2" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="h6" sx={{ my: 0.25 }}>
+        {value}
+      </Typography>
+      <Typography variant="caption" color="text.secondary">
+        {detail}
+      </Typography>
+    </Box>
+  );
+}
+
+function Summary({ summary }: { summary: SellingHistorySummary }) {
+  const knownRemaining =
+    summary.remainingWithKnownAgeQuantity +
+    summary.remainingWithUncertainPresenceQuantity;
+  const remaining = Math.max(
+    0,
+    summary.cohortQuantity - summary.soldQuantity - summary.removedQuantity,
+  );
+  const remainingWithUnknownListedDate = Math.max(0, remaining - knownRemaining);
+  return (
+    <Box
+      sx={{
+        display: "grid",
+        gridTemplateColumns: { xs: "repeat(2, minmax(0, 1fr))", md: "repeat(4, minmax(0, 1fr))" },
+        gap: 2,
+      }}
+    >
+      <Stat
+        label="Sold"
+        value={unitLabel(summary.soldQuantity)}
+        detail={`${unitLabel(summary.soldWithKnownListedDateQuantity)} with a known listed date`}
+      />
+      <Stat
+        label="Sold-only average"
+        value={days(summary.soldOnlyAverageDays)}
+        detail="Observed time listed before sale; it is not an expected wait for all inventory"
+      />
+      <Stat
+        label="Median / P90"
+        value={`${days(summary.medianDaysToSale)} / ${days(summary.p90DaysToSale)}`}
+        detail={
+          summary.percentileStatus === "estimable"
+            ? "Time listed before sale"
+            : `Unavailable: ${statusLabel(summary.percentileStatus)}`
+        }
+      />
+      <Stat
+        label="Ledger expected remaining"
+        value={unitLabel(remaining)}
+        detail={`${unitLabel(summary.remainingWithKnownAgeQuantity)} with known age · ${unitLabel(summary.remainingWithUncertainPresenceQuantity)} uncertain presence · ${unitLabel(remainingWithUnknownListedDate)} unknown listed date`}
+      />
+    </Box>
+  );
+}
+
+function SellThrough({ summary }: { summary: SellingHistorySummary }) {
+  return (
+    <TableContainer sx={{ mt: 2, overflowX: "auto" }}>
+      <Table size="small" aria-label="Age-eligible sell-through">
+        <TableHead>
+          <TableRow>
+            <TableCell>Age-eligible sell-through</TableCell>
+            <TableCell align="right">Eligible</TableCell>
+            <TableCell align="right">Sold</TableCell>
+            <TableCell align="right">Rate</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {summary.sellThrough.map((horizon) => (
+            <TableRow key={horizon.days}>
+              <TableCell>{horizon.days} days</TableCell>
+              <TableCell align="right">{unitLabel(horizon.eligibleQuantity)}</TableCell>
+              <TableCell align="right">{unitLabel(horizon.soldQuantity)}</TableCell>
+              <TableCell align="right">
+                {horizon.rate === null
+                  ? horizon.status === "unsettled_outcomes"
+                    ? "Unavailable: unsettled outcomes"
+                    : "Unavailable"
+                  : `${(horizon.rate * 100).toFixed(1)}%`}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+function Coverage({ report }: { report: Extract<InventorySellingHistoryReport, { status: "ready" }> }) {
+  const { coverage, orderCoverage, overall } = report;
+  const gaps = orderCoverage.gaps.filter(Boolean);
+  const rangeLabel = range(orderCoverage.searchRange);
+  return (
+    <Stack spacing={0.75} sx={{ mt: 2 }}>
+      <Stack direction="row" spacing={0.75} useFlexGap flexWrap="wrap">
+        <Chip size="small" variant="outlined" label={`Order history: ${statusLabel(orderCoverage.status)}`} />
+        <Chip size="small" variant="outlined" label={`Known listed dates ${unitLabel(overall.knownListedDateQuantity)} of ${unitLabel(overall.cohortQuantity)}`} />
+        {overall.unknownListedDateQuantity > 0 && <Chip size="small" color="warning" variant="outlined" label={`${unitLabel(overall.unknownListedDateQuantity)} unknown listed date`} />}
+        {coverage.openingUnknownQuantity > 0 && <Chip size="small" color="warning" variant="outlined" label={`${unitLabel(coverage.openingUnknownQuantity)} original opening quantity with unknown listed date`} />}
+        {coverage.pendingProjectionQuantity > 0 && <Chip size="small" color="info" variant="outlined" label={`${unitLabel(coverage.pendingProjectionQuantity)} pending`} />}
+        {coverage.heldProjectionQuantity > 0 && <Chip size="small" color="warning" variant="outlined" label={`${unitLabel(coverage.heldProjectionQuantity)} held`} />}
+        {coverage.unresolvedRemovalQuantity > 0 && <Chip size="small" color="warning" variant="outlined" label={`${unitLabel(coverage.unresolvedRemovalQuantity)} unresolved removal`} />}
+        {coverage.legacyUnlinkedQuantity > 0 && <Chip size="small" variant="outlined" label={`${unitLabel(coverage.legacyUnlinkedQuantity)} legacy unlinked${coverage.legacyUnlinkedForecastQuantity > 0 ? ` · ${unitLabel(coverage.legacyUnlinkedForecastQuantity)} with preserved forecast evidence` : ""}`} />}
+        {coverage.olderPublicationQuantity > 0 && <Chip size="small" variant="outlined" label={`${unitLabel(coverage.olderPublicationQuantity)} older publication excluded by window`} />}
+        {coverage.awaitingCutoffQuantity > 0 && <Chip size="small" variant="outlined" label={`${unitLabel(coverage.awaitingCutoffQuantity)} awaiting cutoff`} />}
+      </Stack>
+      <Typography variant="caption" color="text.secondary">
+        {rangeLabel ? `Order search: ${rangeLabel}. ` : ""}
+        Observed {orderCoverage.observedThrough ? `through ${date(orderCoverage.observedThrough)}` : "through an unknown date"}
+        {orderCoverage.lastAttemptAt ? ` · Last sync attempt ${date(orderCoverage.lastAttemptAt)}` : ""}
+        {orderCoverage.completedAt ? ` · Completed ${date(orderCoverage.completedAt)}` : ""}
+        {orderCoverage.expectedTotal !== undefined ? ` · ${quantity(orderCoverage.ordersObserved)} of ${quantity(orderCoverage.expectedTotal)} orders observed` : ` · ${quantity(orderCoverage.ordersObserved)} orders observed`}
+      </Typography>
+      {(gaps.length > 0 || orderCoverage.error) && (
+        <Typography variant="caption" color="warning.main">
+          {gaps.length ? `History gaps: ${gaps.join("; ")}` : ""}
+          {gaps.length && orderCoverage.error ? " · " : ""}
+          {orderCoverage.error ? `Last sync issue: ${orderCoverage.error}` : ""}
+        </Typography>
+      )}
+    </Stack>
+  );
+}
+
+function ProductLines({ report }: { report: Extract<InventorySellingHistoryReport, { status: "ready" }> }) {
+  if (!report.productLines.length) return null;
+  return (
+    <TableContainer sx={{ mt: 2, overflowX: "auto" }}>
+      <Table size="small" aria-label="Product-line selling history">
+        <TableHead>
+          <TableRow>
+            <TableCell>Product line</TableCell>
+            <TableCell align="right">Cohort</TableCell>
+            <TableCell align="right">Sold</TableCell>
+            <TableCell align="right">Sold-only average</TableCell>
+            <TableCell align="right">Remaining known age</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {report.productLines.map((line) => (
+            <TableRow key={line.productLine}>
+              <TableCell>{line.productLine}</TableCell>
+              <TableCell align="right">{unitLabel(line.cohortQuantity)}</TableCell>
+              <TableCell align="right">{unitLabel(line.soldQuantity)}</TableCell>
+              <TableCell align="right">{days(line.soldOnlyAverageDays)}</TableCell>
+              <TableCell align="right">{unitLabel(line.remainingWithKnownAgeQuantity)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+function ScopeControls({ report }: { report: InventorySellingHistoryReport }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const updateScope = (key: "historyDays" | "historyProductLine", value: string) => {
+    const nextSearchParams = new URLSearchParams(searchParams);
+    if (key === "historyProductLine" && value === "") {
+      nextSearchParams.delete(key);
+    } else {
+      nextSearchParams.set(key, value);
+    }
+    nextSearchParams.set("historyPage", "1");
+    setSearchParams(nextSearchParams);
+  };
+
+  return (
+    <Stack direction={{ xs: "column", sm: "row" }} spacing={1} sx={{ mt: 1.5 }}>
+      <FormControl size="small" sx={{ minWidth: 150 }}>
+        <InputLabel id="selling-history-window-label">History window</InputLabel>
+        <Select
+          labelId="selling-history-window-label"
+          label="History window"
+          value={String(report.scope.windowDays)}
+          onChange={(event) => updateScope("historyDays", event.target.value)}
+        >
+          {SELLING_HISTORY_WINDOWS.map((windowDays) => (
+            <MenuItem key={windowDays} value={String(windowDays)}>
+              Last {windowDays} days
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl size="small" sx={{ minWidth: 180 }}>
+        <InputLabel id="selling-history-product-line-label">Product line</InputLabel>
+        <Select
+          labelId="selling-history-product-line-label"
+          label="Product line"
+          value={report.scope.productLine ?? ""}
+          onChange={(event) =>
+            updateScope("historyProductLine", event.target.value)
+          }
+        >
+          <MenuItem value="">All product lines</MenuItem>
+          {report.availableProductLines.map((productLine) => (
+            <MenuItem key={productLine} value={productLine}>
+              {productLine}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Stack>
+  );
+}
+
+function Details({ report }: { report: Extract<InventorySellingHistoryReport, { status: "ready" }> }) {
+  const shown = report.details.length;
+  const total = report.detailTotal;
+  return (
+    <Box component="details" sx={{ mt: 2, maxWidth: "100%" }}>
+      <Box component="summary" sx={{ cursor: "pointer", typography: "body2", color: "text.secondary" }}>
+        Inspect publication lots and allocated orders ({shown === total ? `all ${quantity(shown)}` : `showing ${quantity(shown)} of ${quantity(total)}`})
+      </Box>
+      <TableContainer sx={{ mt: 1, overflowX: "auto" }}>
+        <Table size="small" aria-label="Publication lot and order details">
+          <TableHead>
+            <TableRow>
+              <TableCell>Lot</TableCell>
+              <TableCell align="right">Published</TableCell>
+              <TableCell align="right">Sold / removed / remaining</TableCell>
+              <TableCell>Orders and forecast baseline</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {report.details.map((detail) => (
+              <TableRow key={detail.episodeKey}>
+                <TableCell>
+                  <Typography variant="body2">{detail.productName}</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {detail.productLine} · SKU {detail.sku} · receipt {detail.receiptId} · {statusLabel(detail.kind)}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  <Typography variant="body2">{detail.listedAt ? date(detail.listedAt) : "Unknown"}</Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    {detail.remainingAgeDays === null ? "Remaining age unavailable" : `Remaining age ${days(detail.remainingAgeDays)}`}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  {unitLabel(detail.soldQuantity)} / {unitLabel(detail.removedQuantity)} / {unitLabel(detail.ledgerRemainingQuantity)}
+                  {detail.presenceUncertain && <Typography variant="caption" color="warning.main" component="div">Remaining presence uncertain</Typography>}
+                </TableCell>
+                <TableCell>
+                  <Typography variant="caption" component="div">
+                    Forecast baseline: {detail.forecastEvidenceProvenance}
+                    {detail.forecastEvidence?.pricingModelVersion ? ` · model ${detail.forecastEvidence.pricingModelVersion}` : ""}
+                    {detail.forecastEvidence?.estimatedTimeToSellDays !== undefined && detail.forecastEvidence.estimatedTimeToSellDays !== null ? ` · recorded estimate ${detail.forecastEvidence.estimatedTimeToSellDays.toFixed(1)} days` : ""}
+                  </Typography>
+                  {detail.orders.length ? detail.orders.map((order) => (
+                    <Typography key={`${order.orderNumber}:${order.soldAt}`} variant="caption" color="text.secondary" component="div">
+                      Order {order.orderNumber}: {unitLabel(order.quantity)} sold {date(order.soldAt)}{order.listedDays === null ? " · listed time unavailable" : ` · ${days(order.listedDays)} listed`}
+                    </Typography>
+                  )) : <Typography variant="caption" color="text.secondary">No allocated sale orders in this lot.</Typography>}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}
+
+function DetailPageControl({ page, pageCount }: { page: number; pageCount: number }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  return (
+    <Stack direction="row" justifyContent="center" sx={{ mt: 1.5 }}>
+      <Pagination
+        count={pageCount}
+        page={page}
+        size="small"
+        onChange={(_, nextPage) => {
+          const nextSearchParams = new URLSearchParams(searchParams);
+          nextSearchParams.set("historyPage", String(nextPage));
+          setSearchParams(nextSearchParams);
+        }}
+      />
+    </Stack>
+  );
+}
+
+/** Observed listing exposure and sales outcomes for the current seller. */
+export function InventorySellingHistory({ report }: { report: InventorySellingHistoryReport }) {
+  if (report.status === "unavailable") {
+    return (
+      <Paper variant="outlined" sx={{ p: 2, mb: 3 }}>
+        <Typography variant="h6">Selling history</Typography>
+        <ScopeControls report={report} />
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          Selling history is unavailable: {statusLabel(report.reason)}.
+        </Typography>
+        <Chip size="small" variant="outlined" sx={{ mt: 1 }} label={`Order history: ${statusLabel(report.orderCoverage.status)}`} />
+      </Paper>
+    );
+  }
+
+  const noEvidence = report.overall.cohortQuantity === 0;
+  return (
+    <Paper variant="outlined" sx={{ p: 2, mb: 3 }}>
+      <Stack direction="row" spacing={1} alignItems="center" useFlexGap flexWrap="wrap">
+        <Typography variant="h6">Selling history</Typography>
+        <Chip size="small" color="success" variant="outlined" label="Observed listing exposure" />
+      </Stack>
+      <ScopeControls report={report} />
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+        Analysis from {date(report.analysisFrom)} · As of {date(report.asOf)}. Time listed is separate from intake-to-sale age.
+      </Typography>
+      {noEvidence ? (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+          No published listing cohorts are available in this analysis window yet.
+        </Typography>
+      ) : (
+        <>
+          <Box sx={{ mt: 2 }}><Summary summary={report.overall} /></Box>
+          <SellThrough summary={report.overall} />
+          <ProductLines report={report} />
+          <Details report={report} />
+          {report.detailPageCount > 1 && (
+            <DetailPageControl
+              page={report.detailPage}
+              pageCount={report.detailPageCount}
+            />
+          )}
+        </>
+      )}
+      <Coverage report={report} />
+    </Paper>
+  );
+}

--- a/app/features/inventory-strategy/routes/inventory-strategy.tsx
+++ b/app/features/inventory-strategy/routes/inventory-strategy.tsx
@@ -1,11 +1,13 @@
-import { Alert, Box, Button, Stack, Typography } from "@mui/material";
+import { Alert, Box, Button, LinearProgress, Stack, Typography } from "@mui/material";
 import { useEffect, useMemo, useState } from "react";
 import {
   data,
   useFetcher,
   useLoaderData,
+  useNavigation,
   useRevalidator,
   type ActionFunctionArgs,
+  type LoaderFunctionArgs,
   type MetaFunction,
 } from "react-router";
 import {
@@ -18,14 +20,21 @@ import type { CapitalCycleEconomics } from "~/features/pricing/domain/capitalCyc
 import { DEFAULT_CAPITAL_CYCLE_INPUTS } from "../components/capitalCycleInputs";
 import { ForecastGrading } from "../components/ForecastGrading";
 import { HorizonCurve } from "../components/HorizonCurve";
+import { InventorySellingHistory } from "../components/InventorySellingHistory";
 import { HurdleSweep } from "../components/HurdleSweep";
 import { PercentileExplorer } from "../components/PercentileExplorer";
 import { PolicyComparison } from "../components/PolicyComparison";
 import { StrategyVerdict } from "../components/StrategyVerdict";
 import { loadForecastGrading } from "../services/forecastGrading.server";
 import { loadInventoryStrategyDashboard } from "../services/inventoryStrategyDashboard.server";
+import { loadInventorySellingHistory } from "../services/inventorySellingHistory.server";
 import { queueInventoryStrategyAnalysis } from "../services/inventoryStrategyAnalysis.server";
 import { DEFAULT_FORECAST_GRADING_HORIZON_DAYS } from "../types/inventoryStrategy";
+import {
+  DEFAULT_SELLING_HISTORY_SCOPE,
+  SELLING_HISTORY_WINDOWS,
+  type SellingHistoryScope,
+} from "../types/inventorySellingHistory";
 
 type ActionData =
   | { success: true; message: string }
@@ -40,13 +49,33 @@ export const meta: MetaFunction = () => [
   },
 ];
 
-export async function loader() {
+export async function loader({ request }: LoaderFunctionArgs) {
+  const searchParams = new URL(request.url).searchParams;
+  const requestedHistoryPage = Number.parseInt(
+    searchParams.get("historyPage") ?? "1",
+    10,
+  );
+  const historyPage = Number.isInteger(requestedHistoryPage)
+    ? Math.max(1, requestedHistoryPage)
+    : 1;
+  const requestedWindowDays = Number.parseInt(
+    searchParams.get("historyDays") ?? "",
+    10,
+  );
+  const historyScope: SellingHistoryScope = {
+    windowDays: SELLING_HISTORY_WINDOWS.includes(
+      requestedWindowDays as SellingHistoryScope["windowDays"],
+    )
+      ? (requestedWindowDays as SellingHistoryScope["windowDays"])
+      : DEFAULT_SELLING_HISTORY_SCOPE.windowDays,
+    productLine: searchParams.get("historyProductLine")?.trim() || null,
+  };
   const [publicationConfiguration, pricingConfig] = await Promise.all([
     inventoryPublicationSettingsRepository.get(),
     pricingConfigRepository.get(),
   ]);
   const settings = publicationConfiguration.settings.continuousPricing;
-  const [dashboard, recentBatches, forecastGrading] = await Promise.all([
+  const [dashboard, recentBatches, forecastGrading, sellingHistoryResult] = await Promise.all([
     loadInventoryStrategyDashboard(settings.sellerKey, pricingConfig),
     settings.sellerKey
       ? inventoryBatchesRepository.findRecent({
@@ -55,12 +84,30 @@ export async function loader() {
         })
       : [],
     loadForecastGrading(settings.sellerKey),
+    loadInventorySellingHistory(settings.sellerKey, {
+      detailPage: historyPage,
+      scope: historyScope,
+    })
+      .then((report) => ({ report, error: null }))
+      .catch((error) => {
+        console.error("Inventory selling history load failed", error);
+        return {
+          report: null,
+          error: "Selling history could not be loaded. Existing strategy analysis is still available.",
+        };
+      }),
   ]);
   const latestAnalysis =
     recentBatches.find((batch) => batch.sourceLabel === settings.sellerKey) ??
     null;
 
-  return data({ settings, dashboard, latestAnalysis, forecastGrading });
+  return data({
+    settings,
+    dashboard,
+    latestAnalysis,
+    forecastGrading,
+    sellingHistoryResult,
+  });
 }
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -109,8 +156,15 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function InventoryStrategyRoute() {
-  const { settings, dashboard, latestAnalysis, forecastGrading } =
+  const {
+    settings,
+    dashboard,
+    latestAnalysis,
+    forecastGrading,
+    sellingHistoryResult,
+  } =
     useLoaderData<typeof loader>();
+  const navigation = useNavigation();
   const fetcher = useFetcher<ActionData>();
   const analysisFetcher = useFetcher<{
     batchNumber?: number;
@@ -242,6 +296,16 @@ export default function InventoryStrategyRoute() {
           ) ?? forecastGrading[0]
         }
       />
+      {navigation.state === "loading" ? (
+        <LinearProgress aria-label="Loading selling history" sx={{ mb: 1 }} />
+      ) : null}
+      {sellingHistoryResult.error ? (
+        <Alert severity="error" sx={{ mb: 3 }}>
+          {sellingHistoryResult.error}
+        </Alert>
+      ) : sellingHistoryResult.report ? (
+        <InventorySellingHistory report={sellingHistoryResult.report} />
+      ) : null}
       <ForecastGrading
         reports={forecastGrading}
         policyMethod={dashboard.policy.method}

--- a/app/features/inventory-strategy/services/inventorySellingHistory.server.test.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.server.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import type { SellingHistorySourceEvidence } from "../types/inventorySellingHistory";
+import { loadInventorySellingHistory } from "./inventorySellingHistory.server";
+
+const calls: string[] = [];
+const source = {
+  backfillSupportedForecastEvidence: async (sellerKey: string, limit = 0) => {
+    calls.push(`backfill:${sellerKey}:${limit}`);
+    return 0;
+  },
+  findEvidence: async (sellerKey: string, scope: SellingHistorySourceEvidence["scope"]): Promise<SellingHistorySourceEvidence> => {
+    calls.push(`find:${sellerKey}`);
+    return {
+      sellerKey,
+      scope,
+      availableProductLines: [],
+      analysisFrom: "2024-09-08T00:00:00.000Z",
+      inventoryObservedAt: "2026-09-08T00:00:00.000Z",
+      orderCoverage: {
+        sellerKey,
+        source: "tcgplayer_api",
+        status: "complete",
+        completedAt: "2026-09-08T00:00:00.000Z",
+        ordersObserved: 0,
+        detailsRecorded: 0,
+        gaps: [],
+      },
+      episodes: [],
+      episodeCount: 0,
+      outcomes: [],
+      outcomeCount: 0,
+      projection: { pendingQuantity: 0, heldQuantity: 0, affectedSkus: [] },
+      openingUnknownQuantity: 0,
+      legacyUnlinked: { quantity: 0, forecastQuantity: 0 },
+      olderPublicationQuantity: 0,
+      awaitingCutoffQuantity: 0,
+      unresolvedRemoval: { quantity: 0, affectedSkus: [] },
+    };
+  },
+};
+
+const report = await loadInventorySellingHistory(" seller ", { detailPage: 2 }, source);
+assert.equal(report.status, "ready");
+if (report.status === "ready") assert.equal(report.detailPage, 1);
+assert.deepEqual(calls, ["backfill:seller:500", "find:seller"]);
+
+calls.length = 0;
+const missingSeller = await loadInventorySellingHistory("", {}, source);
+assert.equal(missingSeller.status, "unavailable");
+assert.deepEqual(calls, []);
+
+console.log("PASS inventory selling history loads bounded evidence for one seller");

--- a/app/features/inventory-strategy/services/inventorySellingHistory.server.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.server.ts
@@ -1,0 +1,68 @@
+import {
+  inventoryPublicationsRepository,
+  inventorySellingHistoryRepository,
+} from "~/core/db";
+import type { SellerOrderCoverage } from "~/features/seller-order-history/types/sellerOrderHistory";
+import type {
+  InventorySellingHistoryReport,
+  SellingHistoryScope,
+  SellingHistorySourceEvidence,
+} from "../types/inventorySellingHistory";
+import { DEFAULT_SELLING_HISTORY_SCOPE } from "../types/inventorySellingHistory";
+import { buildInventorySellingHistoryReport } from "./inventorySellingHistory";
+
+export interface InventorySellingHistorySource {
+  backfillSupportedForecastEvidence(
+    sellerKey: string,
+    limit?: number,
+  ): Promise<number>;
+  findEvidence(
+    sellerKey: string,
+    scope: SellingHistoryScope,
+  ): Promise<SellingHistorySourceEvidence>;
+}
+
+const source: InventorySellingHistorySource = {
+  backfillSupportedForecastEvidence: (sellerKey, limit) =>
+    inventoryPublicationsRepository.backfillSupportedForecastEvidence(
+      sellerKey,
+      limit,
+    ),
+  findEvidence: (sellerKey, scope) =>
+    inventorySellingHistoryRepository.findEvidence(sellerKey, scope),
+};
+
+const noCoverage = (sellerKey: string): SellerOrderCoverage => ({
+  sellerKey,
+  source: "tcgplayer_api",
+  status: "not_started",
+  ordersObserved: 0,
+  detailsRecorded: 0,
+  gaps: [],
+});
+
+export async function loadInventorySellingHistory(
+  sellerKey: string,
+  options: { detailPage?: number; scope?: SellingHistoryScope } = {},
+  dataSource: InventorySellingHistorySource = source,
+): Promise<InventorySellingHistoryReport> {
+  const seller = sellerKey.trim();
+  if (!seller) {
+    return {
+      status: "unavailable",
+      sellerKey: "",
+      scope: options.scope ?? DEFAULT_SELLING_HISTORY_SCOPE,
+      availableProductLines: [],
+      reason: "seller_not_configured",
+      orderCoverage: noCoverage(""),
+    };
+  }
+  await dataSource.backfillSupportedForecastEvidence(seller, 500);
+  return buildInventorySellingHistoryReport(
+    await dataSource.findEvidence(
+      seller,
+      options.scope ?? DEFAULT_SELLING_HISTORY_SCOPE,
+    ),
+    options.detailPage ?? 1,
+  );
+}

--- a/app/features/inventory-strategy/services/inventorySellingHistory.test.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.test.ts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+import type { SellingHistorySourceEvidence } from "../types/inventorySellingHistory";
+import { buildInventorySellingHistoryReport } from "./inventorySellingHistory";
+
+const day = (index: number) =>
+  new Date(Date.UTC(2026, 0, 1 + index)).toISOString();
+
+function evidence(
+  overrides: Partial<SellingHistorySourceEvidence> = {},
+): SellingHistorySourceEvidence {
+  return {
+    sellerKey: "seller",
+    scope: { windowDays: 180, productLine: null },
+    availableProductLines: ["Magic", "Pokemon"],
+    analysisFrom: day(-700),
+    inventoryObservedAt: day(30),
+    orderCoverage: {
+      sellerKey: "seller",
+      source: "tcgplayer_api",
+      status: "complete",
+      completedAt: day(30),
+      ordersObserved: 3,
+      detailsRecorded: 3,
+      gaps: [],
+    },
+    episodes: [],
+    episodeCount: 0,
+    outcomes: [],
+    outcomeCount: 0,
+    projection: { pendingQuantity: 0, heldQuantity: 0, affectedSkus: [] },
+    openingUnknownQuantity: 7,
+    legacyUnlinked: { quantity: 0, forecastQuantity: 0 },
+    olderPublicationQuantity: 0,
+    awaitingCutoffQuantity: 0,
+    unresolvedRemoval: { quantity: 0, affectedSkus: [] },
+    ...overrides,
+  };
+}
+
+const episodes = [
+  {
+    episodeKey: "receipt:1",
+    receiptId: 1,
+    sku: 101,
+    productLine: "Pokemon",
+    productName: "First",
+    kind: "confirmed_publication" as const,
+    quantity: 3,
+    listedAt: day(0),
+    forecastEvidence: null,
+    forecastEvidenceProvenance: "unknown" as const,
+  },
+  {
+    episodeKey: "receipt:2",
+    receiptId: 2,
+    sku: 101,
+    productLine: "Pokemon",
+    productName: "First",
+    kind: "confirmed_publication" as const,
+    quantity: 2,
+    listedAt: day(4),
+    forecastEvidence: null,
+    forecastEvidenceProvenance: "unknown" as const,
+  },
+  {
+    episodeKey: "receipt:3",
+    receiptId: 3,
+    sku: 202,
+    productLine: "Magic",
+    productName: "Mature",
+    kind: "confirmed_publication" as const,
+    quantity: 10,
+    listedAt: day(0),
+    forecastEvidence: null,
+    forecastEvidenceProvenance: "unknown" as const,
+  },
+  {
+    episodeKey: "receipt:4",
+    receiptId: 4,
+    sku: 303,
+    productLine: "Magic",
+    productName: "Young",
+    kind: "confirmed_publication" as const,
+    quantity: 10,
+    listedAt: day(25),
+    forecastEvidence: null,
+    forecastEvidenceProvenance: "unknown" as const,
+  },
+];
+const outcomes = [
+  { episodeKey: "receipt:1", kind: "sale" as const, quantity: 3, happenedAt: day(5), orderNumber: "A", orderLineId: "1", source: "seller_order" as const },
+  { episodeKey: "receipt:2", kind: "sale" as const, quantity: 1, happenedAt: day(5), orderNumber: "A", orderLineId: "1", source: "seller_order" as const },
+  { episodeKey: "receipt:3", kind: "sale" as const, quantity: 2, happenedAt: day(10), orderNumber: "B", orderLineId: "2", source: "seller_order" as const },
+];
+
+const report = buildInventorySellingHistoryReport(
+  evidence({ episodes, episodeCount: episodes.length, outcomes, outcomeCount: outcomes.length }),
+);
+assert.equal(report.status, "ready");
+if (report.status === "ready") {
+  const pokemon = report.productLines.find((row) => row.productLine === "Pokemon")!;
+  assert.equal(pokemon.soldWithKnownListedDateQuantity, 4);
+  assert.equal(pokemon.soldOnlyAverageDays, 4);
+  assert.equal(pokemon.remainingWithKnownAgeQuantity, 1);
+  const magic30 = report.productLines
+    .find((row) => row.productLine === "Magic")!
+    .sellThrough.find((row) => row.days === 30)!;
+  assert.deepEqual(magic30, {
+    days: 30,
+    eligibleQuantity: 10,
+    soldQuantity: 2,
+    rate: 0.2,
+    status: "exact",
+  });
+  assert.equal(report.overall.medianDaysToSale, null);
+  assert.equal(report.overall.p90DaysToSale, null);
+  assert.equal(report.coverage.openingUnknownQuantity, 7);
+}
+
+const unsettled = buildInventorySellingHistoryReport(
+  evidence({
+    episodes: [episodes[2]],
+    episodeCount: 1,
+    projection: { pendingQuantity: 2, heldQuantity: 0, affectedSkus: [202] },
+  }),
+);
+assert.equal(unsettled.status, "ready");
+if (unsettled.status === "ready") {
+  assert.equal(unsettled.overall.medianDaysToSale, null);
+  assert.equal(unsettled.overall.percentileStatus, "unsettled_outcomes");
+  assert.deepEqual(
+    unsettled.overall.sellThrough.find((row) => row.days === 30),
+    {
+      days: 30,
+      eligibleQuantity: 10,
+      soldQuantity: 0,
+      rate: null,
+      status: "unsettled_outcomes",
+    },
+  );
+}
+
+const removed = buildInventorySellingHistoryReport(
+  evidence({
+    episodes: [episodes[2]],
+    episodeCount: 1,
+    outcomes: [{
+      episodeKey: "receipt:3",
+      kind: "removed",
+      quantity: 1,
+      happenedAt: day(15),
+      orderNumber: "C",
+      orderLineId: "3",
+      source: "cancellation",
+    }],
+    outcomeCount: 1,
+  }),
+);
+assert.equal(removed.status, "ready");
+if (removed.status === "ready") {
+  assert.equal(removed.overall.percentileStatus, "competing_removals");
+  assert.equal(removed.overall.medianDaysToSale, null);
+  assert.equal(
+    removed.overall.sellThrough.find((row) => row.days === 30)?.eligibleQuantity,
+    10,
+  );
+}
+
+const futurePublication = buildInventorySellingHistoryReport(
+  evidence({
+    episodes: [{ ...episodes[2], listedAt: day(31) }],
+    episodeCount: 1,
+    awaitingCutoffQuantity: 10,
+  }),
+);
+assert.equal(futurePublication.status, "ready");
+if (futurePublication.status === "ready") {
+  assert.equal(futurePublication.overall.cohortQuantity, 0);
+  assert.equal(futurePublication.coverage.awaitingCutoffQuantity, 10);
+}
+
+const overBound = buildInventorySellingHistoryReport(
+  evidence({
+    scope: { windowDays: 730, productLine: null },
+    episodeCount: 20_001,
+  }),
+);
+assert.equal(overBound.status, "unavailable");
+if (overBound.status === "unavailable") {
+  assert.equal(overBound.reason, "history_bounds_exceeded");
+  assert.deepEqual(overBound.scope, { windowDays: 730, productLine: null });
+  assert.deepEqual(overBound.availableProductLines, ["Magic", "Pokemon"]);
+}
+const narrowed = buildInventorySellingHistoryReport(
+  evidence({ scope: { windowDays: 180, productLine: "Magic" } }),
+);
+assert.equal(narrowed.status, "ready");
+
+const returned = buildInventorySellingHistoryReport(
+  evidence({
+    episodes: [
+      episodes[0],
+      {
+        ...episodes[1],
+        episodeKey: "restock:1:receipt:1",
+        kind: "physical_restock",
+        quantity: 1,
+        listedAt: null,
+      },
+    ],
+    episodeCount: 2,
+    outcomes: [
+      {
+        ...outcomes[0],
+        quantity: 1,
+        kind: "removed",
+        source: "cancellation",
+      },
+    ],
+    outcomeCount: 1,
+  }),
+);
+assert.equal(returned.status, "ready");
+if (returned.status === "ready") {
+  assert.equal(returned.overall.unknownListedDateQuantity, 1);
+  assert.equal(returned.overall.percentileStatus, "competing_removals");
+  assert.equal(returned.overall.medianDaysToSale, null);
+}
+
+assert.equal(
+  buildInventorySellingHistoryReport(
+    evidence({ orderCoverage: { ...evidence().orderCoverage, status: "incomplete" } }),
+  ).status,
+  "unavailable",
+);
+assert.equal(
+  buildInventorySellingHistoryReport(evidence({ episodeCount: 1 })).status,
+  "unavailable",
+);
+
+console.log("PASS inventory selling history preserves cohorts, censoring, and coverage");

--- a/app/features/inventory-strategy/services/inventorySellingHistory.test.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.test.ts
@@ -166,6 +166,43 @@ if (removed.status === "ready") {
   );
 }
 
+const majoritySoldOutcomes = [{
+  episodeKey: "receipt:3",
+  kind: "sale" as const,
+  quantity: 6,
+  happenedAt: day(10),
+  orderNumber: "D",
+  orderLineId: "4",
+  source: "seller_order" as const,
+}];
+const fullyObserved = buildInventorySellingHistoryReport(
+  evidence({
+    episodes: [episodes[2]],
+    episodeCount: 1,
+    outcomes: majoritySoldOutcomes,
+    outcomeCount: 1,
+  }),
+);
+assert.equal(fullyObserved.status, "ready");
+if (fullyObserved.status === "ready") {
+  assert.equal(fullyObserved.overall.medianDaysToSale, 10);
+  assert.equal(fullyObserved.overall.percentileStatus, "estimable");
+}
+const stalePresence = buildInventorySellingHistoryReport(
+  evidence({
+    inventoryObservedAt: day(5),
+    episodes: [episodes[2]],
+    episodeCount: 1,
+    outcomes: majoritySoldOutcomes,
+    outcomeCount: 1,
+  }),
+);
+assert.equal(stalePresence.status, "ready");
+if (stalePresence.status === "ready") {
+  assert.equal(stalePresence.overall.medianDaysToSale, null);
+  assert.equal(stalePresence.overall.percentileStatus, "uncertain_presence");
+}
+
 const futurePublication = buildInventorySellingHistoryReport(
   evidence({
     episodes: [{ ...episodes[2], listedAt: day(31) }],

--- a/app/features/inventory-strategy/services/inventorySellingHistory.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.ts
@@ -1,0 +1,360 @@
+import {
+  SELL_THROUGH_HORIZONS,
+  type InventorySellingHistoryReport,
+  type SellingHistoryEpisodeDetail,
+  type SellingHistoryEpisodeEvidence,
+  type SellingHistoryOutcomeEvidence,
+  type SellingHistoryProductLine,
+  type SellingHistorySourceEvidence,
+  type SellingHistorySummary,
+} from "../types/inventorySellingHistory";
+
+const DAY_MS = 86_400_000;
+const DETAIL_LIMIT = 50;
+
+type PreparedEpisode = SellingHistoryEpisodeEvidence & {
+  listedTime: number | null;
+  outcomes: SellingHistoryOutcomeEvidence[];
+};
+
+function daysBetween(start: number, end: number): number {
+  return Math.max(0, (end - start) / DAY_MS);
+}
+
+function reachedPercentile(
+  observations: Array<{ days: number; quantity: number; sold: boolean }>,
+  targetSurvival: number,
+): number | null {
+  let atRisk = observations.reduce((sum, row) => sum + row.quantity, 0);
+  let survival = 1;
+  const sorted = [...observations].sort((left, right) => left.days - right.days);
+  for (let index = 0; index < sorted.length; ) {
+    const days = sorted[index].days;
+    const rows: typeof sorted = [];
+    while (index < sorted.length && sorted[index].days === days) {
+      rows.push(sorted[index]);
+      index += 1;
+    }
+    const sold = rows
+      .filter((row) => row.sold)
+      .reduce((sum, row) => sum + row.quantity, 0);
+    if (sold > 0 && atRisk > 0) survival *= 1 - sold / atRisk;
+    if (survival <= targetSurvival) return days;
+    atRisk -= rows.reduce((sum, row) => sum + row.quantity, 0);
+  }
+  return null;
+}
+
+function prepareEpisodes(
+  episodes: SellingHistoryEpisodeEvidence[],
+  outcomes: SellingHistoryOutcomeEvidence[],
+  asOfTime: number,
+): PreparedEpisode[] {
+  const outcomesByEpisode = new Map<string, SellingHistoryOutcomeEvidence[]>();
+  for (const outcome of outcomes) {
+    if (Date.parse(outcome.happenedAt) > asOfTime) continue;
+    const rows = outcomesByEpisode.get(outcome.episodeKey) ?? [];
+    rows.push(outcome);
+    outcomesByEpisode.set(outcome.episodeKey, rows);
+  }
+  return episodes
+    .filter(
+      (episode) =>
+        episode.listedAt === null || Date.parse(episode.listedAt) <= asOfTime,
+    )
+    .map((episode) => {
+    const episodeOutcomes = outcomesByEpisode.get(episode.episodeKey) ?? [];
+    const used = episodeOutcomes.reduce((sum, row) => sum + row.quantity, 0);
+    if (used > episode.quantity) {
+      throw new Error(
+        "Selling history episode " + episode.episodeKey + " uses more units than its cohort.",
+      );
+    }
+    return {
+      ...episode,
+      listedTime: episode.listedAt ? Date.parse(episode.listedAt) : null,
+      outcomes: episodeOutcomes,
+    };
+    });
+}
+
+function summarize(
+  episodes: PreparedEpisode[],
+  asOfTime: number,
+  uncertainSkus: Set<number>,
+  unsettledSkus: Set<number>,
+  hasUnresolvedRemoval: boolean,
+): SellingHistorySummary {
+  const cohortQuantity = episodes.reduce((sum, row) => sum + row.quantity, 0);
+  const known = episodes.filter((row) => row.listedTime !== null);
+  const knownListedDateQuantity = known.reduce(
+    (sum, row) => sum + row.quantity,
+    0,
+  );
+  const sales = episodes.flatMap((episode) =>
+    episode.outcomes
+      .filter((outcome) => outcome.kind === "sale")
+      .map((outcome) => ({ episode, outcome })),
+  );
+  const knownSales = sales.filter(({ episode }) => episode.listedTime !== null);
+  const removedQuantity = episodes.reduce(
+    (sum, episode) =>
+      sum +
+      episode.outcomes
+        .filter((outcome) => outcome.kind === "removed")
+        .reduce((subtotal, outcome) => subtotal + outcome.quantity, 0),
+    0,
+  );
+  const remaining = episodes.map((episode) => ({
+    episode,
+    quantity:
+      episode.quantity -
+      episode.outcomes.reduce((sum, outcome) => sum + outcome.quantity, 0),
+  }));
+  const knownRemaining = remaining.filter(
+    ({ episode, quantity }) => episode.listedTime !== null && quantity > 0,
+  );
+  const remainingWithUncertainPresenceQuantity = knownRemaining
+    .filter(({ episode }) => uncertainSkus.has(episode.sku))
+    .reduce((sum, row) => sum + row.quantity, 0);
+  const remainingWithKnownAgeQuantity = knownRemaining
+    .filter(({ episode }) => !uncertainSkus.has(episode.sku))
+    .reduce((sum, row) => sum + row.quantity, 0);
+  const soldDays = knownSales.map(({ episode, outcome }) => ({
+    days: daysBetween(episode.listedTime!, Date.parse(outcome.happenedAt)),
+    quantity: outcome.quantity,
+  }));
+  const soldWithKnownListedDateQuantity = soldDays.reduce(
+    (sum, row) => sum + row.quantity,
+    0,
+  );
+  const soldOnlyAverageDays = soldWithKnownListedDateQuantity
+    ? soldDays.reduce((sum, row) => sum + row.days * row.quantity, 0) /
+      soldWithKnownListedDateQuantity
+    : null;
+  const competingRemovals = removedQuantity > 0 || hasUnresolvedRemoval;
+  const unsettledOutcomes = known.some((episode) => unsettledSkus.has(episode.sku));
+  const percentileUnavailable = competingRemovals || unsettledOutcomes;
+  const survivalObservations = percentileUnavailable
+    ? []
+    : [
+        ...soldDays.map((row) => ({ ...row, sold: true })),
+        ...knownRemaining.map(({ episode, quantity }) => ({
+          days: daysBetween(episode.listedTime!, asOfTime),
+          quantity,
+          sold: false,
+        })),
+      ];
+  const medianDaysToSale = percentileUnavailable
+    ? null
+    : reachedPercentile(survivalObservations, 0.5);
+  const p90DaysToSale = percentileUnavailable
+    ? null
+    : reachedPercentile(survivalObservations, 0.1);
+
+  return {
+    cohortQuantity,
+    knownListedDateQuantity,
+    unknownListedDateQuantity: cohortQuantity - knownListedDateQuantity,
+    soldQuantity: sales.reduce((sum, row) => sum + row.outcome.quantity, 0),
+    soldWithKnownListedDateQuantity,
+    remainingWithKnownAgeQuantity,
+    remainingWithUncertainPresenceQuantity,
+    removedQuantity,
+    soldOnlyAverageDays,
+    medianDaysToSale,
+    p90DaysToSale,
+    percentileStatus: unsettledOutcomes
+      ? "unsettled_outcomes"
+      : competingRemovals
+      ? "competing_removals"
+      : medianDaysToSale !== null || p90DaysToSale !== null
+        ? "estimable"
+        : "not_reached",
+    sellThrough: SELL_THROUGH_HORIZONS.map((days) => {
+      const eligible = known.filter(
+        (episode) => daysBetween(episode.listedTime!, asOfTime) >= days,
+      );
+      const eligibleQuantity = eligible.reduce(
+        (sum, episode) => sum + episode.quantity,
+        0,
+      );
+      const soldQuantity = eligible.reduce(
+        (sum, episode) =>
+          sum +
+          episode.outcomes
+            .filter(
+              (outcome) =>
+                outcome.kind === "sale" &&
+                daysBetween(
+                  episode.listedTime!,
+                  Date.parse(outcome.happenedAt),
+                ) <= days,
+            )
+            .reduce((subtotal, outcome) => subtotal + outcome.quantity, 0),
+        0,
+      );
+      const unsettled = eligible.some((episode) => unsettledSkus.has(episode.sku));
+      return {
+        days,
+        eligibleQuantity,
+        soldQuantity,
+        rate: eligibleQuantity && !unsettled ? soldQuantity / eligibleQuantity : null,
+        status: unsettled ? "unsettled_outcomes" : "exact",
+      };
+    }),
+  };
+}
+
+function episodeDetail(
+  episode: PreparedEpisode,
+  asOfTime: number,
+  uncertainSkus: Set<number>,
+): SellingHistoryEpisodeDetail {
+  const sold = episode.outcomes.filter((row) => row.kind === "sale");
+  const removed = episode.outcomes.filter((row) => row.kind === "removed");
+  const used = episode.outcomes.reduce((sum, row) => sum + row.quantity, 0);
+  const ledgerRemainingQuantity = episode.quantity - used;
+  return {
+    episodeKey: episode.episodeKey,
+    receiptId: episode.receiptId,
+    sku: episode.sku,
+    productLine: episode.productLine,
+    productName: episode.productName,
+    kind: episode.kind,
+    quantity: episode.quantity,
+    listedAt: episode.listedAt,
+    soldQuantity: sold.reduce((sum, row) => sum + row.quantity, 0),
+    removedQuantity: removed.reduce((sum, row) => sum + row.quantity, 0),
+    ledgerRemainingQuantity,
+    remainingAgeDays:
+      ledgerRemainingQuantity > 0 && episode.listedTime !== null
+        ? daysBetween(episode.listedTime, asOfTime)
+        : null,
+    presenceUncertain: uncertainSkus.has(episode.sku),
+    forecastEvidenceProvenance: episode.forecastEvidenceProvenance,
+    forecastEvidence: episode.forecastEvidence,
+    orders: sold
+      .filter((row) => row.orderNumber)
+      .map((row) => ({
+        orderNumber: row.orderNumber!,
+        quantity: row.quantity,
+        soldAt: row.happenedAt,
+        listedDays:
+          episode.listedTime === null
+            ? null
+            : daysBetween(episode.listedTime, Date.parse(row.happenedAt)),
+      })),
+  };
+}
+
+export function buildInventorySellingHistoryReport(
+  evidence: SellingHistorySourceEvidence,
+  detailPage = 1,
+): InventorySellingHistoryReport {
+  const unavailable = (
+    reason: Extract<
+      InventorySellingHistoryReport,
+      { status: "unavailable" }
+    >["reason"],
+  ): InventorySellingHistoryReport => ({
+    status: "unavailable",
+    sellerKey: evidence.sellerKey,
+    scope: evidence.scope,
+    availableProductLines: evidence.availableProductLines,
+    reason,
+    orderCoverage: evidence.orderCoverage,
+  });
+  if (evidence.orderCoverage.sellerKey !== evidence.sellerKey)
+    return unavailable("seller_not_configured");
+  if (
+    evidence.orderCoverage.status !== "complete" ||
+    evidence.orderCoverage.gaps.length > 0 ||
+    !evidence.orderCoverage.completedAt
+  )
+    return unavailable("order_coverage_incomplete");
+  if (
+    evidence.episodeCount > evidence.episodes.length ||
+    evidence.outcomeCount > evidence.outcomes.length
+  )
+    return unavailable("history_bounds_exceeded");
+
+  const asOfTime = Date.parse(evidence.orderCoverage.completedAt);
+  const prepared = prepareEpisodes(evidence.episodes, evidence.outcomes, asOfTime);
+  const observedAt = evidence.inventoryObservedAt
+    ? Date.parse(evidence.inventoryObservedAt)
+    : null;
+  const uncertainSkus = new Set([
+    ...evidence.projection.affectedSkus,
+    ...evidence.unresolvedRemoval.affectedSkus,
+    ...(observedAt === null || observedAt < asOfTime
+      ? prepared.map((episode) => episode.sku)
+      : []),
+  ]);
+  const grouped = new Map<string, PreparedEpisode[]>();
+  for (const episode of prepared) {
+    const productLineEpisodes = grouped.get(episode.productLine);
+    if (productLineEpisodes) productLineEpisodes.push(episode);
+    else grouped.set(episode.productLine, [episode]);
+  }
+  const productLines: SellingHistoryProductLine[] = [...grouped.entries()]
+    .map(([productLine, rows]) => ({
+      productLine,
+      ...summarize(
+        rows,
+        asOfTime,
+        uncertainSkus,
+        new Set(rows.filter((row) => evidence.projection.affectedSkus.includes(row.sku)).map((row) => row.sku)),
+        evidence.unresolvedRemoval.affectedSkus.some((sku) =>
+          rows.some((row) => row.sku === sku),
+        ),
+      ),
+    }))
+    .sort((left, right) => right.cohortQuantity - left.cohortQuantity);
+  const details = prepared
+    .map((episode) => episodeDetail(episode, asOfTime, uncertainSkus))
+    .sort((left, right) => {
+      if (left.listedAt === null) return 1;
+      if (right.listedAt === null) return -1;
+      return right.listedAt.localeCompare(left.listedAt);
+    });
+  const detailPageCount = Math.max(1, Math.ceil(details.length / DETAIL_LIMIT));
+  const selectedDetailPage = Math.min(
+    detailPageCount,
+    Math.max(1, Math.trunc(detailPage)),
+  );
+  const detailOffset = (selectedDetailPage - 1) * DETAIL_LIMIT;
+
+  return {
+    status: "ready",
+    sellerKey: evidence.sellerKey,
+    scope: evidence.scope,
+    availableProductLines: evidence.availableProductLines,
+    analysisFrom: evidence.analysisFrom,
+    asOf: new Date(asOfTime).toISOString(),
+    orderCoverage: evidence.orderCoverage,
+    overall: summarize(
+      prepared,
+      asOfTime,
+      uncertainSkus,
+      new Set(evidence.projection.affectedSkus),
+      evidence.unresolvedRemoval.quantity > 0,
+    ),
+    productLines,
+    details: details.slice(detailOffset, detailOffset + DETAIL_LIMIT),
+    detailTotal: details.length,
+    detailPage: selectedDetailPage,
+    detailPageCount,
+    coverage: {
+      pendingProjectionQuantity: evidence.projection.pendingQuantity,
+      heldProjectionQuantity: evidence.projection.heldQuantity,
+      unresolvedRemovalQuantity: evidence.unresolvedRemoval.quantity,
+      affectedRemovalSkus: evidence.unresolvedRemoval.affectedSkus.length,
+      openingUnknownQuantity: evidence.openingUnknownQuantity,
+      legacyUnlinkedQuantity: evidence.legacyUnlinked.quantity,
+      legacyUnlinkedForecastQuantity: evidence.legacyUnlinked.forecastQuantity,
+      olderPublicationQuantity: evidence.olderPublicationQuantity,
+      awaitingCutoffQuantity: evidence.awaitingCutoffQuantity,
+    },
+  };
+}

--- a/app/features/inventory-strategy/services/inventorySellingHistory.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.ts
@@ -134,7 +134,11 @@ function summarize(
     : null;
   const competingRemovals = removedQuantity > 0 || hasUnresolvedRemoval;
   const unsettledOutcomes = known.some((episode) => unsettledSkus.has(episode.sku));
-  const percentileUnavailable = competingRemovals || unsettledOutcomes;
+  const uncertainPresence = knownRemaining.some(({ episode }) =>
+    uncertainSkus.has(episode.sku),
+  );
+  const percentileUnavailable =
+    competingRemovals || unsettledOutcomes || uncertainPresence;
   const survivalObservations = percentileUnavailable
     ? []
     : [
@@ -166,6 +170,8 @@ function summarize(
     p90DaysToSale,
     percentileStatus: unsettledOutcomes
       ? "unsettled_outcomes"
+      : uncertainPresence
+        ? "uncertain_presence"
       : competingRemovals
       ? "competing_removals"
       : medianDaysToSale !== null || p90DaysToSale !== null

--- a/app/features/inventory-strategy/types/inventorySellingHistory.ts
+++ b/app/features/inventory-strategy/types/inventorySellingHistory.ts
@@ -96,7 +96,8 @@ export interface SellingHistorySummary {
     | "estimable"
     | "not_reached"
     | "competing_removals"
-    | "unsettled_outcomes";
+    | "unsettled_outcomes"
+    | "uncertain_presence";
   sellThrough: SellThroughHorizon[];
 }
 

--- a/app/features/inventory-strategy/types/inventorySellingHistory.ts
+++ b/app/features/inventory-strategy/types/inventorySellingHistory.ts
@@ -1,0 +1,169 @@
+import type { InventoryPublicationForecastEvidence } from "~/features/inventory-publication/types/inventoryPublication";
+import type { SellerOrderCoverage } from "~/features/seller-order-history/types/sellerOrderHistory";
+
+export const SELL_THROUGH_HORIZONS = [7, 30, 60, 90] as const;
+export const SELLING_HISTORY_WINDOWS = [90, 180, 365, 730] as const;
+
+export interface SellingHistoryScope {
+  windowDays: (typeof SELLING_HISTORY_WINDOWS)[number];
+  productLine: string | null;
+}
+
+export const DEFAULT_SELLING_HISTORY_SCOPE: SellingHistoryScope = {
+  windowDays: 180,
+  productLine: null,
+};
+
+export type SellingHistoryEpisodeKind =
+  | "confirmed_publication"
+  | "opening_balance"
+  | "physical_restock"
+  | "order_quantity_correction";
+
+export interface SellingHistoryEpisodeEvidence {
+  episodeKey: string;
+  receiptId: number;
+  sku: number;
+  productLine: string;
+  productName: string;
+  kind: SellingHistoryEpisodeKind;
+  quantity: number;
+  listedAt: string | null;
+  forecastEvidence: InventoryPublicationForecastEvidence | null;
+  forecastEvidenceProvenance: "recorded" | "estimated" | "unknown";
+}
+
+export interface SellingHistoryOutcomeEvidence {
+  episodeKey: string;
+  kind: "sale" | "removed";
+  quantity: number;
+  happenedAt: string;
+  orderNumber: string | null;
+  orderLineId: string | null;
+  source: "seller_order" | "cancellation" | "quantity_correction";
+}
+
+export interface SellingHistorySourceEvidence {
+  sellerKey: string;
+  scope: SellingHistoryScope;
+  availableProductLines: string[];
+  analysisFrom: string;
+  inventoryObservedAt: string | null;
+  orderCoverage: SellerOrderCoverage;
+  episodes: SellingHistoryEpisodeEvidence[];
+  episodeCount: number;
+  outcomes: SellingHistoryOutcomeEvidence[];
+  outcomeCount: number;
+  projection: {
+    pendingQuantity: number;
+    heldQuantity: number;
+    affectedSkus: number[];
+  };
+  openingUnknownQuantity: number;
+  legacyUnlinked: {
+    quantity: number;
+    forecastQuantity: number;
+  };
+  olderPublicationQuantity: number;
+  awaitingCutoffQuantity: number;
+  unresolvedRemoval: {
+    quantity: number;
+    affectedSkus: number[];
+  };
+}
+
+export interface SellThroughHorizon {
+  days: number;
+  eligibleQuantity: number;
+  soldQuantity: number;
+  rate: number | null;
+  status: "exact" | "unsettled_outcomes";
+}
+
+export interface SellingHistorySummary {
+  cohortQuantity: number;
+  knownListedDateQuantity: number;
+  unknownListedDateQuantity: number;
+  soldQuantity: number;
+  soldWithKnownListedDateQuantity: number;
+  remainingWithKnownAgeQuantity: number;
+  remainingWithUncertainPresenceQuantity: number;
+  removedQuantity: number;
+  soldOnlyAverageDays: number | null;
+  medianDaysToSale: number | null;
+  p90DaysToSale: number | null;
+  percentileStatus:
+    | "estimable"
+    | "not_reached"
+    | "competing_removals"
+    | "unsettled_outcomes";
+  sellThrough: SellThroughHorizon[];
+}
+
+export interface SellingHistoryProductLine extends SellingHistorySummary {
+  productLine: string;
+}
+
+export interface SellingHistoryEpisodeDetail {
+  episodeKey: string;
+  receiptId: number;
+  sku: number;
+  productLine: string;
+  productName: string;
+  kind: SellingHistoryEpisodeKind;
+  quantity: number;
+  listedAt: string | null;
+  soldQuantity: number;
+  removedQuantity: number;
+  ledgerRemainingQuantity: number;
+  remainingAgeDays: number | null;
+  presenceUncertain: boolean;
+  forecastEvidenceProvenance: "recorded" | "estimated" | "unknown";
+  forecastEvidence: InventoryPublicationForecastEvidence | null;
+  orders: Array<{
+    orderNumber: string;
+    quantity: number;
+    soldAt: string;
+    listedDays: number | null;
+  }>;
+}
+
+export type InventorySellingHistoryReport =
+  | {
+      status: "unavailable";
+      sellerKey: string;
+      scope: SellingHistoryScope;
+      availableProductLines: string[];
+      reason:
+        | "seller_not_configured"
+        | "inventory_coverage_missing"
+        | "order_coverage_incomplete"
+        | "history_bounds_exceeded";
+      orderCoverage: SellerOrderCoverage;
+    }
+  | {
+      status: "ready";
+      sellerKey: string;
+      scope: SellingHistoryScope;
+      availableProductLines: string[];
+      asOf: string;
+      analysisFrom: string;
+      orderCoverage: SellerOrderCoverage;
+      overall: SellingHistorySummary;
+      productLines: SellingHistoryProductLine[];
+      details: SellingHistoryEpisodeDetail[];
+      detailTotal: number;
+      detailPage: number;
+      detailPageCount: number;
+      coverage: {
+        pendingProjectionQuantity: number;
+        heldProjectionQuantity: number;
+        unresolvedRemovalQuantity: number;
+        affectedRemovalSkus: number;
+        openingUnknownQuantity: number;
+        legacyUnlinkedQuantity: number;
+        legacyUnlinkedForecastQuantity: number;
+        olderPublicationQuantity: number;
+        awaitingCutoffQuantity: number;
+      };
+    };

--- a/app/features/pending-inventory/components/inventoryPublicationRunSummary.test.ts
+++ b/app/features/pending-inventory/components/inventoryPublicationRunSummary.test.ts
@@ -31,6 +31,8 @@ function createItem(
     desiredAbsoluteQuantity: null,
     pricedAt: NOW,
     eligibilityReasons: [],
+    forecastEvidence: null,
+    forecastEvidenceProvenance: "unknown",
     status,
     errorCode: null,
     errorMessage: null,

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -21,6 +21,9 @@ import "../features/inventory-publication/services/inventoryPublicationPolicy.te
 import "../features/continuous-pricing/services/continuousPricingSettings.test";
 import "../features/continuous-pricing/services/continuousMarketPrices.server.test";
 import "../features/inventory-strategy/services/inventoryStrategy.test";
+import "../features/inventory-strategy/services/inventorySellingHistory.test";
+import "../features/inventory-strategy/services/inventorySellingHistory.server.test";
+import "../features/inventory-strategy/components/InventorySellingHistory.test";
 import "../features/inventory-strategy/services/inventoryStrategyDashboard.server.test";
 import "../features/inventory-strategy/services/versionedCache.test";
 import "../features/inventory-strategy/components/verdict.test";

--- a/db/migrations/040_add_inventory_selling_history.sql
+++ b/db/migrations/040_add_inventory_selling_history.sql
@@ -1,0 +1,13 @@
+ALTER TABLE inventory_publication_items
+  ADD COLUMN forecast_evidence JSONB,
+  ADD COLUMN forecast_evidence_provenance TEXT NOT NULL DEFAULT 'unknown'
+    CHECK (forecast_evidence_provenance IN ('recorded', 'estimated', 'unknown')),
+  ADD CONSTRAINT inventory_publication_items_forecast_evidence_shape CHECK (
+    (forecast_evidence IS NULL AND forecast_evidence_provenance = 'unknown')
+    OR
+    (jsonb_typeof(forecast_evidence) = 'object'
+      AND forecast_evidence_provenance IN ('recorded', 'estimated'))
+  );
+
+CREATE INDEX inventory_fifo_revision_allocations_supply_idx
+  ON inventory_fifo_revision_allocations (supply_key, revision_id);

--- a/db/migrations/040_add_inventory_selling_history.sql
+++ b/db/migrations/040_add_inventory_selling_history.sql
@@ -11,3 +11,7 @@ ALTER TABLE inventory_publication_items
 
 CREATE INDEX inventory_fifo_revision_allocations_supply_idx
   ON inventory_fifo_revision_allocations (supply_key, revision_id);
+
+CREATE INDEX inventory_publication_items_forecast_backfill_idx
+  ON inventory_publication_items (publication_id, id)
+  WHERE status = 'published' AND quantity_delta > 0 AND forecast_evidence IS NULL;

--- a/docs/inventory-selling-history.md
+++ b/docs/inventory-selling-history.md
@@ -1,0 +1,72 @@
+# Inventory selling history
+
+Inventory Strategy measures marketplace exposure from the shared inventory
+history. It does not infer listing time from receipt intake, opening-balance
+cutoffs, price changes, or the current pricing model.
+
+## Cohorts and outcomes
+
+A cohort is the quantity on one receipt lot when its first successful
+marketplace publication is confirmed. Partial batch success produces separate
+cohorts only where the publication producer already has separate receipt lots
+and publication items. A retry or repricing operation cannot change the saved
+publication time or forecast evidence.
+
+Current FIFO revision allocations supply sale outcomes. A sale that spans two
+publication lots retains the quantity and listed duration from each lot.
+Canceled orders are removals, not sales. Physical restocks and order quantity
+corrections restore FIFO eligibility, but their `available_at` value is not
+marketplace publication evidence; those quantities have an unknown listed date
+until a later publication is explicitly confirmed. Opening inventory is also
+date-unknown.
+
+The report defaults to a rolling 180-day publication window. The user can
+select 90, 365, or 730 days and can narrow the report to one product line.
+Aggregate calculations read at most 20,000 cohorts and 40,000 outcomes within
+that selected scope; if either bound is reached, the report preserves the scope
+controls and asks the user to narrow instead of silently calculating from a
+partial population. Confirmed quantity before the selected window remains
+visible in coverage. Inspectable detail is paged independently at 50 cohorts
+per page.
+
+## Statistics
+
+The observation cutoff is the completion time of the latest complete,
+gap-free seller order scan. A complete order scan lets new confirmed
+publication cohorts accumulate without waiting for another full inventory
+export. Publications and returned quantities after that cutoff wait for the
+next scan and appear in coverage rather than entering the current cohort.
+Remaining quantities are labeled as ledger-expected; their
+presence is uncertain when the latest complete inventory observation is older
+than the cutoff, a FIFO projection is pending or held, or a removal is
+unresolved.
+
+Sell-through at 7, 30, 60, and 90 days includes only cohorts old enough to have
+the full horizon observed. Every unit in an eligible cohort stays in the
+denominator, including unsold and removed units. A pending or held FIFO outcome
+makes the affected horizon unavailable; it is never treated as a silent
+failure.
+
+Median and p90 days to sale use quantity-weighted Kaplan-Meier risk sets, with
+remaining units right-censored at the observation cutoff. A percentile is
+unavailable until the survival curve reaches it. Known stock removals are a
+competing outcome rather than ordinary censoring, so the report abstains from
+full-cohort percentiles whenever removals are present. The sold-only average is
+labeled for its sold population and is not presented as expected wait for all
+inventory.
+
+## Forecast evidence and coverage
+
+Forward publication planning copies only forecast, pricing policy, and model
+fields supplied by the exact pricing candidate. Receipt activation binds that
+immutable snapshot to the confirmed quantity. Historical evidence is backfilled
+in batches of at most 500 only when batch, SKU, result time, candidate key, and
+published price match an existing successful pricing result. Unsupported rows
+remain `unknown`; current prices and models are never used to reconstruct an
+old forecast.
+
+Legacy publications without receipt links remain outside selling cohorts.
+Inventory Strategy reports their quantity and the subset with preserved exact
+forecast evidence, alongside unknown opening quantity, order freshness and
+gaps, pending or held FIFO quantities, and unresolved removals. Cost and price
+coverage do not gate listed-date metrics.

--- a/docs/inventory-selling-history.md
+++ b/docs/inventory-selling-history.md
@@ -53,20 +53,27 @@ unavailable until the survival curve reaches it. Known stock removals are a
 competing outcome rather than ordinary censoring, so the report abstains from
 full-cohort percentiles whenever removals are present. The sold-only average is
 labeled for its sold population and is not presented as expected wait for all
-inventory.
+inventory. Full-cohort percentiles also remain unavailable when remaining
+quantity has no inventory-presence evidence through the report cutoff.
 
 ## Forecast evidence and coverage
 
 Forward publication planning copies only forecast, pricing policy, and model
 fields supplied by the exact pricing candidate. Receipt activation binds that
-immutable snapshot to the confirmed quantity. Historical evidence is backfilled
-in batches of at most 500 only when batch, SKU, result time, candidate key, and
-published price match an existing successful pricing result. Unsupported rows
-remain `unknown`; current prices and models are never used to reconstruct an
-old forecast.
+immutable snapshot to the confirmed quantity. Historical positive-quantity
+publication evidence is backfilled in batches of at most 500 only when batch,
+SKU, result time, candidate key, and published price match an existing
+successful pricing result. Price-only repricing rows remain unknown. Unsupported
+rows also remain `unknown`; current prices and models are never used to
+reconstruct an old forecast.
 
 Legacy publications without receipt links remain outside selling cohorts.
 Inventory Strategy reports their quantity and the subset with preserved exact
 forecast evidence, alongside unknown opening quantity, order freshness and
 gaps, pending or held FIFO quantities, and unresolved removals. Cost and price
 coverage do not gate listed-date metrics.
+
+Unresolved removal coverage reuses the shared FIFO reconciliation result. Only
+the negative residual between an observed inventory change and its expected
+publication, sale, restock, and correction flow is a removal; an explained
+inventory decrease is not reclassified by this report.


### PR DESCRIPTION
Closes #64.

Inventory Strategy now reports observed listing exposure from confirmed publication lots and the shared current FIFO allocations. It shows age-eligible 7/30/60/90-day sell-through, quantity-weighted sold intervals, right-censored median/p90 estimates, ledger-expected remaining ages, product-line summaries, and paged lot/order explanations. Opening inventory, unlinked legacy publications, pending or held FIFO projections, removals, stale presence, incomplete order scans, and dates after the scan cutoff remain explicit coverage rather than becoming optimistic outcomes.

Publication planning now preserves the supplied forecast, pricing policy, and model evidence on the immutable candidate. A seller-scoped, 500-row idempotent backfill accepts historical positive-quantity publication evidence only when batch, SKU, pricing timestamp, candidate identity, and published price match the saved successful result. Price-only rows are skipped, and a partial index keeps repeated scans bounded. Backfill preserves the original legacy request identity; repricing and activation retries cannot replace evidence, while conflicting supplied evidence is still rejected.

The report defaults to 180 days and supports 90/365/730-day and product-line scopes. Aggregate reads are capped at 20,000 cohorts and 40,000 outcomes after scope filters; if a selected scope still exceeds a cap, the controls remain available to narrow it. Lot detail pages contain 50 cohorts.

Known limitation: physical restock and order-correction `available_at` timestamps prove FIFO eligibility, not marketplace publication. Those quantities keep an unknown listed date until the publication producer records separate live evidence. The current producer can preserve partial activation times across independent receipt lots/items; it does not split one receipt into multiple activation installments.

## Validation

- `npm test` — passed full unit and render suite.
- `npm run typecheck` — passed.
- `npm run build` — passed client, SSR, and worker builds (existing MUI external-resolution warnings only).
- `TEST_DATABASE_URL=.../tcgplayer_strategy_test_author64_repair_20260908 npx tsx app/core/db/repositories/inventorySellingHistory.server.integration.test.ts` — passed exact/mismatched seller, candidate, time, price, zero-delta exclusion, legacy replay identity, conflicting evidence, FIFO residual removal, retry, limit, and repricing immutability cases.
- `TEST_DATABASE_URL=.../tcgplayer_fifo_test_author64_20260908 npx tsx app/core/db/repositories/inventoryPublicationReceipts.server.integration.test.ts` — passed independent partial publication activations, retry idempotency, failure/ambiguity, and immutable publication forecast evidence.
- Disposable PostgreSQL migration from 001 through 040 — passed.
- 20,000-cohort pure report probe — 110.52 ms on the author host after removing quadratic grouping.
- Real-backup backfill rehearsal after the partial index — 500 matches in 299 ms, 250 in 189 ms, then empty repeats in 14–17 ms; price-only history was not scanned.

## Quality Packet

### Acceptance map

| Acceptance | Executed probe |
| --- | --- |
| Sale spans two publication additions with quantity-weighted intervals; retries/repricing preserve baselines | Pure split-lot test (3 units at day 0 + 2 at day 4, 4 sold day 5 = 4.0 weighted days); publication-receipt integration retry; forecast-backfill repricing integration |
| Ten-unit cohort with two sales keeps all ten in the denominator | Pure report and disposable-DB fixture assert 2/10 = 20% at 30 days |
| Young cohorts excluded from 90-day failures; unknown dates explicit | Pure horizon tests, opening/restock unknown-date coverage, and after-cutoff exclusion test |
| Failed publication, opening stock, cancellation, restock/correction, partial sales, stale/incomplete sync | Existing publication/FIFO integration plus focused competing-removal, FIFO residual, unsettled-outcome, uncertain-presence, incomplete-coverage, and MUI-state fixtures |
| Useful without acquisition costs; no invented precision | Report has no cost dependency; sold-only average is labeled; median/p90 and rates abstain when evidence is insufficient |
| Database, report, and UI states | Two disposable-DB integrations, full suite, focused SSR component states, and production build |

### Contract dimensions

- **INTENT:** Every #64 acceptance criterion maps to an executed probe above. Overall, product-line, lot, and order views use the configured strategy seller and one scan cutoff.
- **CORRECTNESS:** The report consumes current FIFO revision allocations. Canceled quantities and only the authoritative FIFO reconciliation's unexplained negative residual are removals; fixed horizons retain all eligible cohort units, unsold units enter Kaplan-Meier risk sets, competing removals, unsettled projections, and uncertain remaining presence force abstention, and post-cutoff evidence waits for the next scan.
- **SECURITY:** No authorization, credential, secret, or external-write surface changed. Seller keys and scope inputs remain parameterized SQL; the route obtains the seller from existing server configuration and returns a generic load error.
- **SURFACES:** Migration 040 is covered by clean migration and DB tests; publication candidate fields by publication tests; repository/report fields by pure and integration tests; Inventory Strategy loading/empty/error/unavailable/success/scope/detail states by route behavior, SSR tests, and build.
- **SIMPLICITY:** Footprint is the requested vertical slice: one additive migration, narrow publication capture/backfill, one bounded history repository, pure statistics, one server loader, one MUI card, route integration, tests, and one contract document. `InventorySellingHistorySource` has production and test implementations; the report component is used by the route and SSR fixtures; the forecast snapshot helper is used by planning and direct tests. No allocator, order ledger, accounting module, cache, job, or infrastructure was added.
- **DEPTH:** The route receives one report union. Repository joins, evidence classification, censoring, horizon eligibility, scope bounds, and paging stay behind the server/pure module interfaces.
- **RELIABILITY:** Missing seller, incomplete/gapped scans, cap exhaustion, pending/held replay, competing removals, stale presence, post-cutoff activity, and loader failure all have conservative states. Backfill is seller-scoped, bounded, idempotent across historical enrichment, restricted to positive additions, and only fills null evidence.
- **PERFORMANCE:** Episode/outcome SQL applies seller, cutoff, window, and product-line filters before 20k/40k limits. Supporting seller/live, FIFO supply, and pending positive-publication backfill indexes are used; detail is 50/page. Pure calculation is O(n log n) and measured at 110.52 ms for 20k cohorts; real-backup backfill exhausted 750 supported rows in 488 ms and repeated empty checks in 14–17 ms.
- **EXPERIENCE:** Existing MUI hierarchy and strategy actions remain intact. The new concise card covers navigation loading, independent load error, unavailable, empty, success, coverage chips, responsive tables, scope controls, and paged expandable detail.
- **LANGUAGE:** Public names follow #64's domain contract: confirmed publication, time listed, sell-through, remaining age, opening quantity, removal, FIFO projection, order coverage, and forecast evidence. The repository has no mandatory glossary; issue prose is the owning contract.

### User quality dimensions

- **Correctness:** Cohorts, dates, sellers, cutoffs, quantities, and evidence provenance remain independently auditable.
- **Performance:** Scoped bounded SQL, indexed joins, bounded backfill/detail, and the 20k measurement prevent avoidable growth costs.
- **Simplicity:** The implementation composes the receipt/publication/order/FIFO foundation and adds no parallel history system.
- **Elegance:** One report model drives overall, product-line, coverage, and detail states; pure calculations stay separate from persistence.
- **Design:** MUI controls and coverage language let the user understand both the result and its evidence limits.
- **Footprint:** Changes stay in inventory strategy, narrow publication persistence, one additive migration, route integration, focused tests, and documentation.

