### PR TITLE
Restore staged publication failure handling

### DIFF
--- a/app/core/clients/baseDomainClient.server.test.ts
+++ b/app/core/clients/baseDomainClient.server.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import type { AxiosResponse } from "axios";
 import {
   ConcurrencyLimiter,
-  observeSafeHttpResponse,
+  DomainHttpClient,
   RequestThrottler,
 } from "./baseDomainClient.server";
 import {
@@ -33,23 +33,73 @@ function createDomainConfig(
 
 const testCases: TestCase[] = [
   {
-    name: "response observers receive bounded metadata and cannot fail a request",
-    run: () => {
-      const response = {
-        status: 200,
-        headers: {
-          "content-type": "application/private+json; account=do-not-retain",
-        },
-        request: { _redirectable: { _redirectCount: 1 } },
-      } as unknown as AxiosResponse<unknown>;
-      let observed: unknown;
-
-      assert.doesNotThrow(() =>
-        observeSafeHttpResponse(response, (metadata) => {
-          observed = metadata;
-          throw new Error("observer failed");
-        }),
+    name: "DomainHttpClient.post exposes bounded metadata without changing request behavior",
+    run: async () => {
+      const client = new DomainHttpClient(
+        DOMAIN_KEYS.MP_SEARCH_API,
+        "https://synthetic.invalid",
       );
+      let requestOptions: unknown;
+      let maxRetries: number | undefined;
+      let observed: unknown;
+      const internals = client as unknown as {
+        axiosClient: {
+          post<T>(
+            path: string,
+            data: unknown,
+            options: unknown,
+          ): Promise<AxiosResponse<T>>;
+        };
+        executeWithRetry<T>(
+          method: string,
+          path: string,
+          request: () => Promise<AxiosResponse<T>>,
+          logContext: unknown,
+          retries: number,
+        ): Promise<T>;
+      };
+      internals.axiosClient = {
+        async post<T>(_path: string, _data: unknown, options: unknown) {
+          requestOptions = options;
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {
+              "content-type":
+                "application/private+json; account=do-not-retain",
+            },
+            request: { _redirectable: { _redirectCount: 1 } },
+            config: { headers: {} },
+            data: { StagedPricingUploadId: 16104570 } as T,
+          } as AxiosResponse<T>;
+        },
+      };
+      internals.executeWithRetry = async <T>(
+        _method: string,
+        _path: string,
+        request: () => Promise<AxiosResponse<T>>,
+        _logContext: unknown,
+        retries: number,
+      ) => {
+        maxRetries = retries;
+        return (await request()).data;
+      };
+
+      const result = await client.post<{ StagedPricingUploadId: number }>(
+        "/synthetic-initialize",
+        new URLSearchParams({ filename: "synthetic.csv", type: "Pricing" }),
+        {
+          retry: false,
+          observeResponse(metadata) {
+            observed = metadata;
+            throw new Error("synthetic observer failure");
+          },
+        },
+      );
+
+      assert.deepEqual(result, { StagedPricingUploadId: 16104570 });
+      assert.equal(maxRetries, 0);
+      assert.deepEqual(requestOptions, {});
       assert.deepEqual(observed, {
         status: 200,
         contentType: "json",
@@ -57,6 +107,36 @@ const testCases: TestCase[] = [
       });
       assert.ok(!JSON.stringify(observed).includes("account"));
       assert.ok(!JSON.stringify(observed).includes("private"));
+
+      internals.axiosClient = {
+        async post<T>() {
+          throw Object.assign(new Error("synthetic rejected response"), {
+            isAxiosError: true,
+            response: {
+              status: 403,
+              headers: { "content-type": "text/html; private=discard" },
+              request: { _redirectable: { _redirectCount: 0 } },
+              config: { headers: {} },
+              data: "private body",
+            } as AxiosResponse<T>,
+          });
+        },
+      };
+      observed = undefined;
+      await assert.rejects(
+        client.post("/synthetic-rejection", undefined, {
+          retry: false,
+          observeResponse(metadata) {
+            observed = metadata;
+          },
+        }),
+        /synthetic rejected response/,
+      );
+      assert.deepEqual(observed, {
+        status: 403,
+        contentType: "html",
+        redirected: false,
+      });
     },
   },
   {

--- a/app/core/clients/baseDomainClient.server.test.ts
+++ b/app/core/clients/baseDomainClient.server.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
+import type { AxiosResponse } from "axios";
 import {
   ConcurrencyLimiter,
+  observeSafeHttpResponse,
   RequestThrottler,
 } from "./baseDomainClient.server";
 import {
@@ -30,6 +32,33 @@ function createDomainConfig(
 }
 
 const testCases: TestCase[] = [
+  {
+    name: "response observers receive bounded metadata and cannot fail a request",
+    run: () => {
+      const response = {
+        status: 200,
+        headers: {
+          "content-type": "application/private+json; account=do-not-retain",
+        },
+        request: { _redirectable: { _redirectCount: 1 } },
+      } as unknown as AxiosResponse<unknown>;
+      let observed: unknown;
+
+      assert.doesNotThrow(() =>
+        observeSafeHttpResponse(response, (metadata) => {
+          observed = metadata;
+          throw new Error("observer failed");
+        }),
+      );
+      assert.deepEqual(observed, {
+        status: 200,
+        contentType: "json",
+        redirected: true,
+      });
+      assert.ok(!JSON.stringify(observed).includes("account"));
+      assert.ok(!JSON.stringify(observed).includes("private"));
+    },
+  },
   {
     name: "RequestThrottler.recordSuccess uses the latest persisted delay between success thresholds",
     run: async () => {

--- a/app/core/clients/baseDomainClient.server.ts
+++ b/app/core/clients/baseDomainClient.server.ts
@@ -16,6 +16,57 @@ import {
 const MAX_RETRIES = 3;
 const RETRYABLE_STATUS_CODES = new Set([403, 429, 502, 503, 504]);
 
+export interface SafeHttpResponseMetadata {
+  status: number;
+  contentType: "json" | "html" | "text" | "other" | null;
+  redirected: boolean | null;
+}
+
+function classifyContentType(
+  value: unknown,
+): SafeHttpResponseMetadata["contentType"] {
+  if (typeof value !== "string") return null;
+  const mediaType = value.split(";", 1)[0]?.trim().toLowerCase();
+  if (mediaType === "application/json" || mediaType?.endsWith("+json")) {
+    return "json";
+  }
+  if (mediaType === "text/html") return "html";
+  if (mediaType?.startsWith("text/")) return "text";
+  return "other";
+}
+
+function getSafeResponseMetadata<T>(
+  response: AxiosResponse<T>,
+): SafeHttpResponseMetadata {
+  const contentType = response.headers["content-type"];
+  const redirectCount = (
+    response.request as
+      | { _redirectable?: { _redirectCount?: unknown } }
+      | null
+      | undefined
+  )?._redirectable?._redirectCount;
+
+  return {
+    status: response.status,
+    contentType: classifyContentType(contentType),
+    redirected:
+      typeof redirectCount === "number" ? redirectCount > 0 : null,
+  };
+}
+
+export function observeSafeHttpResponse<T>(
+  response: AxiosResponse<T>,
+  observer?: (metadata: SafeHttpResponseMetadata) => void,
+): void {
+  if (!observer) return;
+  try {
+    observer(getSafeResponseMetadata(response));
+  } catch {
+    // Diagnostics cannot turn a successful provider response into a failed
+    // stateful request.
+  }
+}
+
 // ============================================================================
 // Rate Limiting & Throttling (per-domain instance)
 // ============================================================================
@@ -325,13 +376,22 @@ export class DomainHttpClient {
     data?: TData,
     options?: Pick<AxiosRequestConfig, "headers" | "responseType" | "timeout" | "signal"> & {
       retry?: boolean;
+      observeResponse?: (metadata: SafeHttpResponseMetadata) => void;
     },
   ): Promise<TResponse> {
-    const { retry = true, ...requestOptions } = options ?? {};
+    const { retry = true, observeResponse, ...requestOptions } = options ?? {};
     return this.executeWithRetry(
       "POST",
       path,
-      () => this.axiosClient.post<TResponse>(path, data, requestOptions),
+      async () => {
+        const response = await this.axiosClient.post<TResponse>(
+          path,
+          data,
+          requestOptions,
+        );
+        observeSafeHttpResponse(response, observeResponse);
+        return response;
+      },
       data ? { data } : undefined,
       retry ? MAX_RETRIES : 0,
       requestOptions.signal as AbortSignal | undefined,

--- a/app/core/clients/baseDomainClient.server.ts
+++ b/app/core/clients/baseDomainClient.server.ts
@@ -54,7 +54,7 @@ function getSafeResponseMetadata<T>(
   };
 }
 
-export function observeSafeHttpResponse<T>(
+function observeSafeHttpResponse<T>(
   response: AxiosResponse<T>,
   observer?: (metadata: SafeHttpResponseMetadata) => void,
 ): void {
@@ -384,13 +384,20 @@ export class DomainHttpClient {
       "POST",
       path,
       async () => {
-        const response = await this.axiosClient.post<TResponse>(
-          path,
-          data,
-          requestOptions,
-        );
-        observeSafeHttpResponse(response, observeResponse);
-        return response;
+        try {
+          const response = await this.axiosClient.post<TResponse>(
+            path,
+            data,
+            requestOptions,
+          );
+          observeSafeHttpResponse(response, observeResponse);
+          return response;
+        } catch (error) {
+          if (axios.isAxiosError<TResponse>(error) && error.response) {
+            observeSafeHttpResponse(error.response, observeResponse);
+          }
+          throw error;
+        }
       },
       data ? { data } : undefined,
       retry ? MAX_RETRIES : 0,

--- a/app/features/inventory-publication/services/inventoryPublicationWorker.server.ts
+++ b/app/features/inventory-publication/services/inventoryPublicationWorker.server.ts
@@ -5,6 +5,7 @@ import {
 } from "~/core/db";
 import {
   finalizeStagedPricingImport,
+  getStagedPricingInitializationErrorCode,
   initializeStagedPricingImport,
   moveStagedPricingImportToLive,
   rollbackStagedPricingImport,
@@ -287,6 +288,12 @@ function buildProductDetailMismatchOutcomes(
 }
 
 export function isSellerPortalAuthenticationFailure(error: unknown): boolean {
+  if (
+    getStagedPricingInitializationErrorCode(error) ===
+    "staged_initialization_authentication_required"
+  ) {
+    return true;
+  }
   const candidate = error as { response?: { status?: unknown } };
   const status = Number(candidate?.response?.status);
   if (status === 401 || status === 403) {
@@ -495,15 +502,18 @@ async function failBeforeMove(
     }
   }
 
+  const initializationErrorCode =
+    getStagedPricingInitializationErrorCode(error) ??
+    "staged_initialization_failed";
   await dependencies.markPlannedItems(
     publication.id,
     "failed",
-    "staged_initialization_failed",
+    initializationErrorCode,
     originalMessage,
   );
   await dependencies.transition(publication.id, currentStatus, "failed", {
     workerId,
-    errorCode: "staged_initialization_failed",
+    errorCode: initializationErrorCode,
     errorMessage: originalMessage,
   });
 }

--- a/app/features/inventory-publication/services/inventoryPublicationWorker.test.ts
+++ b/app/features/inventory-publication/services/inventoryPublicationWorker.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { StagedPricingInitializationError } from "~/integrations/tcgplayer/client/staged-pricing-import.server";
 import type {
   InventoryPublication,
   InventoryPublicationItem,
@@ -94,6 +95,7 @@ function createDependencies(
     moveError?: Error;
     saveFailures?: number;
     completionTransitionFailures?: number;
+    initializeError?: Error;
   } = {},
 ): {
   dependencies: InventoryPublicationWorkerDependencies;
@@ -101,11 +103,13 @@ function createDependencies(
   outcomes: InventoryPublicationItemOutcome[];
   markedItems: Array<{ status: string; errorCode: string }>;
   projectedPublications: InventoryPublication[];
+  portalFailures: unknown[];
 } {
   const calls: string[] = [];
   const outcomes: InventoryPublicationItemOutcome[] = [];
   const markedItems: Array<{ status: string; errorCode: string }> = [];
   const projectedPublications: InventoryPublication[] = [];
+  const portalFailures: unknown[] = [];
   let saveFailures = overrides.saveFailures ?? 0;
   let completionTransitionFailures =
     overrides.completionTransitionFailures ?? 0;
@@ -115,9 +119,13 @@ function createDependencies(
     outcomes,
     markedItems,
     projectedPublications,
+    portalFailures,
     dependencies: {
       initialize: async () => {
         calls.push("initialize");
+        if (overrides.initializeError) {
+          throw overrides.initializeError;
+        }
         return 16104570;
       },
       upload: async ({ updates }) => {
@@ -192,6 +200,10 @@ function createDependencies(
       },
       recordPublishedPrices: async (publication) => {
         projectedPublications.push(publication);
+      },
+      recordPortalFailure: async (error) => {
+        calls.push("record-portal-failure");
+        portalFailures.push(error);
       },
     },
   };
@@ -504,6 +516,50 @@ const testCases: TestCase[] = [
         isSellerPortalAuthenticationFailure(new Error("timeout")),
         false,
       );
+      assert.equal(
+        isSellerPortalAuthenticationFailure(
+          new StagedPricingInitializationError(
+            "staged_initialization_authentication_required",
+            "Sanitized authentication failure.",
+          ),
+        ),
+        true,
+      );
+    },
+  },
+  {
+    name: "classified initialization failure stops before every downstream provider call",
+    run: async () => {
+      const initializeError = new StagedPricingInitializationError(
+        "staged_initialization_response_invalid",
+        "Seller Portal returned an invalid staged pricing initialization response.",
+      );
+      const { dependencies, calls, markedItems, portalFailures } =
+        createDependencies({ initializeError });
+
+      await executeClaimedStagedPublication(
+        createPublication(),
+        "test-worker",
+        dependencies,
+      );
+
+      assert.deepEqual(calls, [
+        "initialize",
+        "record-portal-failure",
+        "mark-items:failed",
+        "transition:staging:failed",
+      ]);
+      assert.deepEqual(markedItems, [
+        {
+          status: "failed",
+          errorCode: "staged_initialization_response_invalid",
+        },
+      ]);
+      assert.deepEqual(portalFailures, [initializeError]);
+      assert.ok(!calls.includes("rollback"));
+      assert.ok(!calls.includes("upload:1"));
+      assert.ok(!calls.includes("finalize:1"));
+      assert.ok(!calls.includes("move"));
     },
   },
 ];

--- a/app/integrations/tcgplayer/client/staged-pricing-import.server.test.ts
+++ b/app/integrations/tcgplayer/client/staged-pricing-import.server.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import type { SafeHttpResponseMetadata } from "~/core/clients/baseDomainClient.server";
 import {
   buildFinalizeStagedPricingImportForm,
   buildInitializeStagedPricingImportForm,
@@ -9,6 +10,7 @@ import {
   initializeStagedPricingImport,
   moveStagedPricingImportToLive,
   rollbackStagedPricingImport,
+  StagedPricingInitializationError,
   STAGED_PRICING_IMPORT_CHUNK_SIZE,
   type SellerPortalFormPost,
   type StagedPricingUpdate,
@@ -28,6 +30,30 @@ const update: StagedPricingUpdate = {
 
 function postResponse(response: unknown): SellerPortalFormPost {
   return async <TResponse>(): Promise<TResponse> => response as TResponse;
+}
+
+function observedPostResponse(
+  response: unknown,
+  metadata: SafeHttpResponseMetadata = {
+    status: 200,
+    contentType: "json",
+    redirected: false,
+  },
+): SellerPortalFormPost {
+  return async <TResponse>(
+    _path: string,
+    _form: URLSearchParams,
+    observeResponse?: (metadata: SafeHttpResponseMetadata) => void,
+  ): Promise<TResponse> => {
+    observeResponse?.(metadata);
+    return response as TResponse;
+  };
+}
+
+function rejectedPost(error: unknown): SellerPortalFormPost {
+  return async <TResponse>(): Promise<TResponse> => {
+    throw error;
+  };
 }
 
 const testCases: TestCase[] = [
@@ -209,6 +235,141 @@ const testCases: TestCase[] = [
           postResponse({ success: false }),
         ),
         /did not finalize staged pricing upload 16104570/,
+      );
+    },
+  },
+  {
+    name: "staged pricing initialization accepts only the observed safe numeric identity",
+    run: async () => {
+      assert.equal(
+        await initializeStagedPricingImport(
+          "observed-contract.csv",
+          observedPostResponse({ StagedPricingUploadId: 16104570 }),
+        ),
+        16104570,
+      );
+
+      const invalidResponses: unknown[] = [
+        { StagedPricingUploadId: "16104570" },
+        {},
+        { StagedPricingUploadId: null },
+        { StagedPricingUploadId: 0 },
+        { StagedPricingUploadId: -1 },
+        { StagedPricingUploadId: 1.5 },
+        { StagedPricingUploadId: Number.MAX_SAFE_INTEGER + 1 },
+        "<html><body>Unexpected response</body></html>",
+      ];
+      for (const response of invalidResponses) {
+        await assert.rejects(
+          initializeStagedPricingImport(
+            "invalid-contract.csv",
+            observedPostResponse(response),
+          ),
+          (error: unknown) =>
+            error instanceof StagedPricingInitializationError &&
+            error.code === "staged_initialization_response_invalid" &&
+            error.message.includes("status=200") &&
+            !error.message.includes("Unexpected response"),
+        );
+      }
+    },
+  },
+  {
+        name: "staged pricing initialization classifies login, challenge, and rejection without body text",
+    run: async () => {
+      const cases: Array<{
+        response: unknown;
+        metadata?: SafeHttpResponseMetadata;
+        code: StagedPricingInitializationError["code"];
+        secret: string;
+      }> = [
+        {
+          response:
+            '<!doctype html><html><form action="/login">Sign in private</form></html>',
+          metadata: {
+            status: 200,
+            contentType: "html",
+            redirected: true,
+          },
+          code: "staged_initialization_authentication_required",
+          secret: "private",
+        },
+        {
+          response:
+            "<!doctype html><html><div>Verify you are human private</div></html>",
+          metadata: {
+            status: 200,
+            contentType: "html",
+            redirected: false,
+          },
+          code: "staged_initialization_challenge",
+          secret: "private",
+        },
+        {
+          response: {
+            Success: false,
+            Messages: ["private provider explanation"],
+          },
+          code: "staged_initialization_rejected",
+          secret: "private provider explanation",
+        },
+        {
+          response: {
+            StagedPricingUploadId: 16104570,
+            success: false,
+            error: "private contradictory response",
+          },
+          code: "staged_initialization_rejected",
+          secret: "private contradictory response",
+        },
+      ];
+
+      for (const testCase of cases) {
+        await assert.rejects(
+          initializeStagedPricingImport(
+            "classified-contract.csv",
+            observedPostResponse(testCase.response, testCase.metadata),
+          ),
+          (error: unknown) =>
+            error instanceof StagedPricingInitializationError &&
+            error.code === testCase.code &&
+            !error.message.includes(testCase.secret),
+        );
+      }
+    },
+  },
+  {
+    name: "staged pricing initialization sanitizes transport failures and preserves their phase",
+    run: async () => {
+      await assert.rejects(
+        initializeStagedPricingImport(
+          "transport-failure.csv",
+          rejectedPost({
+            name: "AxiosError",
+            code: "ECONNABORTED",
+            message: "private request details",
+            config: { headers: { Cookie: "private cookie" } },
+          }),
+        ),
+        (error: unknown) =>
+          error instanceof StagedPricingInitializationError &&
+          error.code === "staged_initialization_transport_failed" &&
+          error.message.includes("before a response was confirmed") &&
+          error.message.includes("transport=ECONNABORTED") &&
+          !error.message.includes("private"),
+      );
+      await assert.rejects(
+        initializeStagedPricingImport(
+          "authentication-failure.csv",
+          rejectedPost({
+            code: "ERR_BAD_REQUEST",
+            response: { status: 401, data: "private response" },
+          }),
+        ),
+        (error: unknown) =>
+          error instanceof StagedPricingInitializationError &&
+          error.code === "staged_initialization_authentication_required" &&
+          !error.message.includes("private"),
       );
     },
   },

--- a/app/integrations/tcgplayer/client/staged-pricing-import.server.test.ts
+++ b/app/integrations/tcgplayer/client/staged-pricing-import.server.test.ts
@@ -56,6 +56,29 @@ function rejectedPost(error: unknown): SellerPortalFormPost {
   };
 }
 
+function rejectedHttpPost(
+  status: number,
+  response: unknown,
+  metadata: SafeHttpResponseMetadata = {
+    status,
+    contentType: "json",
+    redirected: false,
+  },
+): SellerPortalFormPost {
+  return async <TResponse>(
+    _path: string,
+    _form: URLSearchParams,
+    observeResponse?: (metadata: SafeHttpResponseMetadata) => void,
+  ): Promise<TResponse> => {
+    observeResponse?.(metadata);
+    throw {
+      isAxiosError: true,
+      code: status >= 500 ? "ERR_BAD_RESPONSE" : "ERR_BAD_REQUEST",
+      response: { status, data: response },
+    };
+  };
+}
+
 const testCases: TestCase[] = [
   {
     name: "staged pricing forms preserve the verified minimal import contract",
@@ -241,6 +264,16 @@ const testCases: TestCase[] = [
   {
     name: "staged pricing initialization accepts only the observed safe numeric identity",
     run: async () => {
+      let invalidFilePostCalls = 0;
+      await assert.rejects(
+        initializeStagedPricingImport(" ", async <TResponse>() => {
+          invalidFilePostCalls += 1;
+          return {} as TResponse;
+        }),
+        RangeError,
+      );
+      assert.equal(invalidFilePostCalls, 0);
+
       assert.equal(
         await initializeStagedPricingImport(
           "observed-contract.csv",
@@ -275,7 +308,7 @@ const testCases: TestCase[] = [
     },
   },
   {
-        name: "staged pricing initialization classifies login, challenge, and rejection without body text",
+    name: "staged pricing initialization classifies login, challenge, and rejection without body text",
     run: async () => {
       const cases: Array<{
         response: unknown;
@@ -334,6 +367,60 @@ const testCases: TestCase[] = [
             error instanceof StagedPricingInitializationError &&
             error.code === testCase.code &&
             !error.message.includes(testCase.secret),
+        );
+      }
+    },
+  },
+  {
+    name: "staged pricing initialization classifies rejected HTTP bodies without accepting their IDs",
+    run: async () => {
+      const cases: Array<{
+        status: number;
+        response: unknown;
+        metadata?: SafeHttpResponseMetadata;
+        code: StagedPricingInitializationError["code"];
+      }> = [
+        {
+          status: 400,
+          response: { Success: false, Messages: ["private"] },
+          code: "staged_initialization_rejected",
+        },
+        {
+          status: 403,
+          response: "<html><div>Verify you are human private</div></html>",
+          metadata: {
+            status: 403,
+            contentType: "html",
+            redirected: false,
+          },
+          code: "staged_initialization_challenge",
+        },
+        {
+          status: 400,
+          response: { StagedPricingUploadId: 16104570 },
+          code: "staged_initialization_rejected",
+        },
+        {
+          status: 500,
+          response: { StagedPricingUploadId: 16104570 },
+          code: "staged_initialization_transport_failed",
+        },
+      ];
+
+      for (const testCase of cases) {
+        await assert.rejects(
+          initializeStagedPricingImport(
+            "rejected-http.csv",
+            rejectedHttpPost(
+              testCase.status,
+              testCase.response,
+              testCase.metadata,
+            ),
+          ),
+          (error: unknown) =>
+            error instanceof StagedPricingInitializationError &&
+            error.code === testCase.code &&
+            !error.message.includes("private"),
         );
       }
     },

--- a/app/integrations/tcgplayer/client/staged-pricing-import.server.test.ts
+++ b/app/integrations/tcgplayer/client/staged-pricing-import.server.test.ts
@@ -403,7 +403,17 @@ const testCases: TestCase[] = [
         {
           status: 500,
           response: { StagedPricingUploadId: 16104570 },
-          code: "staged_initialization_transport_failed",
+          code: "staged_initialization_http_failed",
+        },
+        {
+          status: 502,
+          response: "private upstream failure",
+          metadata: {
+            status: 502,
+            contentType: "text",
+            redirected: false,
+          },
+          code: "staged_initialization_http_failed",
         },
       ];
 
@@ -420,7 +430,8 @@ const testCases: TestCase[] = [
           (error: unknown) =>
             error instanceof StagedPricingInitializationError &&
             error.code === testCase.code &&
-            !error.message.includes("private"),
+            !error.message.includes("private") &&
+            !error.message.includes("before a response was confirmed"),
         );
       }
     },

--- a/app/integrations/tcgplayer/client/staged-pricing-import.server.ts
+++ b/app/integrations/tcgplayer/client/staged-pricing-import.server.ts
@@ -86,6 +86,7 @@ const postSellerPortalForm: SellerPortalFormPost = <TResponse>(
 export type StagedPricingInitializationErrorCode =
   | "staged_initialization_authentication_required"
   | "staged_initialization_challenge"
+  | "staged_initialization_http_failed"
   | "staged_initialization_rejected"
   | "staged_initialization_response_invalid"
   | "staged_initialization_transport_failed";
@@ -387,6 +388,12 @@ export async function initializeStagedPricingImport(
       throw new StagedPricingInitializationError(
         "staged_initialization_rejected",
         `Seller Portal rejected staged pricing initialization (${diagnostics}; transport=${code}).`,
+      );
+    }
+    if (status !== null) {
+      throw new StagedPricingInitializationError(
+        "staged_initialization_http_failed",
+        `Seller Portal returned an HTTP failure during staged pricing initialization (${diagnostics}; transport=${code}).`,
       );
     }
     throw new StagedPricingInitializationError(

--- a/app/integrations/tcgplayer/client/staged-pricing-import.server.ts
+++ b/app/integrations/tcgplayer/client/staged-pricing-import.server.ts
@@ -1,4 +1,5 @@
 import { sellerPortal } from "~/core/clients";
+import type { SafeHttpResponseMetadata } from "~/core/clients/baseDomainClient.server";
 
 const PRICING_TYPE = "Pricing";
 const FORM_HEADERS = {
@@ -66,6 +67,7 @@ export interface MoveStagedPricingImportResponse {
 export type SellerPortalFormPost = <TResponse>(
   path: string,
   form: URLSearchParams,
+  observeResponse?: (metadata: SafeHttpResponseMetadata) => void,
 ) => Promise<TResponse>;
 
 // These stateful requests can carry signed quantity deltas. Never replay an
@@ -73,11 +75,152 @@ export type SellerPortalFormPost = <TResponse>(
 const postSellerPortalForm: SellerPortalFormPost = <TResponse>(
   path: string,
   form: URLSearchParams,
+  observeResponse?: (metadata: SafeHttpResponseMetadata) => void,
 ): Promise<TResponse> =>
   sellerPortal.post<TResponse, URLSearchParams>(path, form, {
     headers: FORM_HEADERS,
     retry: false,
+    observeResponse,
   });
+
+export type StagedPricingInitializationErrorCode =
+  | "staged_initialization_authentication_required"
+  | "staged_initialization_challenge"
+  | "staged_initialization_rejected"
+  | "staged_initialization_response_invalid"
+  | "staged_initialization_transport_failed";
+
+export class StagedPricingInitializationError extends Error {
+  readonly name = "StagedPricingInitializationError";
+
+  constructor(
+    readonly code: StagedPricingInitializationErrorCode,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export function getStagedPricingInitializationErrorCode(
+  error: unknown,
+): StagedPricingInitializationErrorCode | null {
+  return error instanceof StagedPricingInitializationError ? error.code : null;
+}
+
+function valueKind(value: unknown): string {
+  if (value === undefined) return "missing";
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+function responseKind(value: unknown): string {
+  if (typeof value === "string" && /<html\b|<!doctype\s+html/i.test(value)) {
+    return "html";
+  }
+  return valueKind(value);
+}
+
+function knownFieldShape(response: unknown): string {
+  if (response === null || Array.isArray(response) || typeof response !== "object") {
+    return "none";
+  }
+  const record = response as Record<string, unknown>;
+  const fields = [
+    "StagedPricingUploadId",
+    "Success",
+    "success",
+    "Error",
+    "Errors",
+    "error",
+    "errors",
+    "Message",
+    "Messages",
+  ].flatMap((name) =>
+    Object.hasOwn(record, name) ? [`${name}:${valueKind(record[name])}`] : [],
+  );
+  return fields.length > 0 ? fields.join(",") : "none";
+}
+
+function metadataShape(metadata: SafeHttpResponseMetadata | null): string {
+  if (!metadata) return "status=unknown; contentType=unknown; redirected=unknown";
+  return [
+    `status=${metadata.status}`,
+    `contentType=${metadata.contentType ?? "unknown"}`,
+    `redirected=${metadata.redirected === null ? "unknown" : String(metadata.redirected)}`,
+  ].join("; ");
+}
+
+function responseDiagnostics(
+  response: unknown,
+  metadata: SafeHttpResponseMetadata | null,
+): string {
+  return `${metadataShape(metadata)}; response=${responseKind(response)}; fields=${knownFieldShape(response)}`;
+}
+
+function hasExplicitProviderError(value: unknown): boolean {
+  if (value === true) return true;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return value !== null && typeof value === "object" && Object.keys(value).length > 0;
+}
+
+function isExplicitProviderRejection(response: unknown): boolean {
+  if (response === null || Array.isArray(response) || typeof response !== "object") {
+    return false;
+  }
+  const record = response as Record<string, unknown>;
+  if (record.Success === false || record.success === false) return true;
+  return ["Error", "Errors", "error", "errors"].some(
+    (name) => Object.hasOwn(record, name) && hasExplicitProviderError(record[name]),
+  );
+}
+
+function isLoginResponse(
+  response: unknown,
+  metadata: SafeHttpResponseMetadata | null,
+): boolean {
+  if (metadata?.status === 401 || metadata?.status === 403) return true;
+  if (typeof response !== "string" || responseKind(response) !== "html") return false;
+  return /<form\b[^>]*(login|sign.?in)|\b(login|sign in|authentication)\b/i.test(
+    response,
+  );
+}
+
+function isChallengeResponse(response: unknown): boolean {
+  return (
+    typeof response === "string" &&
+    responseKind(response) === "html" &&
+    /captcha|cf-chl-|challenge-platform|verify you are human|access denied/i.test(
+      response,
+    )
+  );
+}
+
+const SAFE_TRANSPORT_CODES = new Set([
+  "ECONNABORTED",
+  "ECONNRESET",
+  "ECONNREFUSED",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "ERR_CANCELED",
+  "ERR_NETWORK",
+]);
+
+function getTransportStatus(error: unknown): number | null {
+  const status = (error as { response?: { status?: unknown } } | null)?.response
+    ?.status;
+  return typeof status === "number" && Number.isInteger(status)
+    ? status
+    : null;
+}
+
+function getTransportCode(error: unknown): string {
+  const code = (error as { code?: unknown } | null)?.code;
+  return typeof code === "string" && SAFE_TRANSPORT_CODES.has(code)
+    ? code
+    : "other";
+}
 
 function requireNonEmptyText(value: string, name: string): void {
   if (value.trim().length === 0) {
@@ -200,15 +343,66 @@ export async function initializeStagedPricingImport(
   fileName: string,
   post: SellerPortalFormPost = postSellerPortalForm,
 ): Promise<number> {
-  const response = await post<{ StagedPricingUploadId: number }>(
-    PATHS.initialize,
-    buildInitializeStagedPricingImportForm(fileName),
-  );
-  requirePositiveInteger(
-    response.StagedPricingUploadId,
-    "StagedPricingUploadId",
-  );
-  return response.StagedPricingUploadId;
+  let metadata: SafeHttpResponseMetadata | null = null;
+  let response: unknown;
+  try {
+    response = await post<unknown>(
+      PATHS.initialize,
+      buildInitializeStagedPricingImportForm(fileName),
+      (observedMetadata) => {
+        metadata = observedMetadata;
+      },
+    );
+  } catch (error) {
+    const status = getTransportStatus(error);
+    const code = getTransportCode(error);
+    if (status === 401 || status === 403) {
+      throw new StagedPricingInitializationError(
+        "staged_initialization_authentication_required",
+        `Seller Portal required authentication for staged pricing initialization (status=${status}; transport=${code}).`,
+      );
+    }
+    throw new StagedPricingInitializationError(
+      "staged_initialization_transport_failed",
+      `Seller Portal staged pricing initialization failed before a response was confirmed (status=${status ?? "unknown"}; transport=${code}).`,
+    );
+  }
+  const diagnostics = responseDiagnostics(response, metadata);
+
+  if (isChallengeResponse(response)) {
+    throw new StagedPricingInitializationError(
+      "staged_initialization_challenge",
+      `Seller Portal challenged the staged pricing initialization request (${diagnostics}).`,
+    );
+  }
+  if (isLoginResponse(response, metadata)) {
+    throw new StagedPricingInitializationError(
+      "staged_initialization_authentication_required",
+      `Seller Portal required authentication for staged pricing initialization (${diagnostics}).`,
+    );
+  }
+  if (isExplicitProviderRejection(response)) {
+    throw new StagedPricingInitializationError(
+      "staged_initialization_rejected",
+      `Seller Portal rejected staged pricing initialization (${diagnostics}).`,
+    );
+  }
+
+  const uploadId =
+    response !== null && !Array.isArray(response) && typeof response === "object"
+      ? (response as Record<string, unknown>).StagedPricingUploadId
+      : undefined;
+  if (
+    typeof uploadId !== "number" ||
+    !Number.isSafeInteger(uploadId) ||
+    uploadId <= 0
+  ) {
+    throw new StagedPricingInitializationError(
+      "staged_initialization_response_invalid",
+      `Seller Portal returned an invalid staged pricing initialization response (${diagnostics}).`,
+    );
+  }
+  return uploadId;
 }
 
 export async function uploadStagedPricingChunk(

--- a/app/integrations/tcgplayer/client/staged-pricing-import.server.ts
+++ b/app/integrations/tcgplayer/client/staged-pricing-import.server.ts
@@ -222,6 +222,10 @@ function getTransportCode(error: unknown): string {
     : "other";
 }
 
+function getTransportResponse(error: unknown): unknown {
+  return (error as { response?: { data?: unknown } } | null)?.response?.data;
+}
+
 function requireNonEmptyText(value: string, name: string): void {
   if (value.trim().length === 0) {
     throw new RangeError(`${name} must not be empty.`);
@@ -343,12 +347,13 @@ export async function initializeStagedPricingImport(
   fileName: string,
   post: SellerPortalFormPost = postSellerPortalForm,
 ): Promise<number> {
+  const form = buildInitializeStagedPricingImportForm(fileName);
   let metadata: SafeHttpResponseMetadata | null = null;
   let response: unknown;
   try {
     response = await post<unknown>(
       PATHS.initialize,
-      buildInitializeStagedPricingImportForm(fileName),
+      form,
       (observedMetadata) => {
         metadata = observedMetadata;
       },
@@ -356,15 +361,37 @@ export async function initializeStagedPricingImport(
   } catch (error) {
     const status = getTransportStatus(error);
     const code = getTransportCode(error);
-    if (status === 401 || status === 403) {
+    const failedResponse = getTransportResponse(error);
+    const failedMetadata =
+      metadata ??
+      (status === null
+        ? null
+        : { status, contentType: null, redirected: null });
+    const diagnostics = responseDiagnostics(failedResponse, failedMetadata);
+    if (isChallengeResponse(failedResponse)) {
+      throw new StagedPricingInitializationError(
+        "staged_initialization_challenge",
+        `Seller Portal challenged the staged pricing initialization request (${diagnostics}; transport=${code}).`,
+      );
+    }
+    if (isLoginResponse(failedResponse, failedMetadata)) {
       throw new StagedPricingInitializationError(
         "staged_initialization_authentication_required",
-        `Seller Portal required authentication for staged pricing initialization (status=${status}; transport=${code}).`,
+        `Seller Portal required authentication for staged pricing initialization (${diagnostics}; transport=${code}).`,
+      );
+    }
+    if (
+      isExplicitProviderRejection(failedResponse) ||
+      (status !== null && status >= 400 && status < 500)
+    ) {
+      throw new StagedPricingInitializationError(
+        "staged_initialization_rejected",
+        `Seller Portal rejected staged pricing initialization (${diagnostics}; transport=${code}).`,
       );
     }
     throw new StagedPricingInitializationError(
       "staged_initialization_transport_failed",
-      `Seller Portal staged pricing initialization failed before a response was confirmed (status=${status ?? "unknown"}; transport=${code}).`,
+      `Seller Portal staged pricing initialization failed before a response was confirmed (${diagnostics}; transport=${code}).`,
     );
   }
   const diagnostics = responseDiagnostics(response, metadata);


### PR DESCRIPTION
Automatic continuous publication stopped after three staged initialization responses lacked a usable upload identity. The historical response bodies were not retained, so this change does not invent a provider schema conversion. Current production observation confirms the Seller Portal still returns a positive numeric `StagedPricingUploadId` and that its own frontend consumes the same field.

This change keeps that contract strict and makes every failure actionable. It records bounded status/content-type/redirect and known-field shape evidence, classifies authentication, challenge, explicit rejection, invalid response, and transport failures with stable codes, rejects unsafe IDs, and prevents diagnostic observers from changing request behavior. The worker persists the classification while preserving the existing stop-before-upload behavior: no upload, finalize, move-to-live, or guessed rollback follows an unconfirmed ID.

Refs #82

## Verification

- Domain HTTP client tests: 3 passed.
- Staged pricing import tests: 7 passed across the observed numeric contract, string/missing/null/zero/negative/fractional/unsafe IDs, generic HTML, login, challenge, provider rejection, contradictory payload, and sanitized transport failure.
- Inventory publication worker tests: 11 passed, including zero downstream provider calls and no rollback after classified initialization failure.
- Typecheck passed.
- Production build passed on the exact head.
- Production read-only/provider preflight: current frontend and one direct initialization confirm the numeric contract. The probes did not upload, finalize, or move anything live; whether the later current-client attempt allocated an empty draft remains unknown because its final timed-out phase did not retain an ID. The existing 32 staged rows are price-only, remain unchanged, and are protected from the recovery canary.

Production recovery remains deliberate: deploy this head, refresh the selected SKU's eligibility, allow one warning-free price-only canary, verify TCGplayer live-price readback and local confirmation, then restore normal continuous planning. Old failed items are not replayed.

## Quality Packet

`QUALITY_PROFILE: contract`

`G0: PASS` — The smallest safe change is strict parsing plus bounded diagnostics at the existing boundary and durable code propagation. Not built: string coercion or guessed aliases, automatic retry/reset, response-body logging, a new ledger or scheduler, pricing-policy changes, or historical-inventory work.

- `SCOPE [High]`: little=PASS — client boundary, durable worker state, and focused tests change together; much=PASS — six existing files only, with no schema/UI/pricing changes.
- `ROBUSTNESS [High]`: little=PASS — unsafe, malformed, authentication, challenge, rejection, contradiction, and transport cases fail closed; much=PASS — only observed numeric success is accepted and no speculative fallback exists.
- `DEPTH [High]`: little=PASS — response classification stays in the Seller Portal integration and the worker only maps durable codes; much=PASS — no new service, repository, or protocol layer.
- `READABILITY [Med]`: little=PASS — named error codes and bounded response vocabulary state each outcome; much=PASS — helpers are confined to one boundary instead of spreading conditionals through the worker.
- `TESTS [High]`: little=PASS — each changed behavior and replay-safety transition has an executable case; much=PASS — focused contract/worker tests avoid duplicating unrelated publication coverage.
- `OBSERVABILITY [High]`: little=PASS — failures retain phase, safe transport class, response kind, and known field types; much=PASS — successes produce no new logs and raw bodies/messages/headers are never retained.
- `SECURITY [High]`: little=PASS — metadata allowlists content type and transport code; only known field names/types are reported; much=PASS — checks remain at the external boundary.
- `PERFORMANCE [Low]`: little=PASS — parsing is constant work over nine known fields; much=PASS — no query, I/O, retry, or caching mechanism was added.
- `ROLLOUT [High]`: little=PASS — the client option is additive and the numeric success contract is unchanged; much=PASS — no flag or compatibility branch remains.
- `CONSISTENCY [High]`: little=PASS — stateful POST retries remain disabled and worker transitions use existing records; much=PASS — the implementation follows the current client/worker composition.
- `EXPERIENCE [Low]`: little=PASS — operator-visible pause reasons become actionable; much=PASS — there is no UI surface requiring a new component or local override.
- `LANGUAGE [High]`: little=PASS — staged initialization, authentication, challenge, rejection, invalid response, and transport failure match the actual workflow; much=PASS — no synonym or new domain concept was introduced.

