### PR TITLE
Fix return-label lookup for structured tracking data

### DIFF
--- a/app/features/shipping-export/services/tcgplayerSellerOrders.server.test.ts
+++ b/app/features/shipping-export/services/tcgplayerSellerOrders.server.test.ts
@@ -114,6 +114,37 @@ const testCases: TestCase[] = [
     },
   },
   {
+    name: "mapSellerOrderDetailToShippingOrder reads structured tracking records",
+    run: () => {
+      const order = mapSellerOrderDetailToShippingOrder(
+        createSellerOrderDetail({
+          trackingNumbers: [{ trackingNumber: " 9400136208192278220374 " }],
+        }),
+      );
+
+      assert.equal(order["Tracking #"], "9400136208192278220374");
+    },
+  },
+  {
+    name: "mapSellerOrderDetailToShippingOrder skips unusable tracking entries",
+    run: () => {
+      const invalidEntries = [null, undefined, 123, false, {}, { trackingNumber: 123 }, "   "];
+      for (const trackingNumbers of [undefined, null, [], invalidEntries]) {
+        const order = mapSellerOrderDetailToShippingOrder(
+          createSellerOrderDetail({ trackingNumbers }),
+        );
+        assert.equal(order["Tracking #"], "");
+      }
+
+      const order = mapSellerOrderDetailToShippingOrder(
+        createSellerOrderDetail({
+          trackingNumbers: [...invalidEntries, " 9400136208192278220374 "],
+        }),
+      );
+      assert.equal(order["Tracking #"], "9400136208192278220374");
+    },
+  },
+  {
     name: "mapSellerOrderDetailToShippingOrder sums quantities and handles single-token names",
     run: () => {
       const order = mapSellerOrderDetailToShippingOrder(
@@ -366,6 +397,7 @@ const testCases: TestCase[] = [
             return createSellerOrderDetail({
               orderNumber: "ORD-1001",
               status: "Shipped",
+              trackingNumbers: [{ trackingNumber: " 9400136208192278220374 " }],
             });
           },
         },
@@ -392,6 +424,7 @@ const testCases: TestCase[] = [
       assert.deepEqual(response.loadedOrderNumbers, ["ORD-1001"]);
       assert.equal(response.orders.length, 1);
       assert.equal(response.orders[0].products?.[0].marketPrice, 12.25);
+      assert.equal(response.orders[0]["Tracking #"], "9400136208192278220374");
       assert.deepEqual(response.warnings, [
         'Order ORD-1001 is currently "Shipped", not "Ready to Ship". Review it before buying postage.',
       ]);

--- a/app/features/shipping-export/services/tcgplayerSellerOrders.server.ts
+++ b/app/features/shipping-export/services/tcgplayerSellerOrders.server.ts
@@ -78,6 +78,23 @@ function getSingleOrderWarnings(order: SellerOrderDetail): string[] {
   ];
 }
 
+function getTrackingNumber(entries: SellerOrderDetail["trackingNumbers"]): string {
+  if (!Array.isArray(entries)) return "";
+
+  for (const entry of entries) {
+    const value =
+      typeof entry === "object" && entry !== null && "trackingNumber" in entry
+        ? entry.trackingNumber
+        : entry;
+
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return "";
+}
+
 export function mapSellerOrderDetailToShippingOrder(
   order: SellerOrderDetail,
 ): TcgPlayerShippingOrder {
@@ -101,7 +118,7 @@ export function mapSellerOrderDetailToShippingOrder(
     "Item Count": sumProductQuantity(order),
     "Value Of Products": order.transaction.productAmount,
     "Shipping Fee Paid": order.transaction.shippingAmount,
-    "Tracking #": order.trackingNumbers?.[0]?.trim() ?? "",
+    "Tracking #": getTrackingNumber(order.trackingNumbers),
     Carrier: "",
     products: order.products.map((p) => {
       const inventorySkuId = p.skuId.trim();

--- a/app/integrations/tcgplayer/client/get-seller-order.server.ts
+++ b/app/integrations/tcgplayer/client/get-seller-order.server.ts
@@ -52,8 +52,8 @@ export interface SellerOrderDetail {
   products: SellerOrderProduct[];
   refunds: unknown[];
   refundStatus: string;
-  /** May be absent or null; read it defensively. */
-  trackingNumbers?: string[] | null;
+  /** Entries can be strings or structured tracking records; validate before use. */
+  trackingNumbers?: unknown[] | null;
   allowedActions: string[];
 }
 


### PR DESCRIPTION
Return-order lookup failed with `TypeError: _h.trim is not a function` when TCGPlayer returned a structured tracking entry. Read string and structured tracking numbers defensively, skipping unusable entries so shipped orders can load for return labels.

Validation: regression tests reproduce the previous failure and cover structured, missing, and invalid tracking data, including single shipped-order lookup. Full tests, TypeScript checks, and production build pass.
