### PR TITLE
Recover historical publication selling estimates

### DIFF
--- a/app/core/db/repositories/inventoryHistoricalPublications.server.integration.test.ts
+++ b/app/core/db/repositories/inventoryHistoricalPublications.server.integration.test.ts
@@ -70,8 +70,9 @@ async function createPublication(input: {
   productLine: string;
   confirmedAt?: Date | null;
   parentStatus?: string;
+  key?: string;
 }) {
-  const identity = `${input.seller}:${input.sku}:${input.productLine}`;
+  const identity = `${input.seller}:${input.sku}:${input.productLine}:${input.key ?? "only"}`;
   const batch = await queryOne<{ batchNumber: number }>(
     `INSERT INTO inventory_batches (status,source_type,source_label,created_at)
     VALUES ('priced','pending_inventory',$1,$2) RETURNING batch_number AS "batchNumber"`,
@@ -98,11 +99,12 @@ async function createPublication(input: {
   const confirmedAt = input.confirmedAt === undefined
     ? new Date("2026-08-21T00:01:00.000Z")
     : input.confirmedAt;
-  await execute(
+  const item = await queryOne<{ id: string }>(
     `INSERT INTO inventory_publication_items
       (publication_id,candidate_key,inventory_delta_key,batch_number,sku,product_id,product_line,
        set_name,product_name,condition,desired_price,quantity_delta,priced_at,status,published_at,created_at)
-    VALUES ($1,$2,$3,$4,$5,$5,$6,'Set',$7,'Near Mint',1.00,$8,$9,'published',$10,$11)`,
+    VALUES ($1,$2,$3,$4,$5,$5,$6,'Set',$7,'Near Mint',1.00,$8,$9,'published',$10,$11)
+    RETURNING id::text AS id`,
     [
       publication.id, `${prefix}:candidate:${identity}`, `${prefix}:delta:${identity}`,
       batch.batchNumber, input.sku, input.productLine, `Card ${input.sku}`, input.quantity,
@@ -110,9 +112,45 @@ async function createPublication(input: {
       new Date("2026-08-20T00:00:00.000Z"),
     ],
   );
+  assert.ok(item);
+  return item.id;
 }
 
-async function createOrder(seller: string, sku: number) {
+async function linkPublication(input: {
+  seller: string;
+  sku: number;
+  publicationItemId: string;
+  quantity: number;
+  key: string;
+}) {
+  const requestId = `${prefix}:receipt:${input.seller}:${input.sku}:${input.key}`;
+  await execute(
+    `INSERT INTO inventory_pending_mutations
+      (request_id,mutation_type,sku,requested_quantity,product_line_id,set_id,product_id,
+       quantity_delta,resulting_quantity)
+    VALUES ($1,'add',$2,$3,1,1,$2,$3,$3)`,
+    [requestId, input.sku, input.quantity],
+  );
+  const receipt = await queryOne<{ id: number }>(
+    `INSERT INTO inventory_receipts
+      (request_id,sku,original_quantity,product_line_id,set_id,product_id,seller_key,intake_at,market_provenance)
+    VALUES ($1,$2,$3,1,1,$2,$4,$5,'unavailable') RETURNING receipt_id AS id`,
+    [requestId, input.sku, input.quantity, input.seller, new Date("2026-08-20T00:00:00.000Z")],
+  );
+  assert.ok(receipt);
+  await execute(
+    `INSERT INTO inventory_publication_receipt_links
+      (publication_item_id,receipt_id,planned_quantity,target_seller_key,live_at,activated_at,
+       confirmation_evidence)
+    VALUES ($1,$2,$3,$4,$5,$5,'{"source":"historical-publication-test"}'::jsonb)`,
+    [
+      input.publicationItemId, receipt.id, input.quantity, input.seller,
+      new Date("2026-08-21T00:01:00.000Z"),
+    ],
+  );
+}
+
+async function createOrder(seller: string, sku: number, quantity = 1) {
   const order = await queryOne<{ id: string }>(
     `INSERT INTO seller_orders
       (seller_key,order_number,order_time,lifecycle,provider_status,gross_item_proceeds,
@@ -126,10 +164,10 @@ async function createOrder(seller: string, sku: number) {
   await execute(
     `INSERT INTO seller_order_lines
       (order_id,sku_id,product_name,ordered_quantity,gross_item_proceeds)
-    VALUES ($1,$2,'Card',1,1.00)`,
-    [order.id, String(sku)],
+    VALUES ($1,$2,'Card',$3,1.00)`,
+    [order.id, String(sku), quantity],
   );
-  const lines = JSON.stringify([{ skuId: String(sku), quantity: 1 }]);
+  const lines = JSON.stringify([{ skuId: String(sku), quantity }]);
   await execute(
     `INSERT INTO seller_order_revisions
       (order_id,revision_number,source_fingerprint,source,observed_at,order_time,
@@ -171,6 +209,8 @@ try {
   assert.equal(source.historicalPublicationEvidence.additions.length, 4);
   assert.ok(source.historicalPublicationEvidence.additions.every((row) =>
     row.skuProductLineCount === 1));
+  assert.ok(source.historicalPublicationEvidence.additions.every((row) =>
+    row.linkedPreCutoffPublicationCount === 0));
   assert.equal(source.historicalPublicationEvidence.orderRevisionCount, 4);
   assert.deepEqual(source.availableProductLines, ["Magic", "Pokemon"]);
   const estimate = estimateHistoricalPublicationHistory(source.historicalPublicationEvidence);
@@ -227,6 +267,45 @@ try {
   const scopedEstimate = estimateHistoricalPublicationHistory(crossLineScoped.historicalPublicationEvidence);
   assert.deepEqual(scopedEstimate.cohorts[0].reasons, ["publication_identity_conflict"]);
   assert.equal(scopedEstimate.summary.reconstructedOlderQuantity, 0);
+
+  const mixedSeller = `${prefix}:mixed-source-seller`;
+  await createOpening(mixedSeller, coverage);
+  const linkedSameSku = await createPublication({
+    seller:mixedSeller, sku:9030, quantity:1, productLine:"Pokemon", key:"linked",
+  });
+  await linkPublication({
+    seller:mixedSeller, sku:9030, publicationItemId:linkedSameSku, quantity:1, key:"same-sku",
+  });
+  await createPublication({
+    seller:mixedSeller, sku:9030, quantity:1, productLine:"Pokemon", key:"unlinked",
+  });
+  const linkedOtherSku = await createPublication({
+    seller:mixedSeller, sku:9031, quantity:1, productLine:"Pokemon", key:"linked",
+  });
+  await linkPublication({
+    seller:mixedSeller, sku:9031, publicationItemId:linkedOtherSku, quantity:1, key:"other-sku",
+  });
+  await createPublication({
+    seller:mixedSeller, sku:9032, quantity:1, productLine:"Pokemon", key:"unlinked",
+  });
+  await createOrder(mixedSeller, 9030, 2);
+  await createOrder(mixedSeller, 9032);
+  const mixedSource = await inventorySellingHistoryRepository.findEvidence(
+    mixedSeller,
+    { windowDays:180, productLine:null },
+  );
+  assert.deepEqual(mixedSource.historicalPublicationEvidence.additions.map((row) => [
+    row.sku,
+    row.linkedPreCutoffPublicationCount,
+  ]), [[9030,1],[9032,0]],
+  "linked publications are excluded from legacy counts but detected for the same candidate SKU");
+  const mixedEstimate = estimateHistoricalPublicationHistory(mixedSource.historicalPublicationEvidence);
+  assert.deepEqual(mixedEstimate.cohorts.find((row) => row.sku === 9030)?.reasons,
+    ["mixed_publication_receipt_sources"]);
+  assert.equal(mixedEstimate.cohorts.find((row) => row.sku === 9032)?.attributionProvenance,
+    "estimated_closed_flow", "a receipt-linked publication for another SKU does not block the candidate");
+  assert.equal(mixedEstimate.summary.reconstructedOlderQuantity, 0,
+    "hidden linked supply is not reconstructed as older stock");
 
   console.log("PASS historical publication repository preserves scoped facts and validated opening authority");
 } finally {

--- a/app/core/db/repositories/inventoryHistoricalPublications.server.integration.test.ts
+++ b/app/core/db/repositories/inventoryHistoricalPublications.server.integration.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+
+const testDatabaseUrl = process.env.TEST_DATABASE_URL;
+if (!testDatabaseUrl) throw new Error("TEST_DATABASE_URL is required.");
+const testDatabaseName = new URL(testDatabaseUrl).pathname.replace(/^\/+/, "");
+if (!testDatabaseName.startsWith("tcgplayer_strategy_test_")) {
+  throw new Error("Historical publication tests require tcgplayer_strategy_test_*.");
+}
+process.env.DATABASE_URL = testDatabaseUrl;
+
+const { execute, getPool, queryOne } = await import("../database.server");
+const { inventorySellingHistoryRepository } = await import("./inventorySellingHistory.server");
+const { estimateHistoricalPublicationHistory } = await import(
+  "~/features/inventory-strategy/domain/historicalPublicationEstimate"
+);
+
+const prefix = `historical-publication-${Date.now()}`;
+const cutoff = new Date("2026-09-08T03:34:04.106Z");
+const validationCutoff = new Date("2026-09-08T03:39:00.000Z");
+const validationFinished = new Date("2026-09-08T03:40:00.000Z");
+
+async function createOpening(seller: string, coverage: Record<string, unknown>) {
+  const observation = await queryOne<{ id: string }>(
+    `INSERT INTO inventory_complete_observations
+      (request_id,seller_key,source,status,quantity_semantics,started_at,cutoff_at,
+       quantity_fingerprint,supported_quantity_fingerprint,first_content_fingerprint,
+       second_content_fingerprint,item_count,positive_item_count,total_quantity,
+       supported_positive_sku_count,supported_total_quantity,unsupported_positive_item_count,
+       unsupported_positive_quantity,identity_evidence)
+    VALUES ($1,$2,'seller_portal_live_export','complete','sellable_excludes_reserved',$3,$4,
+      'quantity','supported','first','second',1,1,1,1,1,0,0,'{}') RETURNING id::text AS id`,
+    [`${seller}:observation`, seller, new Date(cutoff.getTime() - 1_000), cutoff],
+  );
+  const validation = await queryOne<{ id: string }>(
+    `INSERT INTO inventory_complete_observations
+      (request_id,seller_key,source,status,quantity_semantics,started_at,cutoff_at,
+       quantity_fingerprint,supported_quantity_fingerprint,first_content_fingerprint,
+       second_content_fingerprint,item_count,positive_item_count,total_quantity,
+       supported_positive_sku_count,supported_total_quantity,unsupported_positive_item_count,
+       unsupported_positive_quantity,identity_evidence)
+    VALUES ($1,$2,'seller_portal_live_export','complete','sellable_excludes_reserved',$3,$4,
+      'quantity','supported','first','second',1,1,1,1,1,0,0,'{}') RETURNING id::text AS id`,
+    [`${seller}:validation`, seller, new Date(validationCutoff.getTime() - 1_000), validationCutoff],
+  );
+  assert.ok(observation && validation);
+  await execute(
+    `INSERT INTO inventory_complete_observation_items
+      (observation_id,inventory_key,identity_kind,sku,quantity)
+    VALUES ($1,'9001','standard_sku',9001,1),($2,'9001','standard_sku',9001,1)`,
+    [observation.id, validation.id],
+  );
+  await execute(
+    `INSERT INTO inventory_opening_balance_runs
+      (request_id,seller_key,observation_id,order_coverage_run_id,order_coverage_evidence,
+       cutoff_at,status,evidence_fingerprint,apply_request_id,validation_observation_id,
+       validation_order_coverage_evidence,applied_at)
+    VALUES ($1,$2,$3,1,$4::jsonb,$5,'applied','fingerprint',$6,$7,$8::jsonb,$9)`,
+    [
+      `${seller}:opening`, seller, observation.id, JSON.stringify(coverage), cutoff,
+      `${seller}:apply`, validation.id, JSON.stringify(coverage), validationFinished,
+    ],
+  );
+}
+
+async function createPublication(input: {
+  seller: string;
+  sku: number;
+  quantity: number;
+  batchQuantity?: number;
+  productLine: string;
+  confirmedAt?: Date | null;
+  parentStatus?: string;
+}) {
+  const batch = await queryOne<{ batchNumber: number }>(
+    `INSERT INTO inventory_batches (status,source_type,source_label,created_at)
+    VALUES ('priced','pending_inventory',$1,$2) RETURNING batch_number AS "batchNumber"`,
+    [`${prefix}:${input.sku}`, new Date("2026-08-20T00:00:00.000Z")],
+  );
+  assert.ok(batch);
+  await execute(
+    `INSERT INTO inventory_batch_items
+      (batch_number,sku,add_to_quantity,total_quantity,product_line_id,set_id,product_id,created_at,updated_at)
+    VALUES ($1,$2,$3,0,1,1,$2,$4,$4)`,
+    [batch.batchNumber, input.sku, input.batchQuantity ?? input.quantity, new Date("2026-08-20T00:00:00.000Z")],
+  );
+  const publication = await queryOne<{ id: string }>(
+    `INSERT INTO inventory_publications
+      (planning_key,batch_number,method,source_type,seller_key,status,publishing_at,created_at)
+    VALUES ($1,$2,'staged_delta','pending_inventory',$3,$4,$5,$6) RETURNING id::text AS id`,
+    [
+      `${prefix}:publication:${input.sku}`, batch.batchNumber, input.seller,
+      input.parentStatus ?? "published", new Date("2026-08-21T00:00:00.000Z"),
+      new Date("2026-08-20T00:00:00.000Z"),
+    ],
+  );
+  assert.ok(publication);
+  const confirmedAt = input.confirmedAt === undefined
+    ? new Date("2026-08-21T00:01:00.000Z")
+    : input.confirmedAt;
+  await execute(
+    `INSERT INTO inventory_publication_items
+      (publication_id,candidate_key,inventory_delta_key,batch_number,sku,product_id,product_line,
+       set_name,product_name,condition,desired_price,quantity_delta,priced_at,status,published_at,created_at)
+    VALUES ($1,$2,$3,$4,$5,$5,$6,'Set',$7,'Near Mint',1.00,$8,$9,'published',$10,$11)`,
+    [
+      publication.id, `${prefix}:candidate:${input.sku}`, `${prefix}:delta:${input.sku}`,
+      batch.batchNumber, input.sku, input.productLine, `Card ${input.sku}`, input.quantity,
+      new Date("2026-08-20T12:00:00.000Z"), confirmedAt,
+      new Date("2026-08-20T00:00:00.000Z"),
+    ],
+  );
+}
+
+async function createOrder(seller: string, sku: number) {
+  const order = await queryOne<{ id: string }>(
+    `INSERT INTO seller_orders
+      (seller_key,order_number,order_time,lifecycle,provider_status,gross_item_proceeds,
+       source_revision,source_fingerprint,first_observed_at,last_observed_at,detail_observed_at,latest_source)
+    VALUES ($1,$2,$3,'completed_paid','Completed',1.00,2,'financial-refresh',$4,$5,$5,'tcgplayer_api')
+    RETURNING id::text AS id`,
+    [seller, `${prefix}:order:${sku}`, new Date("2026-08-25T00:00:00.000Z"),
+      new Date("2026-09-08T03:35:00.000Z"), new Date("2026-09-09T00:00:00.000Z")],
+  );
+  assert.ok(order);
+  await execute(
+    `INSERT INTO seller_order_lines
+      (order_id,sku_id,product_name,ordered_quantity,gross_item_proceeds)
+    VALUES ($1,$2,'Card',1,1.00)`,
+    [order.id, String(sku)],
+  );
+  const lines = JSON.stringify([{ skuId: String(sku), quantity: 1 }]);
+  await execute(
+    `INSERT INTO seller_order_revisions
+      (order_id,revision_number,source_fingerprint,source,observed_at,order_time,
+       order_time_evidence,provider_status,lifecycle,line_evidence)
+    VALUES
+      ($1,1,'original','tcgplayer_api',$2,$3,'detail_canonical','Processing','processing',$4::jsonb),
+      ($1,2,'financial-refresh','tcgplayer_api',$5,$3,'detail_canonical','Completed','completed_paid',$4::jsonb)`,
+    [
+      order.id, new Date("2026-09-08T03:35:00.000Z"),
+      new Date("2026-08-25T00:00:00.000Z"), lines,
+      new Date("2026-09-09T00:00:00.000Z"),
+    ],
+  );
+}
+
+try {
+  const seller = `${prefix}:seller`;
+  const coverage = {
+    id: "1",
+    finishedAt: validationFinished.toISOString(),
+    ordersObserved: 2,
+    detailsRecorded: 2,
+  };
+  await createOpening(seller, coverage);
+  await createPublication({ seller, sku:9001, quantity:2, productLine:"Pokemon", parentStatus:"ambiguous" });
+  await createPublication({ seller, sku:9002, quantity:1, productLine:"Magic" });
+  await createPublication({ seller, sku:9003, quantity:1, productLine:"Magic", confirmedAt:null });
+  await createPublication({ seller, sku:9004, quantity:2, batchQuantity:1, productLine:"Pokemon" });
+  await createOrder(seller, 9001);
+  await createOrder(seller, 9002);
+
+  const source = await inventorySellingHistoryRepository.findEvidence(
+    seller,
+    { windowDays:180, productLine:null },
+  );
+  assert.equal(source.historicalPublicationEvidence.sourceAvailable, true);
+  assert.equal(source.historicalPublicationEvidence.coverageComplete, true);
+  assert.equal(source.historicalPublicationEvidence.additionCount, 4);
+  assert.equal(source.historicalPublicationEvidence.additions.length, 4);
+  assert.equal(source.historicalPublicationEvidence.orderRevisionCount, 4);
+  assert.deepEqual(source.availableProductLines, ["Magic", "Pokemon"]);
+  const estimate = estimateHistoricalPublicationHistory(source.historicalPublicationEvidence);
+  assert.equal(estimate.status, "ready");
+  assert.equal(estimate.summary.publicationQuantity, 6);
+  assert.equal(estimate.summary.confirmedAdditionQuantity, 5);
+  assert.equal(estimate.summary.estimatedAdditionQuantity, 3);
+  assert.equal(estimate.summary.estimatedSoldQuantity, 2);
+  assert.equal(estimate.summary.estimatedRemainingAtCutoff, 1);
+  assert.equal(estimate.summary.unsupportedAdditionQuantity, 3);
+  assert.equal(estimate.cohorts.find((row) => row.sku === 9002)?.estimatedRemainingAtCutoff, 0,
+    "absence from the validated complete observation is a known zero opening quantity");
+  assert.deepEqual(estimate.cohorts.find((row) => row.sku === 9003)?.reasons,
+    ["publication_evidence_invalid"]);
+  assert.deepEqual(estimate.cohorts.find((row) => row.sku === 9004)?.reasons,
+    ["publication_evidence_invalid"]);
+
+  const magic = await inventorySellingHistoryRepository.findEvidence(
+    seller,
+    { windowDays:180, productLine:"Magic" },
+  );
+  assert.deepEqual(magic.historicalPublicationEvidence.additions.map((row) => row.sku), [9002,9003]);
+
+  const invalidSeller = `${prefix}:invalid-seller`;
+  await createOpening(invalidSeller, {});
+  await createPublication({ seller:invalidSeller, sku:9010, quantity:1, productLine:"Magic" });
+  const invalid = await inventorySellingHistoryRepository.findEvidence(
+    invalidSeller,
+    { windowDays:180, productLine:null },
+  );
+  assert.equal(invalid.historicalPublicationEvidence.coverageComplete, false);
+  assert.equal(estimateHistoricalPublicationHistory(invalid.historicalPublicationEvidence).reason,
+    "order_coverage_incomplete");
+
+  console.log("PASS historical publication repository preserves scoped facts and validated opening authority");
+} finally {
+  await getPool().end();
+}

--- a/app/core/db/repositories/inventoryHistoricalPublications.server.integration.test.ts
+++ b/app/core/db/repositories/inventoryHistoricalPublications.server.integration.test.ts
@@ -71,10 +71,11 @@ async function createPublication(input: {
   confirmedAt?: Date | null;
   parentStatus?: string;
 }) {
+  const identity = `${input.seller}:${input.sku}:${input.productLine}`;
   const batch = await queryOne<{ batchNumber: number }>(
     `INSERT INTO inventory_batches (status,source_type,source_label,created_at)
     VALUES ('priced','pending_inventory',$1,$2) RETURNING batch_number AS "batchNumber"`,
-    [`${prefix}:${input.sku}`, new Date("2026-08-20T00:00:00.000Z")],
+    [`${prefix}:${identity}`, new Date("2026-08-20T00:00:00.000Z")],
   );
   assert.ok(batch);
   await execute(
@@ -88,7 +89,7 @@ async function createPublication(input: {
       (planning_key,batch_number,method,source_type,seller_key,status,publishing_at,created_at)
     VALUES ($1,$2,'staged_delta','pending_inventory',$3,$4,$5,$6) RETURNING id::text AS id`,
     [
-      `${prefix}:publication:${input.sku}`, batch.batchNumber, input.seller,
+      `${prefix}:publication:${identity}`, batch.batchNumber, input.seller,
       input.parentStatus ?? "published", new Date("2026-08-21T00:00:00.000Z"),
       new Date("2026-08-20T00:00:00.000Z"),
     ],
@@ -103,7 +104,7 @@ async function createPublication(input: {
        set_name,product_name,condition,desired_price,quantity_delta,priced_at,status,published_at,created_at)
     VALUES ($1,$2,$3,$4,$5,$5,$6,'Set',$7,'Near Mint',1.00,$8,$9,'published',$10,$11)`,
     [
-      publication.id, `${prefix}:candidate:${input.sku}`, `${prefix}:delta:${input.sku}`,
+      publication.id, `${prefix}:candidate:${identity}`, `${prefix}:delta:${identity}`,
       batch.batchNumber, input.sku, input.productLine, `Card ${input.sku}`, input.quantity,
       new Date("2026-08-20T12:00:00.000Z"), confirmedAt,
       new Date("2026-08-20T00:00:00.000Z"),
@@ -168,6 +169,8 @@ try {
   assert.equal(source.historicalPublicationEvidence.coverageComplete, true);
   assert.equal(source.historicalPublicationEvidence.additionCount, 4);
   assert.equal(source.historicalPublicationEvidence.additions.length, 4);
+  assert.ok(source.historicalPublicationEvidence.additions.every((row) =>
+    row.skuProductLineCount === 1));
   assert.equal(source.historicalPublicationEvidence.orderRevisionCount, 4);
   assert.deepEqual(source.availableProductLines, ["Magic", "Pokemon"]);
   const estimate = estimateHistoricalPublicationHistory(source.historicalPublicationEvidence);
@@ -201,6 +204,29 @@ try {
   assert.equal(invalid.historicalPublicationEvidence.coverageComplete, false);
   assert.equal(estimateHistoricalPublicationHistory(invalid.historicalPublicationEvidence).reason,
     "order_coverage_incomplete");
+
+  const crossLineSeller = `${prefix}:cross-line-seller`;
+  await createOpening(crossLineSeller, coverage);
+  await createPublication({ seller:crossLineSeller, sku:9020, quantity:1, productLine:"Pokemon" });
+  await createPublication({ seller:crossLineSeller, sku:9020, quantity:1, productLine:"Magic" });
+  const crossLineAll = await inventorySellingHistoryRepository.findEvidence(
+    crossLineSeller,
+    { windowDays:180, productLine:null },
+  );
+  assert.deepEqual(crossLineAll.historicalPublicationEvidence.additions.map((row) =>
+    row.skuProductLineCount), [2,2]);
+  assert.ok(estimateHistoricalPublicationHistory(crossLineAll.historicalPublicationEvidence)
+    .cohorts.every((row) => row.reasons.includes("publication_identity_conflict")));
+  const crossLineScoped = await inventorySellingHistoryRepository.findEvidence(
+    crossLineSeller,
+    { windowDays:180, productLine:"Pokemon" },
+  );
+  assert.equal(crossLineScoped.historicalPublicationEvidence.additions.length, 1);
+  assert.equal(crossLineScoped.historicalPublicationEvidence.additions[0].skuProductLineCount, 2,
+    "the complete seller/SKU identity check runs before product-line filtering");
+  const scopedEstimate = estimateHistoricalPublicationHistory(crossLineScoped.historicalPublicationEvidence);
+  assert.deepEqual(scopedEstimate.cohorts[0].reasons, ["publication_identity_conflict"]);
+  assert.equal(scopedEstimate.summary.reconstructedOlderQuantity, 0);
 
   console.log("PASS historical publication repository preserves scoped facts and validated opening authority");
 } finally {

--- a/app/core/db/repositories/inventorySellingHistory.server.ts
+++ b/app/core/db/repositories/inventorySellingHistory.server.ts
@@ -1,4 +1,7 @@
 import type {
+  HistoricalOrderRevisionEvidence,
+  HistoricalPublicationAdditionEvidence,
+  HistoricalPublicationEstimateEvidence,
   SellingHistoryEpisodeEvidence,
   SellingHistoryOutcomeEvidence,
   SellingHistorySourceEvidence,
@@ -30,6 +33,165 @@ const toOutcome = ({ totalCount: _totalCount, ...row }: CountedOutcome) => ({
   happenedAt: row.happenedAt.toISOString(),
 });
 
+const HISTORICAL_PUBLICATION_LIMIT = 5_000;
+const HISTORICAL_ORDER_REVISION_LIMIT = 20_000;
+// Opening application could only follow complete LastThreeMonths API scans. The
+// scan rows are retention-bounded, so the applied opening's copied attestations
+// are the durable authority. Eighty-eight days is a conservative lower bound
+// for any three-calendar-month search ending at validation completion.
+const HISTORICAL_COVERAGE_MARGIN_DAYS = 88;
+
+type OpeningHistoryAnchor = {
+  observationId: string;
+  cutoffAt: Date;
+  validationCutoffAt: Date | null;
+  observationStatus: string;
+  quantitySemantics: string;
+  orderCoverageEvidence: unknown;
+  validationOrderCoverageEvidence: unknown;
+};
+
+function coverageAttestation(value: unknown, notBefore: Date): { finishedAt: Date } | null {
+  if (!value || typeof value !== "object") return null;
+  const row = value as Record<string, unknown>;
+  const finishedAt = typeof row.finishedAt === "string" ? new Date(row.finishedAt) : null;
+  const validCount = (field: string) => Number.isSafeInteger(row[field]) && Number(row[field]) >= 0;
+  return typeof row.id === "string" && row.id.length > 0 && finishedAt &&
+    Number.isFinite(finishedAt.getTime()) && finishedAt >= notBefore &&
+    validCount("ordersObserved") && validCount("detailsRecorded")
+      ? { finishedAt }
+      : null;
+}
+
+async function historicalPublicationEvidence(
+  seller: string,
+  productLine: string | null,
+): Promise<HistoricalPublicationEstimateEvidence> {
+  const anchor = await queryOne<OpeningHistoryAnchor>(
+    `SELECT run.observation_id::text AS "observationId",run.cutoff_at AS "cutoffAt",
+      validation.cutoff_at AS "validationCutoffAt",observation.status AS "observationStatus",
+      observation.quantity_semantics AS "quantitySemantics",
+      run.order_coverage_evidence AS "orderCoverageEvidence",
+      run.validation_order_coverage_evidence AS "validationOrderCoverageEvidence"
+    FROM inventory_opening_balance_runs run
+    JOIN inventory_complete_observations observation ON observation.id=run.observation_id
+      AND observation.seller_key=run.seller_key
+    LEFT JOIN inventory_complete_observations validation ON validation.id=run.validation_observation_id
+      AND validation.seller_key=run.seller_key
+    WHERE run.seller_key=$1 AND run.status='applied'`,
+    [seller],
+  );
+  if (!anchor) return {
+    sourceAvailable:true,cutoffAt:null,coverageStartsAt:null,coverageComplete:false,validatedAt:null,
+    additions:[],additionCount:0,
+    openingQuantities:[],orderRevisions:[],orderRevisionCount:0,
+  };
+
+  const firstCoverage = coverageAttestation(anchor.orderCoverageEvidence, anchor.cutoffAt);
+  const validationCoverage = anchor.validationCutoffAt
+    ? coverageAttestation(anchor.validationOrderCoverageEvidence, anchor.validationCutoffAt)
+    : null;
+  const coverageComplete = anchor.observationStatus === "complete" &&
+    anchor.quantitySemantics === "sellable_excludes_reserved" &&
+    anchor.validationCutoffAt !== null && anchor.validationCutoffAt >= anchor.cutoffAt &&
+    firstCoverage !== null && validationCoverage !== null;
+  const coverageStartsAt = validationCoverage
+    ? new Date(validationCoverage.finishedAt.getTime() - HISTORICAL_COVERAGE_MARGIN_DAYS * 86_400_000)
+    : null;
+
+  const additionRows = await query<HistoricalPublicationAdditionEvidence & { totalCount: number }>(
+      `SELECT item.id::int AS "publicationItemId",item.sku,item.product_line AS "productLine",
+        item.product_name AS "productName",item.quantity_delta AS quantity,
+        publication.source_type AS "sourceType",publication.method,item.inventory_delta_key AS "inventoryDeltaKey",
+        batch_match.item_count AS "batchItemCount",batch_match.add_to_quantity AS "batchAddToQuantity",
+        publication.publishing_at AS "publishingAt",item.published_at AS "confirmedAt",
+        item.forecast_evidence AS "forecastEvidence",
+        item.forecast_evidence_provenance AS "forecastEvidenceProvenance",COUNT(*) OVER()::int AS "totalCount"
+      FROM inventory_publication_items item
+      JOIN inventory_publications publication ON publication.id=item.publication_id
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*)::int AS item_count,MAX(batch_item.add_to_quantity)::int AS add_to_quantity
+        FROM inventory_batch_items batch_item
+        WHERE batch_item.batch_number=item.batch_number AND batch_item.sku=item.sku
+      ) batch_match ON TRUE
+      WHERE publication.seller_key=$1 AND item.status='published' AND item.quantity_delta>0
+        AND item.created_at<$2
+        AND NOT EXISTS (SELECT 1 FROM inventory_publication_receipt_links link
+          WHERE link.publication_item_id=item.id)
+        AND ($3::text IS NULL OR item.product_line=$3)
+      ORDER BY item.published_at NULLS LAST,item.id LIMIT $4`,
+      [seller, anchor.cutoffAt, productLine, HISTORICAL_PUBLICATION_LIMIT],
+    );
+  const additionCount = additionRows[0]?.totalCount ?? 0;
+  const additions = additionRows.map(({ totalCount: _totalCount, ...row }) => ({
+    ...row,
+    publishingAt: row.publishingAt ? new Date(row.publishingAt).toISOString() : null,
+    confirmedAt: row.confirmedAt ? new Date(row.confirmedAt).toISOString() : null,
+  }));
+  const skus = [...new Set(additions.map((row) => row.sku))];
+  if (skus.length === 0) return {
+    sourceAvailable:true,cutoffAt:anchor.cutoffAt.toISOString(),coverageStartsAt:coverageStartsAt?.toISOString()??null,
+    validatedAt:validationCoverage?.finishedAt.toISOString()??null,
+    coverageComplete,additions:[],additionCount,
+    openingQuantities:[],orderRevisions:[],orderRevisionCount:0,
+  };
+
+  const [openingQuantities, orderRows] = await Promise.all([
+    query<{ sku: number; quantity: number }>(
+      `SELECT sku,quantity FROM inventory_complete_observation_items
+      WHERE observation_id=$1 AND sku=ANY($2::int[]) ORDER BY sku`,
+      [anchor.observationId, skus],
+    ),
+    query<HistoricalOrderRevisionEvidence & { totalCount: number }>(
+      `WITH relevant_orders AS (
+        SELECT DISTINCT revision.order_id
+        FROM seller_order_revisions revision
+        JOIN seller_orders orders ON orders.id=revision.order_id
+        CROSS JOIN LATERAL jsonb_array_elements(revision.line_evidence) line
+        WHERE orders.seller_key=$1 AND COALESCE(revision.order_time,orders.order_time)>=$2
+          AND COALESCE(revision.order_time,orders.order_time)<$3
+          AND (line->>'skuId')=ANY($4::text[])
+      )
+      SELECT revision.order_id::text AS "orderId",orders.order_number AS "orderNumber",
+        revision.revision_number AS "revisionNumber",revision.observed_at AS "observedAt",
+        revision.order_time AS "orderTime",
+        revision.order_time_evidence AS "orderTimeEvidence",revision.lifecycle,
+        revision.line_evidence AS lines,COUNT(*) OVER()::int AS "totalCount"
+      FROM relevant_orders relevant
+      JOIN seller_order_revisions revision ON revision.order_id=relevant.order_id
+      JOIN seller_orders orders ON orders.id=revision.order_id
+      ORDER BY revision.order_id,revision.revision_number LIMIT $5`,
+      [seller, coverageStartsAt ?? anchor.cutoffAt, anchor.cutoffAt, skus.map(String), HISTORICAL_ORDER_REVISION_LIMIT],
+    ),
+  ]);
+  const orderRevisionCount = orderRows[0]?.totalCount ?? 0;
+  return {
+    sourceAvailable:true,cutoffAt:anchor.cutoffAt.toISOString(),coverageStartsAt:coverageStartsAt?.toISOString()??null,
+    validatedAt:validationCoverage?.finishedAt.toISOString()??null,
+    coverageComplete,additions,additionCount,openingQuantities,
+    orderRevisions:orderRows.map(({totalCount:_totalCount,...row})=>({
+      ...row,observedAt:new Date(row.observedAt).toISOString(),
+      orderTime:row.orderTime?new Date(row.orderTime).toISOString():null,
+    })),orderRevisionCount,
+  };
+}
+
+async function safeHistoricalPublicationEvidence(
+  seller: string,
+  productLine: string | null,
+): Promise<HistoricalPublicationEstimateEvidence> {
+  try {
+    return await historicalPublicationEvidence(seller, productLine);
+  } catch (error) {
+    console.error("Historical publication evidence is unavailable:", error);
+    return {
+      sourceAvailable:false,cutoffAt:null,coverageStartsAt:null,coverageComplete:false,
+      validatedAt:null,additions:[],additionCount:0,openingQuantities:[],orderRevisions:[],
+      orderRevisionCount:0,
+    };
+  }
+}
+
 export const inventorySellingHistoryRepository = {
   async findEvidence(
     sellerKey: string,
@@ -56,7 +218,7 @@ export const inventorySellingHistoryRepository = {
       asOf.getTime() - scope.windowDays * 86_400_000,
     );
 
-    const [episodes, outcomes, productLineRows, projection, unresolvedRemoval] = await Promise.all([
+    const [episodes, outcomes, productLineRows, projection, unresolvedRemoval, historicalPublication] = await Promise.all([
       query<CountedEpisode>(
         `WITH all_episodes AS (
           SELECT 'receipt:'||receipt.receipt_id::text AS "episodeKey",
@@ -173,12 +335,21 @@ export const inventorySellingHistoryRepository = {
         [seller, analysisFrom, asOf, scope.productLine, INVENTORY_SELLING_HISTORY_OUTCOME_LIMIT],
       ),
       query<{ productLine: string }>(
-        `SELECT DISTINCT item.product_line AS "productLine"
-        FROM inventory_publication_receipt_links link
-        JOIN inventory_publication_items item ON item.id=link.publication_item_id
-        WHERE link.target_seller_key=$1 AND link.live_at IS NOT NULL
-          AND link.live_at >= $2 AND link.live_at <= $3
-        ORDER BY item.product_line LIMIT 100`,
+        `SELECT DISTINCT source."productLine" FROM (
+          SELECT item.product_line AS "productLine"
+          FROM inventory_publication_receipt_links link
+          JOIN inventory_publication_items item ON item.id=link.publication_item_id
+          WHERE link.target_seller_key=$1 AND link.live_at IS NOT NULL
+            AND link.live_at >= $2 AND link.live_at <= $3
+          UNION ALL
+          SELECT item.product_line
+          FROM inventory_publication_items item
+          JOIN inventory_publications publication ON publication.id=item.publication_id
+          WHERE publication.seller_key=$1 AND item.status='published' AND item.quantity_delta>0
+            AND item.created_at >= $2 AND item.created_at <= $3
+            AND NOT EXISTS (SELECT 1 FROM inventory_publication_receipt_links link
+              WHERE link.publication_item_id=item.id)
+        ) source ORDER BY source."productLine" LIMIT 100`,
         [seller, new Date(asOf.getTime() - 730 * 86_400_000), asOf],
       ),
       queryOne<{ pendingQuantity: number; heldQuantity: number; affectedSkus: number[]; openingUnknownQuantity: number; legacyUnlinkedQuantity: number; legacyUnlinkedForecastQuantity: number; olderPublicationQuantity: number; awaitingCutoffQuantity: number }>(
@@ -269,6 +440,7 @@ export const inventorySellingHistoryRepository = {
         FROM removals`,
         [seller, scope.productLine],
       ),
+      safeHistoricalPublicationEvidence(seller, scope.productLine),
     ]);
 
     return {
@@ -295,6 +467,7 @@ export const inventorySellingHistoryRepository = {
       olderPublicationQuantity: projection?.olderPublicationQuantity ?? 0,
       awaitingCutoffQuantity: projection?.awaitingCutoffQuantity ?? 0,
       unresolvedRemoval: unresolvedRemoval ?? { quantity: 0, affectedSkus: [] },
+      historicalPublicationEvidence: historicalPublication,
     };
   },
 };

--- a/app/core/db/repositories/inventorySellingHistory.server.ts
+++ b/app/core/db/repositories/inventorySellingHistory.server.ts
@@ -104,6 +104,7 @@ async function historicalPublicationEvidence(
         item.product_name AS "productName",item.quantity_delta AS quantity,
         publication.source_type AS "sourceType",publication.method,item.inventory_delta_key AS "inventoryDeltaKey",
         batch_match.item_count AS "batchItemCount",batch_match.add_to_quantity AS "batchAddToQuantity",
+        sku_identity.product_line_count AS "skuProductLineCount",
         publication.publishing_at AS "publishingAt",item.published_at AS "confirmedAt",
         item.forecast_evidence AS "forecastEvidence",
         item.forecast_evidence_provenance AS "forecastEvidenceProvenance",COUNT(*) OVER()::int AS "totalCount"
@@ -114,6 +115,17 @@ async function historicalPublicationEvidence(
         FROM inventory_batch_items batch_item
         WHERE batch_item.batch_number=item.batch_number AND batch_item.sku=item.sku
       ) batch_match ON TRUE
+      LEFT JOIN LATERAL (
+        SELECT COUNT(DISTINCT sibling.product_line)::int AS product_line_count
+        FROM inventory_publication_items sibling
+        JOIN inventory_publications sibling_publication
+          ON sibling_publication.id=sibling.publication_id
+        WHERE sibling_publication.seller_key=$1 AND sibling.sku=item.sku
+          AND sibling.status='published' AND sibling.quantity_delta>0
+          AND sibling.created_at<$2
+          AND NOT EXISTS (SELECT 1 FROM inventory_publication_receipt_links sibling_link
+            WHERE sibling_link.publication_item_id=sibling.id)
+      ) sku_identity ON TRUE
       WHERE publication.seller_key=$1 AND item.status='published' AND item.quantity_delta>0
         AND item.created_at<$2
         AND NOT EXISTS (SELECT 1 FROM inventory_publication_receipt_links link

--- a/app/core/db/repositories/inventorySellingHistory.server.ts
+++ b/app/core/db/repositories/inventorySellingHistory.server.ts
@@ -105,6 +105,7 @@ async function historicalPublicationEvidence(
         publication.source_type AS "sourceType",publication.method,item.inventory_delta_key AS "inventoryDeltaKey",
         batch_match.item_count AS "batchItemCount",batch_match.add_to_quantity AS "batchAddToQuantity",
         sku_identity.product_line_count AS "skuProductLineCount",
+        linked_history.publication_count AS "linkedPreCutoffPublicationCount",
         publication.publishing_at AS "publishingAt",item.published_at AS "confirmedAt",
         item.forecast_evidence AS "forecastEvidence",
         item.forecast_evidence_provenance AS "forecastEvidenceProvenance",COUNT(*) OVER()::int AS "totalCount"
@@ -126,6 +127,17 @@ async function historicalPublicationEvidence(
           AND NOT EXISTS (SELECT 1 FROM inventory_publication_receipt_links sibling_link
             WHERE sibling_link.publication_item_id=sibling.id)
       ) sku_identity ON TRUE
+      LEFT JOIN LATERAL (
+        SELECT COUNT(DISTINCT sibling.id)::int AS publication_count
+        FROM inventory_publication_items sibling
+        JOIN inventory_publications sibling_publication
+          ON sibling_publication.id=sibling.publication_id
+        JOIN inventory_publication_receipt_links sibling_link
+          ON sibling_link.publication_item_id=sibling.id
+        WHERE sibling_publication.seller_key=$1 AND sibling.sku=item.sku
+          AND sibling.status='published' AND sibling.quantity_delta>0
+          AND sibling.published_at<$2
+      ) linked_history ON TRUE
       WHERE publication.seller_key=$1 AND item.status='published' AND item.quantity_delta>0
         AND item.created_at<$2
         AND NOT EXISTS (SELECT 1 FROM inventory_publication_receipt_links link

--- a/app/features/inventory-strategy/components/InventorySellingHistory.test.tsx
+++ b/app/features/inventory-strategy/components/InventorySellingHistory.test.tsx
@@ -78,6 +78,46 @@ const ready: InventorySellingHistoryReport = {
     olderPublicationQuantity: 3,
     awaitingCutoffQuantity: 2,
   },
+  historicalPublicationEstimate: {
+    status: "ready",
+    cutoffAt: "2026-09-08T00:00:00.000Z",
+    summary: {
+      publicationItemCount: 1,
+      publicationQuantity: 3,
+      confirmedAdditionCount: 1,
+      confirmedAdditionQuantity: 3,
+      estimatedAdditionCount: 1,
+      estimatedAdditionQuantity: 3,
+      unsupportedAdditionCount: 0,
+      unsupportedAdditionQuantity: 0,
+      estimatedSoldQuantity: 2,
+      estimatedRemainingAtCutoff: 1,
+      reconstructedOlderQuantity: 1,
+      reconstructedOlderRemainingAtCutoff: 0,
+      supportedSkuCount: 1,
+      conflictedSkuCount: 0,
+    },
+    cohorts: [{
+      publicationItemId: 91,
+      sku: 44,
+      productLine: "Pokémon",
+      productName: "Pikachu",
+      quantity: 3,
+      publishingAt: "2026-07-31T23:59:00.000Z",
+      confirmedAt: "2026-08-01T00:00:00.000Z",
+      dateProvenance: "recorded_confirmation",
+      attributionProvenance: "estimated_closed_flow",
+      estimatedSoldQuantity: 2,
+      estimatedRemainingAtCutoff: 1,
+      reasons: [],
+      forecastEvidence: null,
+      forecastEvidenceProvenance: "unknown",
+      allocations: [{ orderId: "10", orderNumber: "1001", orderedAt: "2026-08-14T00:00:00.000Z", quantity: 2, listedDaysLowerBound: 13, listedDaysUpperBound: 13.001 }],
+    }],
+    cohortCount: 1,
+    conflicts: [],
+    conflictCount: 0,
+  },
 };
 
 function render(report: InventorySellingHistoryReport, entry = "/inventory-strategy?historyPage=2&other=kept") {
@@ -103,6 +143,11 @@ assert.match(success, /Last 180 days/);
 assert.match(success, /Pokémon/);
 assert.match(success, /older publication excluded by window/);
 assert.match(success, /awaiting cutoff/);
+assert.match(success, /Historical publication estimate/);
+assert.match(success, /Uploaded units/);
+assert.match(success, /publication item 91/);
+assert.match(success, /Estimated FIFO attribution/);
+assert.match(success, /listed at least 13\.0 days/);
 assert.doesNotMatch(success, /profit|cost basis|intake-to-sale days held/i);
 
 const openingOnly = render({
@@ -158,7 +203,7 @@ assert.match(paginated, /pagination navigation/);
 assert.match(paginated, /page 2/i);
 
 const empty = render({ ...ready, overall: { ...summary, cohortQuantity: 0 }, productLines: [], details: [], detailTotal: 0 });
-assert.match(empty, /No published listing cohorts are available/);
+assert.match(empty, /No receipt-linked publication cohorts are available/);
 
 const unavailable = render({
   status: "unavailable",
@@ -167,10 +212,29 @@ const unavailable = render({
   availableProductLines: ["Magic", "Pokémon"],
   reason: "history_bounds_exceeded",
   orderCoverage,
+  historicalPublicationEstimate: ready.historicalPublicationEstimate,
 });
 assert.match(unavailable, /Selling history is unavailable: history bounds exceeded/);
 assert.match(unavailable, /Order history: incomplete/);
 assert.match(unavailable, /History window/);
 assert.match(unavailable, /Last 730 days/);
+const unknownConfirmation = render({
+  ...ready,
+  historicalPublicationEstimate: {
+    ...ready.historicalPublicationEstimate,
+    cohorts: [{
+      ...ready.historicalPublicationEstimate.cohorts[0],
+      confirmedAt: null,
+      dateProvenance: "unknown",
+      attributionProvenance: "unsupported",
+      estimatedSoldQuantity: null,
+      estimatedRemainingAtCutoff: null,
+      reasons: ["publication_evidence_invalid"],
+      allocations: [],
+    }],
+  },
+});
+assert.match(unknownConfirmation.replace(/<[^>]*>/g, ""), /Date: unknown · assignment: unavailable/);
+assert.doesNotMatch(unknownConfirmation, /Date: recorded confirmation/);
 
 console.log("PASS inventory selling history presents available, empty, unavailable, and bounded detail states");

--- a/app/features/inventory-strategy/components/InventorySellingHistory.test.tsx
+++ b/app/features/inventory-strategy/components/InventorySellingHistory.test.tsx
@@ -218,6 +218,12 @@ assert.match(unavailable, /Selling history is unavailable: history bounds exceed
 assert.match(unavailable, /Order history: incomplete/);
 assert.match(unavailable, /History window/);
 assert.match(unavailable, /Last 730 days/);
+const missingSeller = render({
+  status:"unavailable",sellerKey:"",scope:{windowDays:180,productLine:null},
+  availableProductLines:[],reason:"seller_not_configured",
+  orderCoverage:{sellerKey:"",source:"tcgplayer_api",status:"not_started",ordersObserved:0,detailsRecorded:0,gaps:[]},
+});
+assert.doesNotMatch(missingSeller, /Historical publication estimate/);
 const unknownConfirmation = render({
   ...ready,
   historicalPublicationEstimate: {
@@ -236,5 +242,23 @@ const unknownConfirmation = render({
 });
 assert.match(unknownConfirmation.replace(/<[^>]*>/g, ""), /Date: unknown · assignment: unavailable/);
 assert.doesNotMatch(unknownConfirmation, /Date: recorded confirmation/);
+
+const conflicted = render({
+  ...ready,
+  historicalPublicationEstimate: {
+    ...ready.historicalPublicationEstimate,
+    summary: {
+      ...ready.historicalPublicationEstimate.summary,
+      unsupportedAdditionCount: 1,
+      unsupportedAdditionQuantity: 3,
+      conflictedSkuCount: 1,
+    },
+    conflicts: [{ sku:44, reasons:["order_lifecycle_unsettled"], quantityDifference:null }],
+    conflictCount: 1,
+  },
+});
+assert.match(conflicted, /1 affected SKU.*need review/);
+assert.match(conflicted, /1 Order status is uncertain/);
+assert.match(conflicted, /SKU 44/);
 
 console.log("PASS inventory selling history presents available, empty, unavailable, and bounded detail states");

--- a/app/features/inventory-strategy/components/InventorySellingHistory.tsx
+++ b/app/features/inventory-strategy/components/InventorySellingHistory.tsx
@@ -55,6 +55,7 @@ function historicalReasonLabel(value: string): string {
     source_bounds_exceeded: "Historical evidence exceeds safe limits",
     publication_evidence_invalid: "Publication evidence is incomplete",
     publication_identity_conflict: "Publication product line is inconsistent for this SKU",
+    mixed_publication_receipt_sources: "This SKU mixes linked and unlinked publication history",
     source_read_failed: "Historical evidence could not be read",
     order_history_changed: "Order quantity, SKU, or time changed",
     order_lifecycle_unsettled: "Order status is uncertain",

--- a/app/features/inventory-strategy/components/InventorySellingHistory.tsx
+++ b/app/features/inventory-strategy/components/InventorySellingHistory.tsx
@@ -54,6 +54,7 @@ function historicalReasonLabel(value: string): string {
     order_coverage_incomplete: "Order coverage is incomplete",
     source_bounds_exceeded: "Historical evidence exceeds safe limits",
     publication_evidence_invalid: "Publication evidence is incomplete",
+    publication_identity_conflict: "Publication product line is inconsistent for this SKU",
     source_read_failed: "Historical evidence could not be read",
     order_history_changed: "Order quantity, SKU, or time changed",
     order_lifecycle_unsettled: "Order status is uncertain",
@@ -204,6 +205,13 @@ function Coverage({ report }: { report: Extract<InventorySellingHistoryReport, {
 }
 
 function HistoricalPublicationHistory({ estimate }: { estimate: HistoricalPublicationEstimate }) {
+  const conflictReasonCounts = new Map<string, number>();
+  for (const conflict of estimate.conflicts) for (const reason of conflict.reasons) {
+    conflictReasonCounts.set(reason, (conflictReasonCounts.get(reason) ?? 0) + 1);
+  }
+  const conflictReasonSummary = [...conflictReasonCounts]
+    .map(([reason, count]) => `${quantity(count)} ${historicalReasonLabel(reason)}`)
+    .join(" · ");
   return (
     <Box sx={{ mt: 3 }}>
       <Stack direction="row" spacing={1} alignItems="center" useFlexGap flexWrap="wrap">
@@ -276,9 +284,14 @@ function HistoricalPublicationHistory({ estimate }: { estimate: HistoricalPublic
             </Box>
           )}
           {estimate.conflictCount > 0 && (
-            <Typography variant="caption" color="warning.main" component="div" sx={{ mt: 1 }}>
-              {quantity(estimate.conflictCount)} SKU reconciliation conflict{estimate.conflictCount === 1 ? "" : "s"}: {estimate.conflicts.map((conflict) => `SKU ${conflict.sku} (${conflict.reasons.map(historicalReasonLabel).join(", ")})`).join("; ")}{estimate.conflicts.length < estimate.conflictCount ? "; additional conflicts omitted from this bounded view" : ""}.
-            </Typography>
+            <Box component="details" sx={{ mt: 1 }}>
+              <Box component="summary" sx={{ cursor: "pointer", typography: "caption", color: "warning.main" }}>
+                {quantity(estimate.conflictCount)} affected SKU{estimate.conflictCount === 1 ? "" : "s"} need review{conflictReasonSummary ? ` · ${conflictReasonSummary}` : ""}
+              </Box>
+              <Typography variant="caption" color="warning.main" component="div" sx={{ mt: 0.5 }}>
+                {estimate.conflicts.map((conflict) => `SKU ${conflict.sku} (${conflict.reasons.map(historicalReasonLabel).join(", ")})`).join("; ")}{estimate.conflicts.length < estimate.conflictCount ? "; additional conflicts omitted from this bounded view" : ""}.
+              </Typography>
+            </Box>
           )}
         </>
       )}
@@ -455,7 +468,9 @@ export function InventorySellingHistory({ report }: { report: InventorySellingHi
           Selling history is unavailable: {statusLabel(report.reason)}.
         </Typography>
         <Chip size="small" variant="outlined" sx={{ mt: 1 }} label={`Order history: ${statusLabel(report.orderCoverage.status)}`} />
-        <HistoricalPublicationHistory estimate={report.historicalPublicationEstimate} />
+        {report.historicalPublicationEstimate && (
+          <HistoricalPublicationHistory estimate={report.historicalPublicationEstimate} />
+        )}
       </Paper>
     );
   }

--- a/app/features/inventory-strategy/components/InventorySellingHistory.tsx
+++ b/app/features/inventory-strategy/components/InventorySellingHistory.tsx
@@ -19,6 +19,7 @@ import {
 import { useSearchParams } from "react-router";
 import {
   SELLING_HISTORY_WINDOWS,
+  type HistoricalPublicationEstimate,
   type InventorySellingHistoryReport,
   type SellingHistorySummary,
 } from "../types/inventorySellingHistory";
@@ -45,6 +46,23 @@ function range(value: string | undefined): string | null {
 
 function statusLabel(value: string): string {
   return value.replaceAll("_", " ");
+}
+
+function historicalReasonLabel(value: string): string {
+  const labels: Record<string, string> = {
+    opening_coverage_missing: "Opening inventory evidence is unavailable",
+    order_coverage_incomplete: "Order coverage is incomplete",
+    source_bounds_exceeded: "Historical evidence exceeds safe limits",
+    publication_evidence_invalid: "Publication evidence is incomplete",
+    source_read_failed: "Historical evidence could not be read",
+    order_history_changed: "Order quantity, SKU, or time changed",
+    order_lifecycle_unsettled: "Order status is uncertain",
+    order_time_unknown: "Order time is unavailable",
+    event_time_tie: "Order and publication order is uncertain",
+    quantity_conflict: "Recorded quantities do not reconcile",
+    temporal_underflow: "A sale precedes enough recorded stock",
+  };
+  return labels[value] ?? statusLabel(value);
 }
 
 function Stat({
@@ -182,6 +200,89 @@ function Coverage({ report }: { report: Extract<InventorySellingHistoryReport, {
         </Typography>
       )}
     </Stack>
+  );
+}
+
+function HistoricalPublicationHistory({ estimate }: { estimate: HistoricalPublicationEstimate }) {
+  return (
+    <Box sx={{ mt: 3 }}>
+      <Stack direction="row" spacing={1} alignItems="center" useFlexGap flexWrap="wrap">
+        <Typography variant="h6">Historical publication estimate</Typography>
+        <Chip size="small" color="warning" variant="outlined" label="Estimated FIFO attribution" />
+      </Stack>
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+        Confirmed quantity-addition uploads are reconciled to seller orders and the fixed opening balance
+        {estimate.cutoffAt ? ` at ${date(estimate.cutoffAt)}` : ""}. Confirmation time records when the app received
+        Seller Portal success; the provider live instant is bounded by the publishing request and that confirmation.
+        Sale and remaining-quantity assignments assume no unrecorded inventory movement and do not change physical FIFO or current metrics.
+      </Typography>
+      {estimate.status === "no_data" ? (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 1.5 }}>
+          No historical quantity-addition publications are available before the opening cutoff.
+        </Typography>
+      ) : (
+        <>
+          <Box sx={{ mt: 1.5, display: "grid", gridTemplateColumns: { xs: "repeat(2, minmax(0, 1fr))", md: "repeat(4, minmax(0, 1fr))" }, gap: 2 }}>
+            <Stat label="Uploaded units" value={unitLabel(estimate.summary.publicationQuantity)} detail={`${quantity(estimate.summary.confirmedAdditionCount)} of ${quantity(estimate.summary.publicationItemCount)} uploads with confirmation time`} />
+            <Stat label="Estimated attribution" value={unitLabel(estimate.summary.estimatedAdditionQuantity)} detail={`${unitLabel(estimate.summary.estimatedSoldQuantity)} sold · ${unitLabel(estimate.summary.estimatedRemainingAtCutoff)} remaining at cutoff`} />
+            <Stat label="Estimated older stock" value={unitLabel(estimate.summary.reconstructedOlderQuantity)} detail={`${unitLabel(estimate.summary.reconstructedOlderRemainingAtCutoff)} remaining at cutoff`} />
+            <Stat label="Needs review" value={unitLabel(estimate.summary.unsupportedAdditionQuantity)} detail={`${quantity(estimate.summary.conflictedSkuCount)} affected SKUs`} />
+          </Box>
+          {estimate.status === "unavailable" && (
+            <Typography variant="body2" color="warning.main" sx={{ mt: 1.5 }}>
+              Historical attribution is unavailable: {historicalReasonLabel(estimate.reason ?? "source_bounds_exceeded")}. The confirmed uploads remain shown as recorded facts.
+            </Typography>
+          )}
+          {estimate.cohorts.length > 0 && (
+            <Box component="details" sx={{ mt: 1.5 }}>
+              <Box component="summary" sx={{ cursor: "pointer", typography: "body2", color: "text.secondary" }}>
+                Inspect historical publication items ({estimate.cohorts.length === estimate.cohortCount
+                  ? `all ${quantity(estimate.cohortCount)}`
+                  : `showing ${quantity(estimate.cohorts.length)} of ${quantity(estimate.cohortCount)}`})
+              </Box>
+              <TableContainer sx={{ mt: 1, overflowX: "auto" }}>
+                <Table size="small" aria-label="Historical publication estimate details">
+                  <TableHead><TableRow>
+                    <TableCell>Publication</TableCell><TableCell>Recorded confirmation</TableCell>
+                    <TableCell align="right">Quantity / estimated sold / estimated remaining</TableCell><TableCell>Evidence</TableCell>
+                  </TableRow></TableHead>
+                  <TableBody>{estimate.cohorts.map((cohort) => (
+                    <TableRow key={cohort.publicationItemId}>
+                      <TableCell>
+                        <Typography variant="body2">{cohort.productName}</Typography>
+                        <Typography variant="caption" color="text.secondary">{cohort.productLine} · SKU {cohort.sku} · publication item {cohort.publicationItemId}</Typography>
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="body2">{date(cohort.confirmedAt)}</Typography>
+                        <Typography variant="caption" color="text.secondary">provider live window {cohort.publishingAt ? `${date(cohort.publishingAt)} to ` : "ending "}{date(cohort.confirmedAt)}</Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        {unitLabel(cohort.quantity)} / {cohort.estimatedSoldQuantity === null ? "Unavailable" : unitLabel(cohort.estimatedSoldQuantity)} / {cohort.estimatedRemainingAtCutoff === null ? "Unavailable" : unitLabel(cohort.estimatedRemainingAtCutoff)}
+                      </TableCell>
+                      <TableCell>
+                        <Typography variant="caption" component="div">Date: {cohort.dateProvenance === "recorded_confirmation" ? "recorded confirmation" : "unknown"} · assignment: {cohort.attributionProvenance === "estimated_closed_flow" ? "estimated FIFO" : "unavailable"}</Typography>
+                        <Typography variant="caption" component="div">Forecast baseline: {cohort.forecastEvidenceProvenance}{cohort.forecastEvidence?.pricingModelVersion ? ` · model ${cohort.forecastEvidence.pricingModelVersion}` : ""}</Typography>
+                        {cohort.reasons.length > 0 && <Typography variant="caption" color="warning.main" component="div">Unavailable: {cohort.reasons.map(historicalReasonLabel).join("; ")}</Typography>}
+                        {cohort.allocations.map((allocation) => (
+                          <Typography key={`${allocation.orderId}:${allocation.orderedAt}`} variant="caption" color="text.secondary" component="div">
+                            Order {allocation.orderNumber}: {unitLabel(allocation.quantity)} · listed at least {days(allocation.listedDaysLowerBound)}{allocation.listedDaysUpperBound === null ? "" : ` and at most ${days(allocation.listedDaysUpperBound)}`}
+                          </Typography>
+                        ))}
+                      </TableCell>
+                    </TableRow>
+                  ))}</TableBody>
+                </Table>
+              </TableContainer>
+            </Box>
+          )}
+          {estimate.conflictCount > 0 && (
+            <Typography variant="caption" color="warning.main" component="div" sx={{ mt: 1 }}>
+              {quantity(estimate.conflictCount)} SKU reconciliation conflict{estimate.conflictCount === 1 ? "" : "s"}: {estimate.conflicts.map((conflict) => `SKU ${conflict.sku} (${conflict.reasons.map(historicalReasonLabel).join(", ")})`).join("; ")}{estimate.conflicts.length < estimate.conflictCount ? "; additional conflicts omitted from this bounded view" : ""}.
+            </Typography>
+          )}
+        </>
+      )}
+    </Box>
   );
 }
 
@@ -354,6 +455,7 @@ export function InventorySellingHistory({ report }: { report: InventorySellingHi
           Selling history is unavailable: {statusLabel(report.reason)}.
         </Typography>
         <Chip size="small" variant="outlined" sx={{ mt: 1 }} label={`Order history: ${statusLabel(report.orderCoverage.status)}`} />
+        <HistoricalPublicationHistory estimate={report.historicalPublicationEstimate} />
       </Paper>
     );
   }
@@ -371,7 +473,7 @@ export function InventorySellingHistory({ report }: { report: InventorySellingHi
       </Typography>
       {noEvidence ? (
         <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
-          No published listing cohorts are available in this analysis window yet.
+          No receipt-linked publication cohorts are available in this analysis window. Historical uploads may still appear below.
         </Typography>
       ) : (
         <>
@@ -387,6 +489,7 @@ export function InventorySellingHistory({ report }: { report: InventorySellingHi
           )}
         </>
       )}
+      <HistoricalPublicationHistory estimate={report.historicalPublicationEstimate} />
       <Coverage report={report} />
     </Paper>
   );

--- a/app/features/inventory-strategy/domain/historicalPublicationEstimate.test.ts
+++ b/app/features/inventory-strategy/domain/historicalPublicationEstimate.test.ts
@@ -26,6 +26,7 @@ function addition(
     batchItemCount: 1,
     batchAddToQuantity: quantity,
     skuProductLineCount: 1,
+    linkedPreCutoffPublicationCount: 0,
     publishingAt: new Date(Date.parse(day(confirmedDay)) - 60_000).toISOString(),
     confirmedAt: day(confirmedDay),
     forecastEvidence: null,
@@ -259,5 +260,20 @@ const crossLineScoped = estimateHistoricalPublicationHistory(evidence(
 ));
 assert.deepEqual(crossLineScoped.cohorts[0].reasons, ["publication_identity_conflict"]);
 assert.equal(crossLineScoped.summary.reconstructedOlderQuantity, 0);
+
+const mixedSources = estimateHistoricalPublicationHistory(evidence(
+  [
+    {
+      ...addition(24, 170, 1, 2),
+      linkedPreCutoffPublicationCount: 1,
+    },
+  ],
+  [],
+  [revision("24", 3, [{ skuId:"170", quantity:2 }])],
+));
+assert.deepEqual(mixedSources.cohorts[0].reasons, ["mixed_publication_receipt_sources"]);
+assert.equal(mixedSources.summary.estimatedAdditionQuantity, 0);
+assert.equal(mixedSources.summary.reconstructedOlderQuantity, 0,
+  "a hidden receipt-linked sibling cannot be reconstructed as older stock");
 
 console.log("PASS historical publication estimates preserve facts and fail closed on ambiguous lineage");

--- a/app/features/inventory-strategy/domain/historicalPublicationEstimate.test.ts
+++ b/app/features/inventory-strategy/domain/historicalPublicationEstimate.test.ts
@@ -25,6 +25,7 @@ function addition(
     inventoryDeltaKey: `batch:${publicationItemId}:${sku}`,
     batchItemCount: 1,
     batchAddToQuantity: quantity,
+    skuProductLineCount: 1,
     publishingAt: new Date(Date.parse(day(confirmedDay)) - 60_000).toISOString(),
     confirmedAt: day(confirmedDay),
     forecastEvidence: null,
@@ -221,5 +222,42 @@ const absentOpeningMeansZero = estimateHistoricalPublicationHistory(evidence(
 ));
 assert.equal(absentOpeningMeansZero.summary.estimatedAdditionQuantity, 1);
 assert.equal(absentOpeningMeansZero.cohorts[0].estimatedRemainingAtCutoff, 0);
+
+const earlyLot = addition(19, 140, 1, 2);
+const lateLot = addition(20, 140, 1, 3);
+const zOrder = revision("10", 4, [{ skuId: "140", quantity: 1 }]);
+zOrder.orderNumber = "Z-ORDER";
+const aOrder = revision("20", 4, [{ skuId: "140", quantity: 1 }]);
+aOrder.orderNumber = "A-ORDER";
+const equalTime = evidence([earlyLot, lateLot], [], [zOrder, aOrder]);
+const equalTimeEstimate = estimateHistoricalPublicationHistory(equalTime);
+assert.equal(equalTimeEstimate.cohorts[0].allocations[0].orderNumber, "A-ORDER");
+assert.deepEqual(
+  estimateHistoricalPublicationHistory(equalTime),
+  equalTimeEstimate,
+  "equal-time order replay is deterministic",
+);
+
+const publicationOrderTie = estimateHistoricalPublicationHistory(evidence(
+  [addition(21, 150, 1, 2)],
+  [],
+  [revision("21", 2, [{ skuId: "150", quantity: 1 }])],
+));
+assert.deepEqual(publicationOrderTie.conflicts[0].reasons, ["event_time_tie"]);
+
+const crossLinePokemon = { ...addition(22, 160, 1, 2), productLine:"Pokemon", skuProductLineCount:2 };
+const crossLineMagic = { ...addition(23, 160, 1, 3), productLine:"Magic", skuProductLineCount:2 };
+const crossLineAll = estimateHistoricalPublicationHistory(evidence(
+  [crossLinePokemon, crossLineMagic],
+  [],
+));
+assert.ok(crossLineAll.cohorts.every((row) =>
+  row.reasons.includes("publication_identity_conflict")));
+const crossLineScoped = estimateHistoricalPublicationHistory(evidence(
+  [crossLinePokemon],
+  [],
+));
+assert.deepEqual(crossLineScoped.cohorts[0].reasons, ["publication_identity_conflict"]);
+assert.equal(crossLineScoped.summary.reconstructedOlderQuantity, 0);
 
 console.log("PASS historical publication estimates preserve facts and fail closed on ambiguous lineage");

--- a/app/features/inventory-strategy/domain/historicalPublicationEstimate.test.ts
+++ b/app/features/inventory-strategy/domain/historicalPublicationEstimate.test.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict";
+import type {
+  HistoricalOrderRevisionEvidence,
+  HistoricalPublicationAdditionEvidence,
+  HistoricalPublicationEstimateEvidence,
+} from "../types/inventorySellingHistory";
+import { estimateHistoricalPublicationHistory } from "./historicalPublicationEstimate";
+
+const day = (value: number) => new Date(Date.UTC(2026, 0, value)).toISOString();
+
+function addition(
+  publicationItemId: number,
+  sku: number,
+  quantity: number,
+  confirmedDay: number,
+): HistoricalPublicationAdditionEvidence {
+  return {
+    publicationItemId,
+    sku,
+    productLine: "Pokemon",
+    productName: `Card ${sku}`,
+    quantity,
+    sourceType: "pending_inventory",
+    method: "staged_delta",
+    inventoryDeltaKey: `batch:${publicationItemId}:${sku}`,
+    batchItemCount: 1,
+    batchAddToQuantity: quantity,
+    publishingAt: new Date(Date.parse(day(confirmedDay)) - 60_000).toISOString(),
+    confirmedAt: day(confirmedDay),
+    forecastEvidence: null,
+    forecastEvidenceProvenance: "unknown",
+  };
+}
+
+function revision(
+  orderId: string,
+  orderDay: number,
+  lines: Array<{ skuId: string; quantity: number }>,
+  revisionNumber = 1,
+  lifecycle = "completed_paid",
+  observedDay = 19,
+): HistoricalOrderRevisionEvidence {
+  return {
+    orderId,
+    orderNumber: `ORDER-${orderId}`,
+    revisionNumber,
+    observedAt: day(observedDay),
+    orderTime: day(orderDay),
+    orderTimeEvidence: "detail_canonical",
+    lifecycle,
+    lines,
+  };
+}
+
+function evidence(
+  additions: HistoricalPublicationAdditionEvidence[],
+  openingQuantities: Array<{ sku: number; quantity: number }>,
+  orderRevisions: HistoricalOrderRevisionEvidence[] = [],
+): HistoricalPublicationEstimateEvidence {
+  return {
+    sourceAvailable: true,
+    cutoffAt: day(20),
+    coverageStartsAt: day(-60),
+    coverageComplete: true,
+    validatedAt: day(20),
+    additions,
+    additionCount: additions.length,
+    openingQuantities,
+    orderRevisions,
+    orderRevisionCount: orderRevisions.length,
+  };
+}
+
+const split = estimateHistoricalPublicationHistory(evidence(
+  [addition(1, 10, 3, 2), addition(2, 10, 2, 6)],
+  [{ sku: 10, quantity: 1 }],
+  [revision("1", 10, [{ skuId: "10", quantity: 4 }])],
+));
+assert.equal(split.status, "ready");
+assert.deepEqual(split.summary, {
+  publicationItemCount: 2,
+  publicationQuantity: 5,
+  confirmedAdditionCount: 2,
+  confirmedAdditionQuantity: 5,
+  estimatedAdditionCount: 2,
+  estimatedAdditionQuantity: 5,
+  unsupportedAdditionCount: 0,
+  unsupportedAdditionQuantity: 0,
+  estimatedSoldQuantity: 4,
+  estimatedRemainingAtCutoff: 1,
+  reconstructedOlderQuantity: 0,
+  reconstructedOlderRemainingAtCutoff: 0,
+  supportedSkuCount: 1,
+  conflictedSkuCount: 0,
+});
+assert.deepEqual(split.cohorts.map((row) => [
+  row.publicationItemId,
+  row.estimatedSoldQuantity,
+  row.estimatedRemainingAtCutoff,
+  row.attributionProvenance,
+]), [
+  [1, 3, 0, "estimated_closed_flow"],
+  [2, 1, 1, "estimated_closed_flow"],
+]);
+assert.equal(split.cohorts[1].allocations[0].listedDaysLowerBound, 4);
+assert.ok((split.cohorts[1].allocations[0].listedDaysUpperBound ?? 0) > 4);
+
+const older = estimateHistoricalPublicationHistory(evidence(
+  [addition(3, 20, 3, 2)],
+  [{ sku: 20, quantity: 5 }],
+  [revision("2", 3, [{ skuId: "20", quantity: 1 }])],
+));
+assert.equal(older.summary.reconstructedOlderQuantity, 3);
+assert.equal(older.summary.reconstructedOlderRemainingAtCutoff, 2);
+assert.equal(older.cohorts[0].estimatedSoldQuantity, 0);
+assert.equal(older.cohorts[0].estimatedRemainingAtCutoff, 3);
+
+const negative = estimateHistoricalPublicationHistory(evidence(
+  [addition(4, 30, 10, 2)],
+  [{ sku: 30, quantity: 5 }],
+  [revision("3", 3, [{ skuId: "30", quantity: 2 }])],
+));
+assert.equal(negative.cohorts[0].attributionProvenance, "unsupported");
+assert.deepEqual(negative.cohorts[0].reasons, ["quantity_conflict"]);
+assert.equal(negative.conflicts[0].quantityDifference, -3);
+
+const temporal = estimateHistoricalPublicationHistory(evidence(
+  [addition(5, 40, 2, 2), addition(6, 40, 5, 6)],
+  [{ sku: 40, quantity: 3 }],
+  [revision("4", 4, [{ skuId: "40", quantity: 4 }])],
+));
+assert.equal(temporal.summary.unsupportedAdditionQuantity, 7);
+assert.deepEqual(temporal.conflicts[0].reasons, ["temporal_underflow"]);
+
+const financialOnlyRevision = estimateHistoricalPublicationHistory(evidence(
+  [addition(7, 50, 2, 2)],
+  [{ sku: 50, quantity: 1 }],
+  [
+    revision("5", 3, [{ skuId: "50", quantity: 1 }], 1, "processing", 19),
+    revision("5", 3, [{ skuId: "50", quantity: 1 }], 2, "completed_paid", 21),
+  ],
+));
+assert.equal(financialOnlyRevision.summary.estimatedAdditionQuantity, 2);
+
+const canceled = estimateHistoricalPublicationHistory(evidence(
+  [addition(8, 60, 2, 2)],
+  [{ sku: 60, quantity: 2 }],
+  [revision("6", 3, [{ skuId: "60", quantity: 1 }], 1, "canceled")],
+));
+assert.deepEqual(canceled.conflicts[0].reasons, ["order_lifecycle_unsettled"]);
+
+const moved = estimateHistoricalPublicationHistory(evidence(
+  [addition(9, 70, 1, 2), addition(10, 71, 1, 2)],
+  [{ sku: 70, quantity: 1 }, { sku: 71, quantity: 1 }],
+  [
+    revision("7", 3, [{ skuId: "70", quantity: 1 }], 1, "completed_paid", 19),
+    revision("7", 3, [{ skuId: "71", quantity: 1 }], 2, "completed_paid", 21),
+  ],
+));
+assert.deepEqual(moved.conflicts.map((row) => [row.sku, row.reasons]), [
+  [70, ["order_history_changed"]],
+  [71, ["order_history_changed"]],
+]);
+
+const priorCanceled = estimateHistoricalPublicationHistory(evidence(
+  [addition(14, 100, 3, 5)],
+  [{ sku: 100, quantity: 3 }],
+  [revision("8", 1, [{ skuId: "100", quantity: 1 }], 1, "canceled")],
+));
+assert.equal(priorCanceled.summary.estimatedAdditionQuantity, 3);
+assert.equal(priorCanceled.cohorts[0].estimatedRemainingAtCutoff, 3);
+
+const repricing = addition(11, 80, 1, 2);
+repricing.quantity = 0;
+repricing.batchAddToQuantity = 0;
+const invalid = estimateHistoricalPublicationHistory(evidence(
+  [repricing, { ...addition(12, 81, 1, 2), batchAddToQuantity: 2 }],
+  [{ sku: 80, quantity: 0 }, { sku: 81, quantity: 1 }],
+));
+assert.equal(invalid.summary.estimatedAdditionQuantity, 0);
+assert.ok(invalid.cohorts.every((row) => row.reasons.includes("publication_evidence_invalid")));
+
+const incomplete = estimateHistoricalPublicationHistory({
+  ...evidence([addition(13, 90, 1, 2)], [{ sku: 90, quantity: 1 }]),
+  orderRevisionCount: 1,
+});
+assert.equal(incomplete.status, "unavailable");
+assert.equal(incomplete.reason, "source_bounds_exceeded");
+
+const sourceFailure = estimateHistoricalPublicationHistory({
+  ...evidence([], []),
+  sourceAvailable: false,
+});
+assert.equal(sourceFailure.status, "unavailable");
+assert.equal(sourceFailure.reason, "source_read_failed");
+
+const unconfirmedAddition = { ...addition(15, 110, 1, 2), confirmedAt: null };
+const unconfirmed = estimateHistoricalPublicationHistory(evidence(
+  [unconfirmedAddition],
+  [],
+));
+assert.equal(unconfirmed.status, "ready");
+assert.equal(unconfirmed.summary.publicationItemCount, 1);
+assert.equal(unconfirmed.summary.confirmedAdditionCount, 0);
+assert.equal(unconfirmed.cohorts[0].dateProvenance, "unknown");
+assert.deepEqual(unconfirmed.cohorts[0].reasons, ["publication_evidence_invalid"]);
+
+const duplicateA = addition(16, 120, 1, 2);
+const duplicateB = { ...addition(17, 121, 1, 2), inventoryDeltaKey: duplicateA.inventoryDeltaKey };
+const duplicateIdentity = estimateHistoricalPublicationHistory(evidence(
+  [duplicateA, duplicateB],
+  [],
+));
+assert.equal(duplicateIdentity.summary.unsupportedAdditionQuantity, 2);
+assert.ok(duplicateIdentity.cohorts.every((row) => row.reasons.includes("publication_evidence_invalid")));
+
+const absentOpeningMeansZero = estimateHistoricalPublicationHistory(evidence(
+  [addition(18, 130, 1, 2)],
+  [],
+  [revision("9", 3, [{ skuId: "130", quantity: 1 }])],
+));
+assert.equal(absentOpeningMeansZero.summary.estimatedAdditionQuantity, 1);
+assert.equal(absentOpeningMeansZero.cohorts[0].estimatedRemainingAtCutoff, 0);
+
+console.log("PASS historical publication estimates preserve facts and fail closed on ambiguous lineage");

--- a/app/features/inventory-strategy/domain/historicalPublicationEstimate.ts
+++ b/app/features/inventory-strategy/domain/historicalPublicationEstimate.ts
@@ -138,8 +138,8 @@ function orderDemands(
 
   for (const rows of demands.values()) rows.sort((left, right) =>
     left.orderedAt.localeCompare(right.orderedAt) ||
-    left.orderId.localeCompare(right.orderId) ||
-    left.orderNumber.localeCompare(right.orderNumber));
+    left.orderNumber.localeCompare(right.orderNumber) ||
+    left.orderId.localeCompare(right.orderId));
   return { demands, conflicts };
 }
 
@@ -161,6 +161,9 @@ function publicationReasons(
     confirmed < cutoffTime &&
     (publishing === null || publishing <= confirmed);
   return [
+    ...(addition.skuProductLineCount !== 1
+      ? ["publication_identity_conflict" as const]
+      : []),
     ...(!validPublication ? ["publication_evidence_invalid" as const] : []),
     ...(confirmed !== null && confirmed < coverageStartTime
       ? ["source_bounds_exceeded" as const]
@@ -327,7 +330,8 @@ export function estimateHistoricalPublicationHistory(
       (left.kind === right.kind
         ? left.kind === "addition"
           ? left.addition.publicationItemId - (right as typeof left).addition.publicationItemId
-          : left.demand.orderId.localeCompare((right as typeof left).demand.orderId)
+          : left.demand.orderNumber.localeCompare((right as typeof left).demand.orderNumber) ||
+            left.demand.orderId.localeCompare((right as typeof left).demand.orderId)
         : left.kind === "addition" ? -1 : 1));
     let olderRemaining = olderQuantity;
     let underflow = false;

--- a/app/features/inventory-strategy/domain/historicalPublicationEstimate.ts
+++ b/app/features/inventory-strategy/domain/historicalPublicationEstimate.ts
@@ -164,6 +164,9 @@ function publicationReasons(
     ...(addition.skuProductLineCount !== 1
       ? ["publication_identity_conflict" as const]
       : []),
+    ...(addition.linkedPreCutoffPublicationCount > 0
+      ? ["mixed_publication_receipt_sources" as const]
+      : []),
     ...(!validPublication ? ["publication_evidence_invalid" as const] : []),
     ...(confirmed !== null && confirmed < coverageStartTime
       ? ["source_bounds_exceeded" as const]

--- a/app/features/inventory-strategy/domain/historicalPublicationEstimate.ts
+++ b/app/features/inventory-strategy/domain/historicalPublicationEstimate.ts
@@ -1,0 +1,434 @@
+import type {
+  HistoricalOrderRevisionEvidence,
+  HistoricalPublicationAdditionEvidence,
+  HistoricalPublicationEstimate,
+  HistoricalPublicationEstimateAllocation,
+  HistoricalPublicationEstimateEvidence,
+  HistoricalPublicationEstimateReason,
+} from "../types/inventorySellingHistory";
+
+const DAY_MS = 86_400_000;
+const DETAIL_LIMIT = 50;
+const SAFE_LIFECYCLES = new Set([
+  "processing",
+  "ready_to_ship",
+  "shipped_in_transit",
+  "shipped_delivered",
+  "completed_paid",
+]);
+
+type Demand = {
+  orderId: string;
+  orderNumber: string;
+  orderedAt: string;
+  quantity: number;
+};
+
+type MutableLot = {
+  addition: HistoricalPublicationAdditionEvidence | null;
+  remaining: number;
+};
+
+const unique = <T>(values: T[]): T[] => [...new Set(values)];
+
+function validTime(value: string | null): number | null {
+  if (!value) return null;
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? time : null;
+}
+
+function linesBySku(revision: HistoricalOrderRevisionEvidence): Map<number, number> | null {
+  const result = new Map<number, number>();
+  for (const line of revision.lines) {
+    if (!/^[1-9][0-9]{0,9}$/.test(line.skuId)) continue;
+    const sku = Number(line.skuId);
+    if (!Number.isSafeInteger(sku) || sku > 2_147_483_647 ||
+        !Number.isSafeInteger(line.quantity) || line.quantity <= 0) return null;
+    result.set(sku, (result.get(sku) ?? 0) + line.quantity);
+  }
+  return result;
+}
+
+function mapsEqual(left: Map<number, number>, right: Map<number, number>): boolean {
+  return left.size === right.size && [...left].every(([key, value]) => right.get(key) === value);
+}
+
+function orderDemands(
+  revisions: HistoricalOrderRevisionEvidence[],
+  firstPublicationBySku: Map<number, number>,
+  cutoffTime: number,
+  validatedAt: string,
+): { demands: Map<number, Demand[]>; conflicts: Map<number, HistoricalPublicationEstimateReason[]> } {
+  const candidateSkus = new Set(firstPublicationBySku.keys());
+  const byOrder = new Map<string, HistoricalOrderRevisionEvidence[]>();
+  for (const revision of revisions) {
+    const rows = byOrder.get(revision.orderId) ?? [];
+    rows.push(revision);
+    byOrder.set(revision.orderId, rows);
+  }
+  const demands = new Map<number, Demand[]>();
+  const conflicts = new Map<number, HistoricalPublicationEstimateReason[]>();
+  const addConflict = (skus: Iterable<number>, reason: HistoricalPublicationEstimateReason) => {
+    for (const sku of skus) {
+      if (!candidateSkus.has(sku)) continue;
+      conflicts.set(sku, unique([...(conflicts.get(sku) ?? []), reason]));
+    }
+  };
+
+  for (const rows of byOrder.values()) {
+    rows.sort((left, right) => left.revisionNumber - right.revisionNumber);
+    const parsed = rows.map((revision) => ({ revision, lines: linesBySku(revision) }));
+    const affectedSkus = new Set(parsed.flatMap(({ lines }) =>
+      lines ? [...lines.keys()].filter((sku) => candidateSkus.has(sku)) : []));
+    if (affectedSkus.size === 0) continue;
+    const windowSkus = new Set([...affectedSkus].filter((sku) => parsed.some(({ revision, lines }) => {
+      const time = validTime(revision.orderTime);
+      return lines?.has(sku) && time !== null &&
+        time >= firstPublicationBySku.get(sku)! && time < cutoffTime;
+    })));
+    if (windowSkus.size === 0) continue;
+    if (parsed.some(({ lines }) => lines === null)) {
+      addConflict(windowSkus, "order_history_changed");
+      continue;
+    }
+    const validationTime = Date.parse(validatedAt);
+    let baselineIndex = -1;
+    for (let index = parsed.length - 1; index >= 0; index -= 1) {
+      if (Date.parse(parsed[index].revision.observedAt) <= validationTime) {
+        baselineIndex = index;
+        break;
+      }
+    }
+    if (baselineIndex < 0) {
+      addConflict(windowSkus, "order_time_unknown");
+      continue;
+    }
+    const baseline = parsed[baselineIndex];
+    const baselineTime = validTime(baseline.revision.orderTime);
+    const later = parsed.slice(baselineIndex + 1);
+    if (baselineTime === null || baseline.revision.orderTimeEvidence !== "detail_canonical") {
+      addConflict(windowSkus, "order_time_unknown");
+      continue;
+    }
+    const changed = later.some(({ revision, lines }) =>
+      validTime(revision.orderTime) !== baselineTime || !mapsEqual(baseline.lines!, lines!));
+    if (changed) {
+      // A correction can move an order across both SKU and time boundaries, so
+      // every candidate SKU in that order remains part of the conflict.
+      addConflict(affectedSkus, "order_history_changed");
+      continue;
+    }
+    if (!SAFE_LIFECYCLES.has(baseline.revision.lifecycle) ||
+        later.some(({ revision }) => !SAFE_LIFECYCLES.has(revision.lifecycle))) {
+      addConflict(windowSkus, "order_lifecycle_unsettled");
+      continue;
+    }
+    for (const [sku, quantity] of baseline.lines!) {
+      if (!candidateSkus.has(sku)) continue;
+      const skuDemands = demands.get(sku) ?? [];
+      skuDemands.push({
+        orderId: baseline.revision.orderId,
+        orderNumber: baseline.revision.orderNumber,
+        orderedAt: baseline.revision.orderTime!,
+        quantity,
+      });
+      demands.set(sku, skuDemands);
+    }
+  }
+
+  for (const rows of demands.values()) rows.sort((left, right) =>
+    left.orderedAt.localeCompare(right.orderedAt) ||
+    left.orderId.localeCompare(right.orderId) ||
+    left.orderNumber.localeCompare(right.orderNumber));
+  return { demands, conflicts };
+}
+
+function publicationReasons(
+  addition: HistoricalPublicationAdditionEvidence,
+  cutoffTime: number,
+  coverageStartTime: number,
+): HistoricalPublicationEstimateReason[] {
+  const confirmed = validTime(addition.confirmedAt);
+  const publishing = validTime(addition.publishingAt);
+  const validPublication =
+    addition.sourceType === "pending_inventory" &&
+    addition.method === "staged_delta" &&
+    addition.quantity > 0 &&
+    Boolean(addition.inventoryDeltaKey) &&
+    addition.batchItemCount === 1 &&
+    addition.batchAddToQuantity === addition.quantity &&
+    confirmed !== null &&
+    confirmed < cutoffTime &&
+    (publishing === null || publishing <= confirmed);
+  return [
+    ...(!validPublication ? ["publication_evidence_invalid" as const] : []),
+    ...(confirmed !== null && confirmed < coverageStartTime
+      ? ["source_bounds_exceeded" as const]
+      : []),
+  ];
+}
+
+function emptySummary(additions: HistoricalPublicationAdditionEvidence[]) {
+  const confirmed = additions.filter((row) => validTime(row.confirmedAt) !== null);
+  return {
+    publicationItemCount: additions.length,
+    publicationQuantity: additions.reduce((sum, row) => sum + row.quantity, 0),
+    confirmedAdditionCount: confirmed.length,
+    confirmedAdditionQuantity: confirmed.reduce((sum, row) => sum + row.quantity, 0),
+    estimatedAdditionCount: 0,
+    estimatedAdditionQuantity: 0,
+    unsupportedAdditionCount: additions.length,
+    unsupportedAdditionQuantity: additions.reduce((sum, row) => sum + row.quantity, 0),
+    estimatedSoldQuantity: 0,
+    estimatedRemainingAtCutoff: 0,
+    reconstructedOlderQuantity: 0,
+    reconstructedOlderRemainingAtCutoff: 0,
+    supportedSkuCount: 0,
+    conflictedSkuCount: new Set(additions.map((row) => row.sku)).size,
+  };
+}
+
+export function estimateHistoricalPublicationHistory(
+  evidence: HistoricalPublicationEstimateEvidence,
+): HistoricalPublicationEstimate {
+  const cutoffTime = validTime(evidence.cutoffAt);
+  const coverageStartTime = validTime(evidence.coverageStartsAt);
+  const allAdditions = [...evidence.additions].sort((left, right) => {
+    if (left.confirmedAt === null) return right.confirmedAt === null
+      ? left.publicationItemId - right.publicationItemId
+      : 1;
+    if (right.confirmedAt === null) return -1;
+    return left.confirmedAt.localeCompare(right.confirmedAt) || left.publicationItemId - right.publicationItemId;
+  });
+  const globalReason: HistoricalPublicationEstimateReason | undefined =
+    !evidence.sourceAvailable ? "source_read_failed" :
+    cutoffTime === null ? "opening_coverage_missing" :
+      !evidence.coverageComplete || validTime(evidence.validatedAt) === null
+        ? "order_coverage_incomplete" :
+        evidence.additionCount !== evidence.additions.length ||
+        evidence.orderRevisionCount !== evidence.orderRevisions.length ||
+        coverageStartTime === null ? "source_bounds_exceeded" : undefined;
+  if (allAdditions.length === 0 && !globalReason) {
+    return {
+      status: "no_data",
+      cutoffAt: evidence.cutoffAt,
+      summary: emptySummary([]),
+      cohorts: [],
+      cohortCount: 0,
+      conflicts: [],
+      conflictCount: 0,
+    };
+  }
+  if (globalReason) {
+    const cohorts = allAdditions.map((addition) => ({
+      publicationItemId: addition.publicationItemId,
+      sku: addition.sku,
+      productLine: addition.productLine,
+      productName: addition.productName,
+      quantity: addition.quantity,
+      publishingAt: addition.publishingAt,
+      confirmedAt: addition.confirmedAt,
+      dateProvenance: addition.confirmedAt ? "recorded_confirmation" as const : "unknown" as const,
+      attributionProvenance: "unsupported" as const,
+      estimatedSoldQuantity: null,
+      estimatedRemainingAtCutoff: null,
+      reasons: [globalReason],
+      allocations: [],
+      forecastEvidence: addition.forecastEvidence,
+      forecastEvidenceProvenance: addition.forecastEvidenceProvenance,
+    }));
+    return {
+      status: "unavailable",
+      reason: globalReason,
+      cutoffAt: evidence.cutoffAt,
+      summary: emptySummary(allAdditions),
+      cohorts: cohorts.slice(0, DETAIL_LIMIT),
+      cohortCount: cohorts.length,
+      conflicts: [],
+      conflictCount: 0,
+    };
+  }
+
+  const reasonsByItem = new Map(allAdditions.map((addition) => [
+    addition.publicationItemId,
+    publicationReasons(addition, cutoffTime!, coverageStartTime!),
+  ]));
+  const itemsByDeltaKey = new Map<string, number[]>();
+  for (const addition of allAdditions) {
+    if (!addition.inventoryDeltaKey) continue;
+    const itemIds = itemsByDeltaKey.get(addition.inventoryDeltaKey) ?? [];
+    itemIds.push(addition.publicationItemId);
+    itemsByDeltaKey.set(addition.inventoryDeltaKey, itemIds);
+  }
+  for (const itemIds of itemsByDeltaKey.values()) {
+    if (itemIds.length < 2) continue;
+    for (const itemId of itemIds) {
+      reasonsByItem.set(itemId, unique([...(reasonsByItem.get(itemId) ?? []), "publication_evidence_invalid"]));
+    }
+  }
+  const additionsBySku = new Map<number, HistoricalPublicationAdditionEvidence[]>();
+  for (const addition of allAdditions) {
+    const rows = additionsBySku.get(addition.sku) ?? [];
+    rows.push(addition);
+    additionsBySku.set(addition.sku, rows);
+  }
+  const firstPublicationBySku = new Map([...additionsBySku].map(([sku, rows]) => [
+    sku,
+    Math.min(...rows.map((row) => validTime(row.confirmedAt) ?? Number.POSITIVE_INFINITY)),
+  ]));
+  const { demands, conflicts: orderConflicts } = orderDemands(
+    evidence.orderRevisions,
+    firstPublicationBySku,
+    cutoffTime!,
+    evidence.validatedAt!,
+  );
+  const opening = new Map(evidence.openingQuantities.map((row) => [row.sku, row.quantity]));
+  const results = new Map<number, {
+    sold: number;
+    remaining: number;
+    allocations: HistoricalPublicationEstimateAllocation[];
+  }>();
+  const conflicts = new Map<number, {
+    reasons: HistoricalPublicationEstimateReason[];
+    difference: number | null;
+  }>();
+  let reconstructedOlderQuantity = 0;
+  let reconstructedOlderRemainingAtCutoff = 0;
+
+  for (const [sku, additions] of additionsBySku) {
+    const staticReasons = unique(additions.flatMap((addition) => reasonsByItem.get(addition.publicationItemId) ?? []));
+    const skuReasons = unique([...staticReasons, ...(orderConflicts.get(sku) ?? [])]);
+    if (skuReasons.length > 0) {
+      conflicts.set(sku, { reasons: skuReasons, difference: null });
+      continue;
+    }
+    const firstConfirmed = Math.min(...additions.map((addition) => Date.parse(addition.confirmedAt!)));
+    const skuDemands = (demands.get(sku) ?? []).filter((demand) =>
+      Date.parse(demand.orderedAt) >= firstConfirmed && Date.parse(demand.orderedAt) < cutoffTime!);
+    if (skuDemands.some((demand) => additions.some((addition) => addition.confirmedAt === demand.orderedAt))) {
+      skuReasons.push("event_time_tie");
+    }
+    const additionQuantity = additions.reduce((sum, row) => sum + row.quantity, 0);
+    const demandQuantity = skuDemands.reduce((sum, row) => sum + row.quantity, 0);
+    const olderQuantity = (opening.get(sku) ?? 0) + demandQuantity - additionQuantity;
+    if (olderQuantity < 0) skuReasons.push("quantity_conflict");
+    if (skuReasons.length > 0) {
+      conflicts.set(sku, { reasons: unique(skuReasons), difference: olderQuantity });
+      continue;
+    }
+
+    const lots: MutableLot[] = olderQuantity > 0
+      ? [{ addition: null, remaining: olderQuantity }]
+      : [];
+    const events = [
+      ...additions.map((addition) => ({ time: Date.parse(addition.confirmedAt!), kind: "addition" as const, addition })),
+      ...skuDemands.map((demand) => ({ time: Date.parse(demand.orderedAt), kind: "demand" as const, demand })),
+    ].sort((left, right) => left.time - right.time ||
+      (left.kind === right.kind
+        ? left.kind === "addition"
+          ? left.addition.publicationItemId - (right as typeof left).addition.publicationItemId
+          : left.demand.orderId.localeCompare((right as typeof left).demand.orderId)
+        : left.kind === "addition" ? -1 : 1));
+    let olderRemaining = olderQuantity;
+    let underflow = false;
+    for (const event of events) {
+      if (event.kind === "addition") {
+        lots.push({ addition: event.addition, remaining: event.addition.quantity });
+        results.set(event.addition.publicationItemId, { sold: 0, remaining: event.addition.quantity, allocations: [] });
+        continue;
+      }
+      let needed = event.demand.quantity;
+      for (const lot of lots) {
+        if (needed === 0) break;
+        const quantity = Math.min(lot.remaining, needed);
+        if (quantity === 0) continue;
+        lot.remaining -= quantity;
+        needed -= quantity;
+        if (!lot.addition) {
+          olderRemaining -= quantity;
+          continue;
+        }
+        const result = results.get(lot.addition.publicationItemId)!;
+        const confirmedAt = Date.parse(lot.addition.confirmedAt!);
+        const publishingAt = validTime(lot.addition.publishingAt);
+        result.sold += quantity;
+        result.remaining -= quantity;
+        result.allocations.push({
+          orderId: event.demand.orderId,
+          orderNumber: event.demand.orderNumber,
+          orderedAt: event.demand.orderedAt,
+          quantity,
+          listedDaysLowerBound: Math.max(0, (event.time - confirmedAt) / DAY_MS),
+          listedDaysUpperBound: publishingAt === null
+            ? null
+            : Math.max(0, (event.time - publishingAt) / DAY_MS),
+        });
+      }
+      if (needed > 0) {
+        underflow = true;
+        break;
+      }
+    }
+    if (underflow) {
+      additions.forEach((addition) => results.delete(addition.publicationItemId));
+      conflicts.set(sku, { reasons: ["temporal_underflow"], difference: olderQuantity });
+      continue;
+    }
+    reconstructedOlderQuantity += olderQuantity;
+    reconstructedOlderRemainingAtCutoff += olderRemaining;
+  }
+
+  const cohorts = allAdditions.map((addition) => {
+    const result = results.get(addition.publicationItemId);
+    const conflict = conflicts.get(addition.sku);
+    return {
+      publicationItemId: addition.publicationItemId,
+      sku: addition.sku,
+      productLine: addition.productLine,
+      productName: addition.productName,
+      quantity: addition.quantity,
+      publishingAt: addition.publishingAt,
+      confirmedAt: addition.confirmedAt,
+      dateProvenance: addition.confirmedAt ? "recorded_confirmation" as const : "unknown" as const,
+      attributionProvenance: result ? "estimated_closed_flow" as const : "unsupported" as const,
+      estimatedSoldQuantity: result?.sold ?? null,
+      estimatedRemainingAtCutoff: result?.remaining ?? null,
+      reasons: result ? [] : conflict?.reasons ?? reasonsByItem.get(addition.publicationItemId) ?? ["publication_evidence_invalid"],
+      allocations: result?.allocations ?? [],
+      forecastEvidence: addition.forecastEvidence,
+      forecastEvidenceProvenance: addition.forecastEvidenceProvenance,
+    };
+  });
+  const estimated = cohorts.filter((row) => row.attributionProvenance === "estimated_closed_flow");
+  const unsupported = cohorts.filter((row) => row.attributionProvenance === "unsupported");
+  const conflictRows = [...conflicts].sort(([left], [right]) => left - right).map(([sku, conflict]) => ({
+    sku,
+    reasons: conflict.reasons,
+    quantityDifference: conflict.difference,
+  }));
+  return {
+    status: "ready",
+    cutoffAt: evidence.cutoffAt,
+    summary: {
+      publicationItemCount: cohorts.length,
+      publicationQuantity: cohorts.reduce((sum, row) => sum + row.quantity, 0),
+      confirmedAdditionCount: cohorts.filter((row) => row.dateProvenance === "recorded_confirmation").length,
+      confirmedAdditionQuantity: cohorts.filter((row) => row.dateProvenance === "recorded_confirmation")
+        .reduce((sum, row) => sum + row.quantity, 0),
+      estimatedAdditionCount: estimated.length,
+      estimatedAdditionQuantity: estimated.reduce((sum, row) => sum + row.quantity, 0),
+      unsupportedAdditionCount: unsupported.length,
+      unsupportedAdditionQuantity: unsupported.reduce((sum, row) => sum + row.quantity, 0),
+      estimatedSoldQuantity: estimated.reduce((sum, row) => sum + (row.estimatedSoldQuantity ?? 0), 0),
+      estimatedRemainingAtCutoff: estimated.reduce((sum, row) => sum + (row.estimatedRemainingAtCutoff ?? 0), 0),
+      reconstructedOlderQuantity,
+      reconstructedOlderRemainingAtCutoff,
+      supportedSkuCount: new Set(estimated.map((row) => row.sku)).size,
+      conflictedSkuCount: conflicts.size,
+    },
+    cohorts: cohorts.slice(0, DETAIL_LIMIT),
+    cohortCount: cohorts.length,
+    conflicts: conflictRows.slice(0, DETAIL_LIMIT),
+    conflictCount: conflictRows.length,
+  };
+}

--- a/app/features/inventory-strategy/services/inventorySellingHistory.server.test.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.server.test.ts
@@ -35,6 +35,18 @@ const source = {
       olderPublicationQuantity: 0,
       awaitingCutoffQuantity: 0,
       unresolvedRemoval: { quantity: 0, affectedSkus: [] },
+      historicalPublicationEvidence: {
+        sourceAvailable: true,
+        cutoffAt: "2026-09-08T00:00:00.000Z",
+        coverageStartsAt: "2026-06-12T00:00:00.000Z",
+        coverageComplete: true,
+        validatedAt: "2026-09-08T00:00:00.000Z",
+        additions: [],
+        additionCount: 0,
+        openingQuantities: [],
+        orderRevisions: [],
+        orderRevisionCount: 0,
+      },
     };
   },
 };

--- a/app/features/inventory-strategy/services/inventorySellingHistory.server.test.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.server.test.ts
@@ -59,6 +59,7 @@ assert.deepEqual(calls, ["backfill:seller:500", "find:seller"]);
 calls.length = 0;
 const missingSeller = await loadInventorySellingHistory("", {}, source);
 assert.equal(missingSeller.status, "unavailable");
+assert.equal("historicalPublicationEstimate" in missingSeller, false);
 assert.deepEqual(calls, []);
 
 console.log("PASS inventory selling history loads bounded evidence for one seller");

--- a/app/features/inventory-strategy/services/inventorySellingHistory.server.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.server.ts
@@ -55,15 +55,6 @@ export async function loadInventorySellingHistory(
       availableProductLines: [],
       reason: "seller_not_configured",
       orderCoverage: noCoverage(""),
-      historicalPublicationEstimate: {
-        status:"unavailable",reason:"source_read_failed",cutoffAt:null,
-        summary:{publicationItemCount:0,publicationQuantity:0,confirmedAdditionCount:0,
-          confirmedAdditionQuantity:0,estimatedAdditionCount:0,estimatedAdditionQuantity:0,
-          unsupportedAdditionCount:0,unsupportedAdditionQuantity:0,estimatedSoldQuantity:0,
-          estimatedRemainingAtCutoff:0,reconstructedOlderQuantity:0,
-          reconstructedOlderRemainingAtCutoff:0,supportedSkuCount:0,conflictedSkuCount:0},
-        cohorts:[],cohortCount:0,conflicts:[],conflictCount:0,
-      },
     };
   }
   await dataSource.backfillSupportedForecastEvidence(seller, 500);

--- a/app/features/inventory-strategy/services/inventorySellingHistory.server.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.server.ts
@@ -55,6 +55,15 @@ export async function loadInventorySellingHistory(
       availableProductLines: [],
       reason: "seller_not_configured",
       orderCoverage: noCoverage(""),
+      historicalPublicationEstimate: {
+        status:"unavailable",reason:"source_read_failed",cutoffAt:null,
+        summary:{publicationItemCount:0,publicationQuantity:0,confirmedAdditionCount:0,
+          confirmedAdditionQuantity:0,estimatedAdditionCount:0,estimatedAdditionQuantity:0,
+          unsupportedAdditionCount:0,unsupportedAdditionQuantity:0,estimatedSoldQuantity:0,
+          estimatedRemainingAtCutoff:0,reconstructedOlderQuantity:0,
+          reconstructedOlderRemainingAtCutoff:0,supportedSkuCount:0,conflictedSkuCount:0},
+        cohorts:[],cohortCount:0,conflicts:[],conflictCount:0,
+      },
     };
   }
   await dataSource.backfillSupportedForecastEvidence(seller, 500);

--- a/app/features/inventory-strategy/services/inventorySellingHistory.test.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.test.ts
@@ -33,6 +33,18 @@ function evidence(
     olderPublicationQuantity: 0,
     awaitingCutoffQuantity: 0,
     unresolvedRemoval: { quantity: 0, affectedSkus: [] },
+    historicalPublicationEvidence: {
+      sourceAvailable: true,
+      cutoffAt: day(20),
+      coverageStartsAt: day(-80),
+      coverageComplete: true,
+      validatedAt: day(20),
+      additions: [],
+      additionCount: 0,
+      openingQuantities: [],
+      orderRevisions: [],
+      orderRevisionCount: 0,
+    },
     ...overrides,
   };
 }
@@ -232,6 +244,21 @@ const narrowed = buildInventorySellingHistoryReport(
   evidence({ scope: { windowDays: 180, productLine: "Magic" } }),
 );
 assert.equal(narrowed.status, "ready");
+
+const historicalReadFailure = buildInventorySellingHistoryReport(evidence({
+  episodes: [episodes[2]],
+  episodeCount: 1,
+  historicalPublicationEvidence: {
+    ...evidence().historicalPublicationEvidence,
+    sourceAvailable: false,
+  },
+}));
+assert.equal(historicalReadFailure.status, "ready");
+if (historicalReadFailure.status === "ready") {
+  assert.equal(historicalReadFailure.overall.cohortQuantity, 10);
+  assert.equal(historicalReadFailure.historicalPublicationEstimate.status, "unavailable");
+  assert.equal(historicalReadFailure.historicalPublicationEstimate.reason, "source_read_failed");
+}
 
 const returned = buildInventorySellingHistoryReport(
   evidence({

--- a/app/features/inventory-strategy/services/inventorySellingHistory.ts
+++ b/app/features/inventory-strategy/services/inventorySellingHistory.ts
@@ -8,6 +8,7 @@ import {
   type SellingHistorySourceEvidence,
   type SellingHistorySummary,
 } from "../types/inventorySellingHistory";
+import { estimateHistoricalPublicationHistory } from "../domain/historicalPublicationEstimate";
 
 const DAY_MS = 86_400_000;
 const DETAIL_LIMIT = 50;
@@ -258,6 +259,9 @@ export function buildInventorySellingHistoryReport(
   evidence: SellingHistorySourceEvidence,
   detailPage = 1,
 ): InventorySellingHistoryReport {
+  const historicalPublicationEstimate = estimateHistoricalPublicationHistory(
+    evidence.historicalPublicationEvidence,
+  );
   const unavailable = (
     reason: Extract<
       InventorySellingHistoryReport,
@@ -270,6 +274,7 @@ export function buildInventorySellingHistoryReport(
     availableProductLines: evidence.availableProductLines,
     reason,
     orderCoverage: evidence.orderCoverage,
+    historicalPublicationEstimate,
   });
   if (evidence.orderCoverage.sellerKey !== evidence.sellerKey)
     return unavailable("seller_not_configured");
@@ -362,5 +367,6 @@ export function buildInventorySellingHistoryReport(
       olderPublicationQuantity: evidence.olderPublicationQuantity,
       awaitingCutoffQuantity: evidence.awaitingCutoffQuantity,
     },
+    historicalPublicationEstimate,
   };
 }

--- a/app/features/inventory-strategy/types/inventorySellingHistory.ts
+++ b/app/features/inventory-strategy/types/inventorySellingHistory.ts
@@ -9,6 +9,117 @@ export interface SellingHistoryScope {
   productLine: string | null;
 }
 
+export type HistoricalPublicationEstimateReason =
+  | "opening_coverage_missing"
+  | "order_coverage_incomplete"
+  | "source_bounds_exceeded"
+  | "publication_evidence_invalid"
+  | "source_read_failed"
+  | "order_history_changed"
+  | "order_lifecycle_unsettled"
+  | "order_time_unknown"
+  | "event_time_tie"
+  | "quantity_conflict"
+  | "temporal_underflow";
+
+export interface HistoricalPublicationAdditionEvidence {
+  publicationItemId: number;
+  sku: number;
+  productLine: string;
+  productName: string;
+  quantity: number;
+  sourceType: string;
+  method: string;
+  inventoryDeltaKey: string | null;
+  batchItemCount: number;
+  batchAddToQuantity: number | null;
+  publishingAt: string | null;
+  confirmedAt: string | null;
+  forecastEvidence: InventoryPublicationForecastEvidence | null;
+  forecastEvidenceProvenance: "recorded" | "estimated" | "unknown";
+}
+
+export interface HistoricalOrderRevisionEvidence {
+  orderId: string;
+  orderNumber: string;
+  revisionNumber: number;
+  observedAt: string;
+  orderTime: string | null;
+  orderTimeEvidence: string;
+  lifecycle: string;
+  lines: Array<{ skuId: string; quantity: number }>;
+}
+
+export interface HistoricalPublicationEstimateEvidence {
+  sourceAvailable: boolean;
+  cutoffAt: string | null;
+  coverageStartsAt: string | null;
+  coverageComplete: boolean;
+  validatedAt: string | null;
+  additions: HistoricalPublicationAdditionEvidence[];
+  additionCount: number;
+  openingQuantities: Array<{ sku: number; quantity: number }>;
+  orderRevisions: HistoricalOrderRevisionEvidence[];
+  orderRevisionCount: number;
+}
+
+export interface HistoricalPublicationEstimateAllocation {
+  orderId: string;
+  orderNumber: string;
+  orderedAt: string;
+  quantity: number;
+  listedDaysLowerBound: number;
+  listedDaysUpperBound: number | null;
+}
+
+export interface HistoricalPublicationEstimateCohort {
+  publicationItemId: number;
+  sku: number;
+  productLine: string;
+  productName: string;
+  quantity: number;
+  publishingAt: string | null;
+  confirmedAt: string | null;
+  dateProvenance: "recorded_confirmation" | "unknown";
+  attributionProvenance: "estimated_closed_flow" | "unsupported";
+  estimatedSoldQuantity: number | null;
+  estimatedRemainingAtCutoff: number | null;
+  reasons: HistoricalPublicationEstimateReason[];
+  allocations: HistoricalPublicationEstimateAllocation[];
+  forecastEvidence: InventoryPublicationForecastEvidence | null;
+  forecastEvidenceProvenance: "recorded" | "estimated" | "unknown";
+}
+
+export interface HistoricalPublicationEstimate {
+  status: "ready" | "no_data" | "unavailable";
+  reason?: HistoricalPublicationEstimateReason;
+  cutoffAt: string | null;
+  summary: {
+    publicationItemCount: number;
+    publicationQuantity: number;
+    confirmedAdditionCount: number;
+    confirmedAdditionQuantity: number;
+    estimatedAdditionCount: number;
+    estimatedAdditionQuantity: number;
+    unsupportedAdditionCount: number;
+    unsupportedAdditionQuantity: number;
+    estimatedSoldQuantity: number;
+    estimatedRemainingAtCutoff: number;
+    reconstructedOlderQuantity: number;
+    reconstructedOlderRemainingAtCutoff: number;
+    supportedSkuCount: number;
+    conflictedSkuCount: number;
+  };
+  cohorts: HistoricalPublicationEstimateCohort[];
+  cohortCount: number;
+  conflicts: Array<{
+    sku: number;
+    reasons: HistoricalPublicationEstimateReason[];
+    quantityDifference: number | null;
+  }>;
+  conflictCount: number;
+}
+
 export const DEFAULT_SELLING_HISTORY_SCOPE: SellingHistoryScope = {
   windowDays: 180,
   productLine: null,
@@ -70,6 +181,7 @@ export interface SellingHistorySourceEvidence {
     quantity: number;
     affectedSkus: number[];
   };
+  historicalPublicationEvidence: HistoricalPublicationEstimateEvidence;
 }
 
 export interface SellThroughHorizon {
@@ -141,6 +253,7 @@ export type InventorySellingHistoryReport =
         | "order_coverage_incomplete"
         | "history_bounds_exceeded";
       orderCoverage: SellerOrderCoverage;
+      historicalPublicationEstimate: HistoricalPublicationEstimate;
     }
   | {
       status: "ready";
@@ -167,4 +280,5 @@ export type InventorySellingHistoryReport =
         olderPublicationQuantity: number;
         awaitingCutoffQuantity: number;
       };
+      historicalPublicationEstimate: HistoricalPublicationEstimate;
     };

--- a/app/features/inventory-strategy/types/inventorySellingHistory.ts
+++ b/app/features/inventory-strategy/types/inventorySellingHistory.ts
@@ -15,6 +15,7 @@ export type HistoricalPublicationEstimateReason =
   | "source_bounds_exceeded"
   | "publication_evidence_invalid"
   | "publication_identity_conflict"
+  | "mixed_publication_receipt_sources"
   | "source_read_failed"
   | "order_history_changed"
   | "order_lifecycle_unsettled"
@@ -35,6 +36,7 @@ export interface HistoricalPublicationAdditionEvidence {
   batchItemCount: number;
   batchAddToQuantity: number | null;
   skuProductLineCount: number;
+  linkedPreCutoffPublicationCount: number;
   publishingAt: string | null;
   confirmedAt: string | null;
   forecastEvidence: InventoryPublicationForecastEvidence | null;

--- a/app/features/inventory-strategy/types/inventorySellingHistory.ts
+++ b/app/features/inventory-strategy/types/inventorySellingHistory.ts
@@ -14,6 +14,7 @@ export type HistoricalPublicationEstimateReason =
   | "order_coverage_incomplete"
   | "source_bounds_exceeded"
   | "publication_evidence_invalid"
+  | "publication_identity_conflict"
   | "source_read_failed"
   | "order_history_changed"
   | "order_lifecycle_unsettled"
@@ -33,6 +34,7 @@ export interface HistoricalPublicationAdditionEvidence {
   inventoryDeltaKey: string | null;
   batchItemCount: number;
   batchAddToQuantity: number | null;
+  skuProductLineCount: number;
   publishingAt: string | null;
   confirmedAt: string | null;
   forecastEvidence: InventoryPublicationForecastEvidence | null;
@@ -253,7 +255,7 @@ export type InventorySellingHistoryReport =
         | "order_coverage_incomplete"
         | "history_bounds_exceeded";
       orderCoverage: SellerOrderCoverage;
-      historicalPublicationEstimate: HistoricalPublicationEstimate;
+      historicalPublicationEstimate?: HistoricalPublicationEstimate;
     }
   | {
       status: "ready";

--- a/app/test/run-tests.ts
+++ b/app/test/run-tests.ts
@@ -30,6 +30,7 @@ import "../features/continuous-pricing/services/continuousMarketPrices.server.te
 import "../features/inventory-strategy/services/inventoryStrategy.test";
 import "../features/inventory-strategy/domain/allocateReinvestmentTurnaround.test";
 import "../features/inventory-strategy/domain/turnaroundStrategy.test";
+import "../features/inventory-strategy/domain/historicalPublicationEstimate.test";
 import "../features/inventory-strategy/components/ReinvestmentTurnaround.test";
 import "../features/inventory-strategy/components/TurnaroundInputs.test";
 import "../features/inventory-strategy/routes/api.reinvestment-turnaround.test";


### PR DESCRIPTION
## Problem and resulting behavior

The 1,140 units accepted through historical Seller Portal quantity-addition uploads have confirmation times and exact batch quantities, but they predate receipt linking. Inventory Strategy therefore reported them only as legacy unlinked quantity.

This change adds a separate historical estimate to Selling History. It replays confirmed additions and canonical seller orders to the fixed opening-balance cutoff, preserves any estimated older stock as unknown-date quantity, and withholds SKUs whose order lifecycle, quantity history, or publication identity is ambiguous. The estimate is labeled independently from observed selling metrics and never creates receipts, changes opening quantities, or feeds physical FIFO, shipping, cost, funding, pricing, or marketplace writes.

## Evidence boundaries

- Uploaded quantity and app-observed move-to-live confirmation are recorded facts. The provider live instant is shown as bounded by the publishing request and confirmation.
- Sale and remaining-quantity assignments are a closed-flow FIFO estimate because no complete pre-publication inventory observation exists.
- Canceled/unknown orders, attribution-field revisions, source limits, invalid batch linkage, cross-product-line SKU identity, mixed linked/unlinked publication history, time ties, negative reconciliation, and temporal underflow fail closed with visible reasons.
- Financial-only order revisions remain usable. Historical SKU/time changes retain both old and current affected identities.
- Historical source failures are isolated so the existing observed Selling History report remains usable.

## Review repairs

- Equal-time order demand now follows the shared FIFO contract: external order number, then stable internal order ID. A reversed-ID regression proves `A-ORDER` allocates before `Z-ORDER`.
- Publication evidence carries `skuProductLineCount`, computed for the seller and SKU before product-line scope filtering. Any value other than one produces `publication_identity_conflict` and withholds that SKU rather than inventing older stock.
- Publication evidence also carries `linkedPreCutoffPublicationCount`. A positive receipt-linked publication for the same seller/SKU before the opening cutoff produces `mixed_publication_receipt_sources`; linked units stay out of legacy counts, and the unlinked SKU is withheld rather than reconstructed as older stock.
- Conflict reasons are summarized by count, with affected SKUs available in an expandable disclosure.
- When no seller is configured, the historical subsection is omitted so it agrees with the report-level `seller_not_configured` state.

## Quality contract v2

G0 selected the smaller read-model path. Not built: new receipts or receipt links; opening-balance changes; a historical physical FIFO ledger; migrations, jobs, caches, or stored backfill state; provider calls; inferred cancellation restocks; cost/funding attribution; changes to shipping intake history, current stock, observed medians, sell-through, forecasts, or pricing.

- **SCOPE — useful history / physical lineage:** Shows every retained positive pre-opening unlinked publication item and estimates supported sold/remaining quantities. Receipt-linked publication units remain with observed cohorts and only provide a same-SKU ambiguity guard; the report does not claim purchase, receipt, or exact physical lineage.
- **ROBUSTNESS — recovery / availability:** Invalid quantity flow, source bounds, timestamps, lifecycle, later attribution changes, cross-product-line SKU identity, and mixed linked/unlinked history fail closed per SKU. A historical read failure stays inside the historical section so the observed report remains available.
- **DEPTH — inspectability / restraint:** Preserves publication IDs, SKUs, confirmation bounds, forecast provenance, order references, quantities, and reasons. Detail output is capped at 50 rows and labeled with the full count rather than adding a second paging system.
- **READABILITY — precision / density:** Uses plain labels such as Uploaded units, Estimated older stock, and Order status is uncertain. The table keeps evidence detail and affected-SKU lists collapsible so the primary strategy view remains scannable.
- **TESTS — boundary coverage / external limits:** Pure, UI, service, full-suite, and fresh PostgreSQL tests cover multi-addition FIFO, same-time order tie-breaking, older stock, zero opening, corrections, cancellation, coverage, cross-product-line identity before scope filtering, same-SKU linked/unlinked history, unrelated linked SKUs, and failures. Tests do not perform a live Seller Portal mutation.
- **OBSERVABILITY — visible classification / telemetry footprint:** The report exposes recorded, estimated, unsupported, conflict, source-error, and bounded-detail counts with grouped and per-row reasons. It adds no new operational metrics or alert stream.
- **SECURITY — seller isolation / access surface:** Every source query is seller-scoped and uses already persisted local evidence. The change adds no credential use, outbound request, route, write endpoint, or permission.
- **PERFORMANCE — bounded reads / completeness:** Sources cap at 5,000 publication items and 20,000 order revisions; output caps detail/conflicts at 50 and fails closed on truncation. Independent production-copy timing is evidence for this dataset, not a general latency guarantee.
- **ROLLOUT — reversible read path / historical persistence:** The feature has no schema or data migration and can be removed without recovery. It relies on the applied opening run’s durable copied scan attestations under the versioned LastThreeMonths producer contract rather than creating a new snapshot table.
- **CONSISTENCY — shared evidence / separate metrics:** Reuses publication, receipt-link, seller-order revision, complete-opening, product-line, and shared FIFO order semantics. Estimated history remains outside receipt-linked observed summaries, physical FIFO, shipping, economics, and forecast grading.
- **EXPERIENCE — reachability / bounded detail:** Historical product lines populate the existing selector even when no receipt-linked cohort exists, and no-data/error states leave other Strategy content visible. The initial slice shows the first 50 of the full classified count without a dedicated historical pager.
- **LANGUAGE — recorded confirmation / estimated assignment:** “Confirmation” means the app observed successful move-to-live; the actual provider instant is bounded by request and confirmation. “Estimated FIFO” states the closed-flow assumption and never calls the reconstructed baseline observed zero.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run build`
- `TEST_DATABASE_URL=postgresql://.../tcgplayer_strategy_test_author80_20260909 npx tsx app/core/db/repositories/inventoryHistoricalPublications.server.integration.test.ts`
- Independent frozen-head domain oracle, production-copy read rehearsal, source-failure injection, and protected-table hash comparison passed. The combined repaired head awaits focused delta review before merge.

Closes #80
